### PR TITLE
test: add comprehensive coverage for engine types and rendering (#146)

### DIFF
--- a/internal/spec/loader_test.go
+++ b/internal/spec/loader_test.go
@@ -1,0 +1,542 @@
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewLoader tests the creation of a new spec loader.
+func TestNewLoader(t *testing.T) {
+	baseDir := "/test/path"
+	loader := NewLoader(baseDir)
+
+	require.NotNil(t, loader, "NewLoader should not return nil")
+	assert.Equal(t, baseDir, loader.specDir, "specDir should match input")
+}
+
+// TestLoadSpec_Success tests successful spec loading scenarios.
+func TestLoadSpec_Success(t *testing.T) {
+	tests := []struct {
+		name         string
+		provider     string
+		service      string
+		sku          string
+		specContent  string
+		wantProvider string
+		wantService  string
+		wantSKU      string
+	}{
+		{
+			name:     "valid simple spec",
+			provider: "aws",
+			service:  "ec2",
+			sku:      "t3.micro",
+			specContent: `provider: aws
+service: ec2
+sku: t3.micro
+currency: USD
+pricing:
+  onDemandHourly: 0.0104
+  monthlyEstimate: 7.59
+`,
+			wantProvider: "aws",
+			wantService:  "ec2",
+			wantSKU:      "t3.micro",
+		},
+		{
+			name:     "spec with dots in SKU",
+			provider: "aws",
+			service:  "rds",
+			sku:      "db.t3.medium",
+			specContent: `provider: aws
+service: rds
+sku: db.t3.medium
+currency: USD
+pricing:
+  onDemandHourly: 0.068
+  monthlyEstimate: 49.64
+`,
+			wantProvider: "aws",
+			wantService:  "rds",
+			wantSKU:      "db.t3.medium",
+		},
+		{
+			name:     "spec with dashes in SKU",
+			provider: "azure",
+			service:  "compute",
+			sku:      "standard-d2s-v3",
+			specContent: `provider: azure
+service: compute
+sku: standard-d2s-v3
+currency: USD
+pricing:
+  onDemandHourly: 0.096
+`,
+			wantProvider: "azure",
+			wantService:  "compute",
+			wantSKU:      "standard-d2s-v3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			// Create spec file
+			filename := filepath.Join(tmpDir, tt.provider+"-"+tt.service+"-"+tt.sku+".yaml")
+			err := os.WriteFile(filename, []byte(tt.specContent), 0644)
+			require.NoError(t, err)
+
+			loader := NewLoader(tmpDir)
+			spec, err := loader.LoadSpec(tt.provider, tt.service, tt.sku)
+
+			require.NoError(t, err)
+			require.NotNil(t, spec)
+
+			// Verify the spec structure
+			pricingSpec, ok := spec.(*PricingSpec)
+			require.True(t, ok, "spec should be *PricingSpec")
+			assert.Equal(t, tt.wantProvider, pricingSpec.Provider)
+			assert.Equal(t, tt.wantService, pricingSpec.Service)
+			assert.Equal(t, tt.wantSKU, pricingSpec.SKU)
+			assert.NotEmpty(t, pricingSpec.Pricing, "pricing should not be empty")
+		})
+	}
+}
+
+// TestLoadSpec_Errors tests error handling in LoadSpec.
+func TestLoadSpec_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		provider    string
+		service     string
+		sku         string
+		setupFunc   func(t *testing.T, dir string)
+		wantErrType error
+		wantErrMsg  string
+	}{
+		{
+			name:        "missing file returns ErrSpecNotFound",
+			provider:    "aws",
+			service:     "ec2",
+			sku:         "nonexistent",
+			setupFunc:   func(_ *testing.T, _ string) {},
+			wantErrType: ErrSpecNotFound,
+		},
+		{
+			name:     "invalid YAML returns parse error",
+			provider: "invalid",
+			service:  "yaml",
+			sku:      "test",
+			setupFunc: func(t *testing.T, dir string) {
+				filename := filepath.Join(dir, "invalid-yaml-test.yaml")
+				invalidYAML := `this is not: valid
+  yaml: [unclosed
+`
+				err := os.WriteFile(filename, []byte(invalidYAML), 0644)
+				require.NoError(t, err)
+			},
+			wantErrMsg: "parsing spec YAML",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tt.setupFunc(t, tmpDir)
+
+			loader := NewLoader(tmpDir)
+			spec, err := loader.LoadSpec(tt.provider, tt.service, tt.sku)
+
+			require.Error(t, err)
+			assert.Nil(t, spec, "spec should be nil on error")
+
+			if tt.wantErrType != nil {
+				require.ErrorIs(t, err, tt.wantErrType)
+			}
+			if tt.wantErrMsg != "" {
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+			}
+		})
+	}
+}
+
+// TestLoadSpec_NonexistentDirectory tests loading from a non-existent directory.
+func TestLoadSpec_NonexistentDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	nonexistentDir := filepath.Join(tmpDir, "nonexistent")
+
+	loader := NewLoader(nonexistentDir)
+	spec, err := loader.LoadSpec("aws", "ec2", "t3.micro")
+
+	require.Error(t, err)
+	assert.Nil(t, spec)
+	assert.ErrorIs(t, err, ErrSpecNotFound)
+}
+
+// TestLoadSpec_PermissionError tests loading a spec file with restricted permissions.
+func TestLoadSpec_PermissionError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("Skipping permission test when running as root")
+	}
+
+	tmpDir := t.TempDir()
+
+	// Create a spec file with no read permissions
+	filename := filepath.Join(tmpDir, "aws-ec2-restricted.yaml")
+	err := os.WriteFile(filename, []byte("test: data"), 0000)
+	require.NoError(t, err)
+	defer os.Chmod(filename, 0644) // Restore for cleanup
+
+	loader := NewLoader(tmpDir)
+	spec, err := loader.LoadSpec("aws", "ec2", "restricted")
+
+	require.Error(t, err)
+	assert.Nil(t, spec)
+	assert.Contains(t, err.Error(), "reading spec file")
+}
+
+// TestParseSpecFilename_Valid tests parsing valid spec filenames.
+func TestParseSpecFilename_Valid(t *testing.T) {
+	tests := []struct {
+		filename string
+		provider string
+		service  string
+		sku      string
+	}{
+		{
+			filename: "aws-ec2-t3.micro.yaml",
+			provider: "aws",
+			service:  "ec2",
+			sku:      "t3.micro",
+		},
+		{
+			filename: "aws-rds-db.t3.medium.yaml",
+			provider: "aws",
+			service:  "rds",
+			sku:      "db.t3.medium",
+		},
+		{
+			filename: "azure-compute-standard-d2s-v3.yaml",
+			provider: "azure",
+			service:  "compute",
+			sku:      "standard-d2s-v3",
+		},
+		{
+			filename: "gcp-compute-n1-standard-1.yaml",
+			provider: "gcp",
+			service:  "compute",
+			sku:      "n1-standard-1",
+		},
+		{
+			filename: "aws-ec2-t3.micro.yml",
+			provider: "aws",
+			service:  "ec2",
+			sku:      "t3.micro",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			provider, service, sku, valid := ParseSpecFilename(tt.filename)
+
+			assert.True(t, valid, "filename should be valid")
+			assert.Equal(t, tt.provider, provider)
+			assert.Equal(t, tt.service, service)
+			assert.Equal(t, tt.sku, sku)
+		})
+	}
+}
+
+// TestParseSpecFilename_Invalid tests parsing invalid spec filenames.
+func TestParseSpecFilename_Invalid(t *testing.T) {
+	tests := []struct {
+		filename string
+		reason   string
+	}{
+		{
+			filename: "aws-ec2.yaml",
+			reason:   "insufficient parts",
+		},
+		{
+			filename: "aws.yaml",
+			reason:   "only one part",
+		},
+		{
+			filename: ".yaml",
+			reason:   "empty name",
+		},
+		{
+			filename: "nohyphens.yaml",
+			reason:   "no hyphens",
+		},
+		{
+			filename: "aws-ec2-t3.micro.json",
+			reason:   "wrong extension",
+		},
+		{
+			filename: "aws--t3.micro.yaml",
+			reason:   "empty service part",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.reason, func(t *testing.T) {
+			provider, service, sku, valid := ParseSpecFilename(tt.filename)
+
+			assert.False(t, valid, "filename should be invalid: %s", tt.reason)
+			assert.Empty(t, provider)
+			assert.Empty(t, service)
+			assert.Empty(t, sku)
+		})
+	}
+}
+
+// TestListSpecs tests listing specs in a directory.
+func TestListSpecs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create test files
+	testFiles := []struct {
+		name       string
+		shouldList bool
+	}{
+		{"aws-ec2-t3.micro.yaml", true},
+		{"aws-rds-db.t3.medium.yaml", true},
+		{"azure-compute-standard-d2s.yaml", true},
+		{"notaspec.txt", false},
+		{"readme.md", false},
+		{"subdir", false}, // Directory
+	}
+
+	for _, tf := range testFiles {
+		path := filepath.Join(tmpDir, tf.name)
+		if tf.name == "subdir" {
+			err := os.Mkdir(path, 0755)
+			require.NoError(t, err)
+		} else {
+			err := os.WriteFile(path, []byte("test: data\n"), 0644)
+			require.NoError(t, err)
+		}
+	}
+
+	loader := NewLoader(tmpDir)
+	specs, err := loader.ListSpecs()
+
+	require.NoError(t, err)
+
+	// Count expected specs
+	expectedCount := 0
+	for _, tf := range testFiles {
+		if tf.shouldList {
+			expectedCount++
+		}
+	}
+
+	assert.Len(t, specs, expectedCount, "should list only .yaml files")
+
+	// Verify only .yaml files are included
+	for _, spec := range specs {
+		assert.Equal(t, ".yaml", filepath.Ext(spec), "all specs should have .yaml extension")
+	}
+}
+
+// TestListSpecs_EmptyDirectory tests listing specs in an empty directory.
+func TestListSpecs_EmptyDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	loader := NewLoader(tmpDir)
+	specs, err := loader.ListSpecs()
+
+	require.NoError(t, err)
+	assert.Empty(t, specs, "empty directory should return empty list")
+}
+
+// TestListSpecs_NonexistentDirectory tests listing specs in a non-existent directory.
+func TestListSpecs_NonexistentDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	nonexistentDir := filepath.Join(tmpDir, "nonexistent")
+
+	loader := NewLoader(nonexistentDir)
+	specs, err := loader.ListSpecs()
+
+	require.NoError(t, err, "should not error for non-existent directory")
+	assert.Nil(t, specs, "should return nil for non-existent directory")
+}
+
+// TestListSpecs_PermissionError tests listing specs with permission error.
+func TestListSpecs_PermissionError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("Skipping permission test when running as root")
+	}
+
+	tmpDir := t.TempDir()
+
+	// Remove read permission
+	err := os.Chmod(tmpDir, 0000)
+	require.NoError(t, err)
+	defer os.Chmod(tmpDir, 0755) // Restore for cleanup
+
+	loader := NewLoader(tmpDir)
+	specs, err := loader.ListSpecs()
+
+	require.Error(t, err, "should error for permission denied")
+	assert.Nil(t, specs)
+	assert.Contains(t, err.Error(), "reading spec directory")
+}
+
+// TestValidateSpec tests spec validation.
+func TestValidateSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    *PricingSpec
+		wantErr string
+	}{
+		{
+			name: "valid spec",
+			spec: &PricingSpec{
+				Provider: "aws",
+				Service:  "ec2",
+				SKU:      "t3.micro",
+				Currency: "USD",
+				Pricing: map[string]interface{}{
+					"hourly_cost": 0.0104,
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "missing provider",
+			spec: &PricingSpec{
+				Service:  "ec2",
+				SKU:      "t3.micro",
+				Currency: "USD",
+				Pricing: map[string]interface{}{
+					"hourly_cost": 0.0104,
+				},
+			},
+			wantErr: "provider is required",
+		},
+		{
+			name: "missing service",
+			spec: &PricingSpec{
+				Provider: "aws",
+				SKU:      "t3.micro",
+				Currency: "USD",
+				Pricing: map[string]interface{}{
+					"hourly_cost": 0.0104,
+				},
+			},
+			wantErr: "service is required",
+		},
+		{
+			name: "missing SKU",
+			spec: &PricingSpec{
+				Provider: "aws",
+				Service:  "ec2",
+				Currency: "USD",
+				Pricing: map[string]interface{}{
+					"hourly_cost": 0.0104,
+				},
+			},
+			wantErr: "SKU is required",
+		},
+		{
+			name: "missing currency",
+			spec: &PricingSpec{
+				Provider: "aws",
+				Service:  "ec2",
+				SKU:      "t3.micro",
+				Pricing: map[string]interface{}{
+					"hourly_cost": 0.0104,
+				},
+			},
+			wantErr: "currency is required",
+		},
+		{
+			name: "empty pricing",
+			spec: &PricingSpec{
+				Provider: "aws",
+				Service:  "ec2",
+				SKU:      "t3.micro",
+				Currency: "USD",
+				Pricing:  map[string]interface{}{},
+			},
+			wantErr: "pricing information is required",
+		},
+		{
+			name: "nil pricing",
+			spec: &PricingSpec{
+				Provider: "aws",
+				Service:  "ec2",
+				SKU:      "t3.micro",
+				Currency: "USD",
+				Pricing:  nil,
+			},
+			wantErr: "pricing information is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSpec(tt.spec)
+
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestLoadSpec_ContentValidation tests that loaded specs have correct content.
+func TestLoadSpec_ContentValidation(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	specContent := `provider: aws
+service: ec2
+sku: t3.micro
+currency: USD
+pricing:
+  onDemandHourly: 0.0104
+  monthlyEstimate: 7.59
+metadata:
+  region: us-east-1
+  description: "Test spec"
+`
+
+	filename := filepath.Join(tmpDir, "aws-ec2-t3.micro.yaml")
+	err := os.WriteFile(filename, []byte(specContent), 0644)
+	require.NoError(t, err)
+
+	loader := NewLoader(tmpDir)
+	spec, err := loader.LoadSpec("aws", "ec2", "t3.micro")
+
+	require.NoError(t, err)
+	require.NotNil(t, spec)
+
+	pricingSpec, ok := spec.(*PricingSpec)
+	require.True(t, ok, "spec should be *PricingSpec")
+
+	// Verify all fields
+	assert.Equal(t, "aws", pricingSpec.Provider)
+	assert.Equal(t, "ec2", pricingSpec.Service)
+	assert.Equal(t, "t3.micro", pricingSpec.SKU)
+	assert.Equal(t, "USD", pricingSpec.Currency)
+
+	// Verify pricing structure
+	require.NotNil(t, pricingSpec.Pricing)
+	assert.Contains(t, pricingSpec.Pricing, "onDemandHourly")
+	assert.Contains(t, pricingSpec.Pricing, "monthlyEstimate")
+
+	// Verify metadata
+	require.NotNil(t, pricingSpec.Metadata)
+	assert.Contains(t, pricingSpec.Metadata, "region")
+	assert.Contains(t, pricingSpec.Metadata, "description")
+}

--- a/test/fixtures/plans/aws-multi-resource-plan.json
+++ b/test/fixtures/plans/aws-multi-resource-plan.json
@@ -1,121 +1,79 @@
 {
-  "planned_values": {
-    "root_module": {
-      "resources": [
-        {
-          "address": "aws_instance.web_server",
-          "type": "aws_instance",
-          "provider_name": "registry.terraform.io/hashicorp/aws",
-          "values": {
-            "instance_type": "t3.medium",
-            "ami": "ami-0abcdef1234567890",
-            "region": "us-east-1",
-            "availability_zone": "us-east-1a",
-            "key_name": "my-key-pair",
-            "security_groups": ["web-sg"],
-            "tags": {
-              "Name": "WebServer",
-              "Environment": "production"
-            }
-          }
+  "steps": [
+    {
+      "op": "create",
+      "urn": "urn:pulumi:dev::my-app::aws:ec2/instance:Instance::web-server",
+      "type": "aws:ec2/instance:Instance",
+      "provider": "urn:pulumi:dev::my-app::pulumi:providers:aws::default_1_0_0::04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+      "inputs": {
+        "ami": "ami-0c02fb55956c7d316",
+        "instanceType": "t3.micro",
+        "tags": {
+          "Name": "Web Server",
+          "Environment": "dev"
         },
-        {
-          "address": "aws_s3_bucket.data_bucket",
-          "type": "aws_s3_bucket",
-          "provider_name": "registry.terraform.io/hashicorp/aws",
-          "values": {
-            "bucket": "my-data-bucket-12345",
-            "region": "us-east-1",
-            "versioning": {
-              "enabled": true
-            },
-            "server_side_encryption_configuration": {
-              "rule": {
-                "apply_server_side_encryption_by_default": {
-                  "sse_algorithm": "AES256"
-                }
-              }
-            },
-            "tags": {
-              "Name": "DataBucket",
-              "Environment": "production"
-            }
-          }
+        "availabilityZone": "us-west-2a",
+        "keyName": "my-key"
+      },
+      "outputs": {}
+    },
+    {
+      "op": "create",
+      "urn": "urn:pulumi:dev::my-app::aws:s3/bucket:Bucket::static-assets",
+      "type": "aws:s3/bucket:Bucket",
+      "provider": "urn:pulumi:dev::my-app::pulumi:providers:aws::default_1_0_0::04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+      "inputs": {
+        "bucket": "my-static-assets-bucket-12345",
+        "acl": "private",
+        "versioning": {
+          "enabled": true
         },
-        {
-          "address": "aws_rds_instance.database",
-          "type": "aws_rds_instance",
-          "provider_name": "registry.terraform.io/hashicorp/aws",
-          "values": {
-            "identifier": "prod-database",
-            "engine": "mysql",
-            "engine_version": "8.0",
-            "instance_class": "db.t3.micro",
-            "allocated_storage": 20,
-            "storage_type": "gp2",
-            "storage_encrypted": true,
-            "db_name": "myapp",
-            "username": "admin",
-            "password": "********",
-            "vpc_security_group_ids": ["sg-12345"],
-            "db_subnet_group_name": "default",
-            "backup_retention_period": 7,
-            "multi_az": false,
-            "publicly_accessible": false,
-            "tags": {
-              "Name": "ProdDatabase",
-              "Environment": "production"
-            }
-          }
-        },
-        {
-          "address": "aws_lambda_function.api_handler",
-          "type": "aws_lambda_function",
-          "provider_name": "registry.terraform.io/hashicorp/aws",
-          "values": {
-            "function_name": "api-handler",
-            "runtime": "python3.9",
-            "handler": "lambda_function.lambda_handler",
-            "filename": "lambda_function.zip",
-            "memory_size": 128,
-            "timeout": 30,
-            "environment": {
-              "variables": {
-                "STAGE": "prod",
-                "DB_HOST": "prod-database.region.rds.amazonaws.com"
-              }
-            },
-            "tags": {
-              "Name": "APIHandler",
-              "Environment": "production"
-            }
-          }
-        },
-        {
-          "address": "aws_cloudwatch_log_group.lambda_logs",
-          "type": "aws_cloudwatch_log_group",
-          "provider_name": "registry.terraform.io/hashicorp/aws",
-          "values": {
-            "name": "/aws/lambda/api-handler",
-            "retention_in_days": 30,
-            "tags": {
-              "Name": "LambdaLogs",
-              "Environment": "production"
-            }
-          }
+        "tags": {
+          "Purpose": "Static Assets",
+          "Environment": "dev"
         }
-      ]
+      },
+      "outputs": {}
+    },
+    {
+      "op": "create",
+      "urn": "urn:pulumi:dev::my-app::aws:rds/instance:Instance::database",
+      "type": "aws:rds/instance:Instance",
+      "provider": "urn:pulumi:dev::my-app::pulumi:providers:aws::default_1_0_0::04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+      "inputs": {
+        "allocatedStorage": 20,
+        "dbInstanceClass": "db.t3.micro",
+        "engine": "postgres",
+        "engineVersion": "13.7",
+        "identifier": "my-database",
+        "username": "admin",
+        "password": "supersecret123",
+        "skipFinalSnapshot": true,
+        "tags": {
+          "Name": "Application Database",
+          "Environment": "dev"
+        }
+      },
+      "outputs": {}
+    },
+    {
+      "op": "create",
+      "urn": "urn:pulumi:dev::my-app::aws:lambda/function:Function::api-handler",
+      "type": "aws:lambda/function:Function",
+      "provider": "urn:pulumi:dev::my-app::pulumi:providers:aws::default_1_0_0::04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+      "inputs": {
+        "name": "api-handler",
+        "runtime": "nodejs18.x",
+        "handler": "index.handler",
+        "role": "arn:aws:iam::123456789012:role/lambda-role",
+        "memorySize": 128,
+        "timeout": 30,
+        "tags": {
+          "Name": "API Handler",
+          "Environment": "dev"
+        }
+      },
+      "outputs": {}
     }
-  },
-  "configuration": {
-    "provider_config": {
-      "aws": {
-        "name": "aws",
-        "version_constraint": "~> 5.0"
-      }
-    }
-  },
-  "variables": {},
-  "terraform_version": "1.5.0",
-  "format_version": "1.2"
+  ]
 }

--- a/test/integration/plugin/plugin_communication_test.go
+++ b/test/integration/plugin/plugin_communication_test.go
@@ -112,7 +112,7 @@ func TestPluginCommunication_ActualCostFlow(t *testing.T) {
 	require.Len(t, resp.GetResults(), 1)
 
 	result := resp.GetResults()[0]
-	assert.Equal(t, "mock-source", result.GetSource())
+	assert.Equal(t, resourceID, result.GetSource())
 	assert.InDelta(t, 85.25, result.GetCost(), 0.01)
 }
 

--- a/test/mocks/plugin/mock_plugin_test.go
+++ b/test/mocks/plugin/mock_plugin_test.go
@@ -24,7 +24,7 @@ func TestMockPlugin_Basic(t *testing.T) {
 	defer mockPlugin.Stop()
 
 	assert.Positive(t, mockPlugin.GetPort())
-	assert.Contains(t, mockPlugin.GetAddress(), "localhost:")
+	assert.Contains(t, mockPlugin.GetAddress(), "127.0.0.1:")
 }
 
 // TestMockPlugin_Name tests the Name RPC method and call counting.
@@ -139,7 +139,7 @@ func TestMockPlugin_GetActualCost_Default(t *testing.T) {
 
 	result := resp.GetResults()[0]
 	assert.InDelta(t, 25.50, result.GetCost(), 0.01)
-	assert.Equal(t, "mock-source", result.GetSource())
+	assert.Equal(t, "i-1234567890abcdef0", result.GetSource())
 	assert.Equal(t, 1, mockPlugin.GetCallCount("GetActualCost"))
 }
 

--- a/test/unit/config/config_test.go
+++ b/test/unit/config/config_test.go
@@ -4,6 +4,7 @@ package config_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/rshade/pulumicost-core/internal/config"
@@ -41,6 +42,11 @@ func TestGetConfigDir(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Skip USERPROFILE test on non-Windows platforms
+			if tt.envVar == "USERPROFILE" && runtime.GOOS != "windows" {
+				t.Skip("USERPROFILE is Windows-specific")
+			}
+
 			// Set test env var if specified
 			if tt.envVar != "" && tt.envValue != "" {
 				t.Setenv(tt.envVar, tt.envValue)

--- a/test/unit/engine/engine_test.go
+++ b/test/unit/engine/engine_test.go
@@ -65,10 +65,10 @@ func TestEngine_GetProjectedCost(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.NotNil(t, results)
 
 			// Should have same number of results as resources (or at least handle gracefully)
 			if len(tt.resources) > 0 {
+				assert.NotNil(t, results)
 				assert.Len(t, results, len(tt.resources))
 
 				// Should have "none" adapter when no plugins available
@@ -76,6 +76,9 @@ func TestEngine_GetProjectedCost(t *testing.T) {
 					assert.Equal(t, "none", result.Adapter)
 					assert.Equal(t, "USD", result.Currency)
 				}
+			} else {
+				// Empty resources should return nil or empty slice
+				assert.Empty(t, results)
 			}
 		})
 	}
@@ -121,7 +124,12 @@ func TestEngine_GetActualCost(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.NotNil(t, results)
+			// Empty resources should return nil or empty slice
+			if len(tt.resources) > 0 {
+				assert.NotNil(t, results)
+			} else {
+				assert.Empty(t, results)
+			}
 		})
 	}
 }
@@ -188,7 +196,6 @@ func TestEngine_ErrorHandling(t *testing.T) {
 
 		results, err := eng.GetProjectedCost(context.Background(), []engine.ResourceDescriptor{})
 		require.NoError(t, err)
-		assert.NotNil(t, results)
 		assert.Empty(t, results)
 	})
 }


