### PR TITLE
fix: add proper CSS styling and layout improvements for GitHub Pages

### DIFF
--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,0 +1,8 @@
+<!-- Additional head elements for SEO and social media -->
+<meta property="og:title" content="{{ page.title | default: site.title }}" />
+<meta property="og:description" content="{{ page.description | default: site.description }}" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="{{ page.url | absolute_url }}" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:title" content="{{ page.title | default: site.title }}" />
+<meta name="twitter:description" content="{{ page.description | default: site.description }}" />

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -5,6 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    <title>{{ page.title | default: site.title }}</title>
+    <meta name="description" content="{{ page.description | default: site.description }}" />
+    <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+    <!--[if lt IE 9]>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
+    <![endif]-->
     {% include head-custom.html %}
   </head>
   <body>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,0 +1,160 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+/* Custom styles for PulumiCost documentation */
+
+/* Improve table styling */
+table {
+  width: 100%;
+  margin: 1.5em 0;
+  border-collapse: collapse;
+  font-size: 0.9em;
+}
+
+table th {
+  background-color: #f6f8fa;
+  font-weight: 600;
+  padding: 12px;
+  text-align: left;
+  border: 1px solid #d0d7de;
+}
+
+table td {
+  padding: 12px;
+  border: 1px solid #d0d7de;
+  vertical-align: top;
+}
+
+table tr:nth-child(even) {
+  background-color: #f6f8fa;
+}
+
+/* Navigation table specific styling */
+table th:first-child,
+table td:first-child {
+  width: 25%;
+}
+
+/* Improve link styling */
+a {
+  color: #0969da;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Better spacing for sections */
+section h2 {
+  margin-top: 2em;
+  padding-top: 0.5em;
+  border-top: 1px solid #d0d7de;
+}
+
+section h2:first-child {
+  margin-top: 0;
+  border-top: none;
+}
+
+/* Improve horizontal rules */
+hr {
+  border: none;
+  border-top: 2px solid #d0d7de;
+  margin: 2em 0;
+}
+
+/* Code block improvements */
+pre {
+  background-color: #f6f8fa;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  padding: 16px;
+  overflow: auto;
+}
+
+code {
+  background-color: #f6f8fa;
+  padding: 0.2em 0.4em;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+pre code {
+  background-color: transparent;
+  padding: 0;
+}
+
+/* Improve list styling */
+ul, ol {
+  line-height: 1.8;
+}
+
+/* Make the content area wider */
+.wrapper {
+  width: 90%;
+  max-width: 1200px;
+}
+
+section {
+  width: 75%;
+}
+
+header {
+  width: 22%;
+}
+
+/* Responsive improvements */
+@media print, screen and (max-width: 960px) {
+  .wrapper {
+    width: 100%;
+  }
+
+  header, section, footer {
+    width: 100%;
+  }
+
+  header {
+    border-bottom: 1px solid #d0d7de;
+    padding-bottom: 20px;
+    margin-bottom: 20px;
+  }
+}
+
+/* Emoji spacing */
+section h2::before,
+section h3::before {
+  margin-right: 0.3em;
+}
+
+/* Strong emphasis */
+strong {
+  font-weight: 600;
+  color: #1f2328;
+}
+
+/* Improve header styling */
+header h1 a {
+  color: #1f2328;
+  font-weight: 700;
+}
+
+header p {
+  color: #656d76;
+}
+
+/* Better footer styling */
+footer {
+  color: #656d76;
+  font-size: 0.85em;
+}
+
+footer a {
+  color: #656d76;
+}
+
+footer a:hover {
+  color: #0969da;
+}


### PR DESCRIPTION
  - Import jekyll-theme-minimal styles in custom layout
  - Add custom CSS for improved table, link, and code styling
  - Create head-custom.html with SEO meta tags
  - Add jekyll-seo-tag plugin for better SEO
  - Improve responsive design and readability
  - Make layout wider (1200px) for better content display