### PR TITLE
refactor!: remove encryption from config, use environment variables f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### BREAKING CHANGES
+
+- **Removed encryption functionality from config package**: The built-in encryption system using PBKDF2 has been completely removed due to security concerns about weak key derivation. Users should now store sensitive values (API keys, credentials) as environment variables instead of in configuration files. This is the industry-standard approach for CLI tools and follows best practices for secret management.
+  - Removed `EncryptValue()` and `DecryptValue()` methods from Config
+  - Removed `--encrypt` flag from `pulumicost config set` command
+  - Removed `--decrypt` flag from `pulumicost config get` command
+  - Removed all encryption-related infrastructure (deriveKey, master key management)
+
+  **Migration Guide**:
+  - Remove any encrypted values from your `~/.pulumicost/config.yaml`
+  - Store sensitive values as environment variables using the pattern: `PULUMICOST_PLUGIN_<PLUGIN_NAME>_<KEY_NAME>`
+  - Example: `export PULUMICOST_PLUGIN_AWS_SECRET_KEY="your-secret"`
+  - Environment variables automatically override config file values
+
+### Changed
+
+- Updated CLI command documentation to recommend environment variables for sensitive data
+- Updated README with comprehensive configuration and environment variable documentation
+- Simplified config package by removing unused encryption dependencies
+
+### Removed
+
+- PBKDF2-based encryption key derivation (security vulnerability)
+- AES-256-GCM encryption for configuration values
+- Master key file creation and management
+- Encryption-related tests and validation
+
+## [0.1.0] - 2025-01-14
+
+### Added
+
+- Initial release of PulumiCost Core CLI
+- Projected cost calculation from Pulumi plans
+- Actual cost queries with time ranges and filtering
+- Cross-provider cost aggregation
+- Plugin-based architecture for extensibility
+- Configuration management system
+- Multiple output formats (table, JSON, NDJSON)
+- Resource grouping and filtering capabilities
+- Comprehensive testing framework

--- a/README.md
+++ b/README.md
@@ -135,6 +135,52 @@ pulumicost cost projected --pulumi-json plan.json --output json
 pulumicost cost projected --pulumi-json plan.json --output ndjson
 ```
 
+## Configuration
+
+### Basic Configuration
+PulumiCost can be configured using a YAML file at `~/.pulumicost/config.yaml`:
+
+```bash
+# Initialize default configuration
+pulumicost config init
+
+# Set configuration values
+pulumicost config set output.default_format json
+pulumicost config set output.precision 4
+pulumicost config set plugins.aws.region us-west-2
+```
+
+### Environment Variables for Secrets
+For sensitive values like API keys and credentials, use environment variables instead of storing them in configuration files:
+
+```bash
+# AWS credentials
+export PULUMICOST_PLUGIN_AWS_ACCESS_KEY_ID="your-access-key"
+export PULUMICOST_PLUGIN_AWS_SECRET_ACCESS_KEY="your-secret-key"
+
+# Azure credentials
+export PULUMICOST_PLUGIN_AZURE_CLIENT_ID="your-client-id"
+export PULUMICOST_PLUGIN_AZURE_CLIENT_SECRET="your-client-secret"
+
+# Kubecost API
+export PULUMICOST_PLUGIN_KUBECOST_API_KEY="your-api-key"
+
+# Vantage API
+export PULUMICOST_PLUGIN_VANTAGE_API_TOKEN="your-token"
+```
+
+Environment variables override configuration file values and are the recommended way to handle sensitive data. The naming convention is: `PULUMICOST_PLUGIN_<PLUGIN_NAME>_<KEY_NAME>` in uppercase.
+
+### Configuration Management Commands
+```bash
+# View configuration
+pulumicost config get output.default_format
+pulumicost config list
+
+# Validate configuration
+pulumicost config validate
+```
+
 ## Plugin Management
 
 ### List Available Plugins

--- a/internal/cli/config_get.go
+++ b/internal/cli/config_get.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 
@@ -11,29 +10,28 @@ import (
 
 // NewConfigGetCmd creates the config get command for retrieving configuration values.
 func NewConfigGetCmd() *cobra.Command {
-	var decrypt bool
 	cmd := &cobra.Command{
 		Use:   "get <key>",
 		Short: "Get a configuration value",
-		Long:  "Gets a configuration value using dot notation from ~/.pulumicost/config.yaml.",
+		Long: `Gets a configuration value using dot notation from ~/.pulumicost/config.yaml.
+
+Note: Sensitive values should be stored as environment variables (e.g., PULUMICOST_PLUGIN_AWS_SECRET_KEY)
+and will not appear in configuration files.`,
 		Example: `  # Get output format
   pulumicost config get output.default_format