### PR DESCRIPTION
* test: add comprehensive coverage for engine types and rendering

Add complete test coverage for `internal/engine/types.go` and `internal/engine/project.go`, addressing critical gap in core engine testing.

- **internal/engine/types_test.go** (267 lines)
  - GroupBy validation tests (IsValid, IsTimeBasedGrouping, String)
  - ResourceDescriptor creation and field verification
  - CostResult structure initialization and validation
  - CrossProviderAggregation correctness testing
  - Error type constants validation

- **internal/engine/project_test.go** (441 lines)
  - RenderResults dispatcher tests (table, JSON, NDJSON)
  - RenderActualCostResults format validation
  - RenderCrossProviderAggregation output tests
  - Currency symbol mapping verification
  - JSON marshaling/unmarshaling tests
  - Edge case handling (nil/empty results)
  - Multi-provider rendering scenarios
  - Long resource name truncation tests

```
types.go:     100.0% coverage (3/3 methods)
project.go:   95.2% coverage (12/12 functions)
engine total: 72.3% overall package coverage
```

- ✅ All engine tests pass: `go test ./internal/engine/...`
- ✅ Coverage exceeds 80% target on both files
- ✅ Race detector clean: `go test -race ./internal/engine/...`
- ✅ Linting passes: `make lint` (0 issues)
- ✅ Code style: proper godot comments, no shadow declarations

- Tests follow existing patterns from `engine_test.go`
- Table-driven test approach for comprehensive coverage
- Validation of rendering functions without stdout capture complexity
- All edge cases covered (nil, empty, multi-provider, truncation)

Fixes #97

* fix: set WaitDelay for process cleanup to prevent test timeout