-  
+
   # Get output precision
   pulumicost config get output.precision
-  
+
   # Get plugin configuration
   pulumicost config get plugins.aws.region
   pulumicost config get plugins.aws
-  
+
   # Get all plugins
   pulumicost config get plugins
-  
+
   # Get logging level
-  pulumicost config get logging.level
-  
-  # Decrypt encrypted value
-  pulumicost config get plugins.aws.secret_key --decrypt`,
+  pulumicost config get logging.level`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			key := args[0]
@@ -47,27 +45,12 @@ func NewConfigGetCmd() *cobra.Command {
 				return fmt.Errorf("failed to get config value: %w", err)
 			}
 
-			// Decrypt value if requested and it's a string
-			if decrypt {
-				if strValue, ok := value.(string); ok {
-					decryptedValue, decryptErr := cfg.DecryptValue(strValue)
-					if decryptErr != nil {
-						return fmt.Errorf("failed to decrypt value: %w", decryptErr)
-					}
-					value = decryptedValue
-				} else {
-					return errors.New("can only decrypt string values")
-				}
-			}
-
 			// Format and output the value
 			formatAndPrintValue(cmd, key, value)
 
 			return nil
 		},
 	}
-
-	cmd.Flags().BoolVar(&decrypt, "decrypt", false, "decrypt the value if it's encrypted")
 
 	return cmd
 }

--- a/internal/cli/config_set.go
+++ b/internal/cli/config_set.go
@@ -9,47 +9,35 @@ import (
 
 // NewConfigSetCmd creates the config set command for setting configuration values.
 func NewConfigSetCmd() *cobra.Command {
-	var encrypt bool
 	cmd := &cobra.Command{
 		Use:   "set <key> <value>",
 		Short: "Set a configuration value",
-		Long:  "Sets a configuration value using dot notation. The configuration will be saved to ~/.pulumicost/config.yaml.",
+		Long: `Sets a configuration value using dot notation. The configuration will be saved to ~/.pulumicost/config.yaml.
+
+For sensitive values like API keys or credentials, use environment variables instead:
+  export PULUMICOST_PLUGIN_AWS_SECRET_KEY="mysecret"
+  export PULUMICOST_PLUGIN_AZURE_CLIENT_SECRET="secret"`,
 		Example: `  # Set output format
   pulumicost config set output.default_format json
-  
+
   # Set output precision
   pulumicost config set output.precision 4
-  
+
   # Set plugin configuration
   pulumicost config set plugins.aws.region us-west-2
   pulumicost config set plugins.aws.profile production
-  
+
   # Set logging level
   pulumicost config set logging.level debug
-  
-  # Set encrypted credential (sensitive values)
-  pulumicost config set plugins.aws.secret_key "mysecret" --encrypt`,
+
+  # For sensitive values, use environment variables instead
+  export PULUMICOST_PLUGIN_AWS_SECRET_KEY="mysecret"`,
 		Args: cobra.ExactArgs(2), //nolint:mnd // Exactly 2 args: key and value
 		RunE: func(cmd *cobra.Command, args []string) error {
 			key := args[0]
 			value := args[1]
 
 			cfg := config.New()
-
-			var displayValue string
-
-			// Encrypt value if requested
-			if encrypt {
-				encryptedValue, err := cfg.EncryptValue(value)
-				if err != nil {
-					return fmt.Errorf("failed to encrypt value: %w", err)
-				}
-				value = encryptedValue
-				displayValue = "[encrypted]"
-				fmt.Fprintln(cmd.ErrOrStderr(), "Value encrypted before storage")
-			} else {
-				displayValue = value
-			}
 
 			// Set the value
 			if err := cfg.Set(key, value); err != nil {
@@ -66,13 +54,11 @@ func NewConfigSetCmd() *cobra.Command {
 				return fmt.Errorf("failed to save config: %w", err)
 			}
 
-			cmd.Printf("Configuration updated: %s = %s\n", key, displayValue)
+			cmd.Printf("Configuration updated: %s = %s\n", key, value)
 
 			return nil
 		},
 	}
-
-	cmd.Flags().BoolVar(&encrypt, "encrypt", false, "encrypt the value before storing (for sensitive data)")
 
 	return cmd
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -142,36 +142,6 @@ func TestConfig_Validation(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid log level")
 }
 
-func TestConfig_EncryptDecrypt(t *testing.T) {
-	stubHome(t)
-	cfg := New()
-
-	original := "secret-value-123"
-
-	encrypted, err := cfg.EncryptValue(original)
-	require.NoError(t, err)
-	assert.NotEqual(t, original, encrypted)
-	assert.NotEmpty(t, encrypted)
-
-	decrypted, err := cfg.DecryptValue(encrypted)
-	require.NoError(t, err)
-	assert.Equal(t, original, decrypted)
-}
-
-func TestConfig_EncryptDecryptErrors(t *testing.T) {
-	stubHome(t)
-	cfg := New()
-
-	// Invalid base64 for decryption
-	_, err := cfg.DecryptValue("invalid-base64")
-	assert.Error(t, err)
-
-	// Invalid encrypted data (too short)
-	_, err = cfg.DecryptValue("dGVzdA==") // "test" in base64, too short for GCM
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "ciphertext too short")
-}
-
 func TestConfig_SaveLoad(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "pulumicost-config-test")
 	require.NoError(t, err)
@@ -190,7 +160,6 @@ func TestConfig_SaveLoad(t *testing.T) {
 			File:  filepath.Join(t.TempDir(), "test.log"),
 		},
 		configPath: filepath.Join(tmpDir, "config.yaml"),
-		encKey:     deriveKey(),
 	}
 
 	// Save configuration
@@ -200,7 +169,6 @@ func TestConfig_SaveLoad(t *testing.T) {
 	// Load configuration
 	cfg2 := &Config{
 		configPath: cfg.configPath,
-		encKey:     deriveKey(),
 	}
 	err = cfg2.Load()
 	require.NoError(t, err)

--- a/test/fixtures/plans/aws-simple-plan.json
+++ b/test/fixtures/plans/aws-simple-plan.json
@@ -1,0 +1,79 @@
+{
+  "steps": [
+    {
+      "op": "create",
+      "urn": "urn:pulumi:dev::my-app::aws:ec2/instance:Instance::web-server",
+      "type": "aws:ec2/instance:Instance",
+      "provider": "urn:pulumi:dev::my-app::pulumi:providers:aws::default_1_0_0::04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+      "inputs": {
+        "ami": "ami-0c02fb55956c7d316",
+        "instanceType": "t3.micro",
+        "tags": {
+          "Name": "Web Server",
+          "Environment": "dev"
+        },
+        "availabilityZone": "us-west-2a",
+        "keyName": "my-key"
+      },
+      "outputs": {}
+    },
+    {
+      "op": "create",
+      "urn": "urn:pulumi:dev::my-app::aws:s3/bucket:Bucket::static-assets",
+      "type": "aws:s3/bucket:Bucket",
+      "provider": "urn:pulumi:dev::my-app::pulumi:providers:aws::default_1_0_0::04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+      "inputs": {
+        "bucket": "my-static-assets-bucket-12345",
+        "acl": "private",
+        "versioning": {
+          "enabled": true
+        },
+        "tags": {
+          "Purpose": "Static Assets",
+          "Environment": "dev"
+        }
+      },
+      "outputs": {}
+    },
+    {
+      "op": "create",
+      "urn": "urn:pulumi:dev::my-app::aws:rds/instance:Instance::database",
+      "type": "aws:rds/instance:Instance",
+      "provider": "urn:pulumi:dev::my-app::pulumi:providers:aws::default_1_0_0::04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+      "inputs": {
+        "allocatedStorage": 20,
+        "dbInstanceClass": "db.t3.micro",
+        "engine": "postgres",
+        "engineVersion": "13.7",
+        "identifier": "my-database",
+        "username": "admin",
+        "password": "supersecret123",
+        "skipFinalSnapshot": true,
+        "tags": {
+          "Name": "Application Database",
+          "Environment": "dev"
+        }
+      },
+      "outputs": {}
+    },
+    {
+      "op": "create",
+      "urn": "urn:pulumi:dev::my-app::aws:lambda/function:Function::api-handler",
+      "type": "aws:lambda/function:Function",
+      "provider": "urn:pulumi:dev::my-app::pulumi:providers:aws::default_1_0_0::04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+      "inputs": {
+        "name": "api-handler",
+        "runtime": "nodejs18.x",
+        "handler": "index.handler",
+        "role": "arn:aws:iam::123456789012:role/lambda-role",
+        "memorySize": 128,
+        "timeout": 30,
+        "tags": {
+          "Name": "API Handler",
+          "Environment": "dev"
+        }
+      },
+      "outputs": {}
+    }
+  ]
+}


### PR DESCRIPTION
…or secrets

## Overview
Removes all encryption functionality from the configuration package due to security concerns and aligns with industry-standard practices of using environment variables for sensitive data.

## Changes

### Breaking Changes
- **Removed encryption/decryption methods**: `EncryptValue()` and `DecryptValue()` methods removed from Config
- **Removed CLI flags**: `--encrypt` flag from `config set` command and `--decrypt` flag from `config get` command
- **Removed encryption infrastructure**: Complete removal of PBKDF2 key derivation, master key management, and AES-256-GCM encryption

### Migration Path
Users should migrate to environment variables for sensitive values:

**Before** (no longer supported):
```bash
pulumicost config set plugins.aws.secret_key "mysecret" --encrypt
```

**After** (recommended approach):
```bash
export PULUMICOST_PLUGIN_AWS_SECRET_KEY="mysecret"
```

Environment variables use the pattern: `PULUMICOST_PLUGIN_<PLUGIN_NAME>_<KEY_NAME>` in uppercase and automatically override config file values.

### Documentation Updates
- Added comprehensive Configuration section to README with environment variable examples
- Updated CLI command help text to recommend environment variables for secrets
- Created CHANGELOG.md with detailed breaking change documentation

### Code Changes
- Removed encryption-related code from `internal/config/config.go`
- Removed encryption-related tests from `internal/config/config_test.go` and `internal/cli/config_test.go`
- Updated `internal/cli/config_set.go` to remove `--encrypt` flag
- Updated `internal/cli/config_get.go` to remove `--decrypt` flag
- Cleaned up unused crypto imports (crypto/aes, crypto/cipher, crypto/rand, encoding/base64, io)

### Test Fixes
- Fixed missing `test/fixtures/plans/aws-simple-plan.json` that was causing E2E test failures
- All tests now pass with encryption functionality removed

## Rationale
The previous encryption implementation had several security issues:
1. Weak PBKDF2 key derivation with predictable entropy (GOOS, GOARCH, homeDir)
2. Unnecessary complexity for a CLI tool's MVP
3. Environment variables are the industry standard for secret management in CLI tools

Following the principle of KISS and standard practices used by tools like Pulumi, AWS CLI, and Terraform, this change simplifies the codebase while improving security.

## Testing
- ✅ `make lint` - All linting passes
- ✅ `make test` - All tests pass
- ✅ Manual testing of config commands confirmed

## Closes
Closes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **BREAKING CHANGES**
  * Removed encryption functionality from configuration. Use environment variables to manage sensitive values.

* **Documentation**
  * Added configuration setup guidance including YAML file initialization and environment variable examples.
  * Expanded plugin management section with validation and directory structure reference.

* **Tests**
  * Updated test fixtures and removed encryption-related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->