### PR TITLE
feat(plugin): add reference recorder plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,17 @@ jobs:
           if [ -d "examples/plugins/aws-example" ]; then
             go build -o bin/aws-example-plugin ./examples/plugins/aws-example
           fi
+          # Build recorder plugin for integration tests
+          make build-recorder
 
       - name: Run tests with coverage
         run: |
           go test -v -race -coverprofile=coverage.out -covermode=atomic ./internal/... ./pkg/...
           go tool cover -func=coverage.out
+
+      - name: Run integration tests
+        run: |
+          go test -v -race ./test/integration/...
 
       - name: Check overall coverage threshold
         run: |
@@ -255,6 +261,13 @@ jobs:
 
           mkdir -p dist
           eval go build ${LDFLAGS} -o dist/${BINARY_NAME}-${GOOS}-${GOARCH} ./cmd/pulumicost
+
+          # Build recorder plugin
+          RECORDER_NAME="pulumicost-plugin-recorder"
+          if [ "${GOOS}" = "windows" ]; then
+            RECORDER_NAME="${RECORDER_NAME}.exe"
+          fi
+          eval go build ${LDFLAGS} -o dist/${RECORDER_NAME}-${GOOS}-${GOARCH} ./plugins/recorder/cmd
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6

--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,6 @@ yarn-error.log*
 
 # Test/debug log files
 *.log
+
+# Recorder plugin output directory
 **/recorded_data/

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,28 @@ LDFLAGS=-ldflags "-X 'github.com/rshade/pulumicost-core/pkg/version.version=$(VE
                   -X 'github.com/rshade/pulumicost-core/pkg/version.gitCommit=$(COMMIT)' \
                   -X 'github.com/rshade/pulumicost-core/pkg/version.buildDate=$(BUILD_DATE)'"
 
-.PHONY: all build test test-unit test-race test-integration test-e2e test-all lint validate clean run dev inspect help docs-lint docs-serve docs-build docs-validate
+.PHONY: all build build-recorder install-recorder build-all test test-unit test-race test-integration test-e2e test-all lint validate clean run dev inspect help docs-lint docs-serve docs-build docs-validate
 
 all: build
+
+build-recorder:
+	@echo "Building recorder plugin..."
+	@mkdir -p bin
+	go build $(LDFLAGS) -o bin/pulumicost-plugin-recorder ./plugins/recorder/cmd
+
+RECORDER_VERSION=0.1.0
+RECORDER_INSTALL_DIR=$(HOME)/.pulumicost/plugins/recorder/$(RECORDER_VERSION)
+
+install-recorder: build-recorder
+	@echo "Installing recorder plugin to $(RECORDER_INSTALL_DIR)..."
+	@mkdir -p $(RECORDER_INSTALL_DIR)
+	cp bin/pulumicost-plugin-recorder $(RECORDER_INSTALL_DIR)/
+	cp plugins/recorder/plugin.manifest.json $(RECORDER_INSTALL_DIR)/
+	chmod 644 $(RECORDER_INSTALL_DIR)/plugin.manifest.json
+	@echo "Recorder plugin installed successfully."
+	@echo "Verify with: pulumicost plugin list"
+
+build-all: build build-recorder
 
 build:
 	@echo "Building $(BINARY)..."
@@ -117,6 +136,9 @@ docs-validate: docs-lint
 help:
 	@echo "Available targets:"
 	@echo "  build            - Build the binary"
+	@echo "  build-recorder   - Build the recorder plugin"
+	@echo "  install-recorder - Build and install recorder plugin to ~/.pulumicost/plugins/"
+	@echo "  build-all        - Build binary and all plugins"
 	@echo "  test             - Run unit tests (fast, default)"
 	@echo "  test-unit        - Run unit tests only"
 	@echo "  test-race        - Run unit tests with race detector"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^20.1.0",
-    "@commitlint/config-conventional": "^20.0.0",
+    "@commitlint/config-conventional": "^20.2.0",
     "markdown-link-check": "^3.11.2",
     "markdownlint-cli2": "^0.20.0",
     "prettier": "^3.1.0"

--- a/plugins/recorder/README.md
+++ b/plugins/recorder/README.md
@@ -1,0 +1,202 @@
+# Recorder Plugin
+
+A reference implementation plugin that records all gRPC requests to JSON files and optionally returns mock cost responses. This plugin serves as both a developer tool for inspecting Core-to-plugin data shapes and a canonical reference implementation demonstrating pluginsdk v0.4.6 patterns.
+
+## Features
+
+- **Request Recording**: Captures all gRPC requests to JSON files for inspection
+- **Mock Responses**: Optionally returns randomized but valid cost responses
+- **Reference Implementation**: Demonstrates pluginsdk v0.4.6 best practices
+- **Thread-Safe**: Safe for concurrent use with sync.Mutex protection
+- **Graceful Shutdown**: Proper signal handling and cleanup
+
+## Installation
+
+```bash
+# From pulumicost-core repository root
+make install-recorder
+
+# Verify installation
+./bin/pulumicost plugin list
+```
+
+This builds the plugin and installs it to `~/.pulumicost/plugins/recorder/0.1.0/`.
+
+## Configuration
+
+Configuration is via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PULUMICOST_RECORDER_OUTPUT_DIR` | `./recorded_data` | Directory for recorded JSON files |
+| `PULUMICOST_RECORDER_MOCK_RESPONSE` | `false` | Enable randomized mock responses |
+
+## Usage
+
+### Basic Recording (Default Mode)
+
+```bash
+# Set output directory (optional)
+export PULUMICOST_RECORDER_OUTPUT_DIR=./my-recordings
+
+# Run cost calculation - requests will be recorded
+./bin/pulumicost cost projected --pulumi-json plan.json
+
+# View recorded files
+ls -la ./my-recordings/
+cat ./my-recordings/*.json | jq .
+```
+
+### Mock Response Mode
+
+```bash
+# Enable mock responses
+export PULUMICOST_RECORDER_MOCK_RESPONSE=true
+
+# Run cost calculation - will return randomized costs
+./bin/pulumicost cost projected --pulumi-json plan.json --output json
+```
+
+## Recorded Request Format
+
+Each request creates a JSON file with the following structure:
+
+```json
+{
+  "timestamp": "2025-12-11T14:30:52Z",
+  "method": "GetProjectedCost",
+  "requestId": "01JEK7X2J3K4M5N6P7Q8R9S0T1",
+  "request": {
+    "resource": {
+      "resourceType": "aws:ec2:Instance",
+      "provider": "aws",
+      "sku": "t3.medium",
+      "region": "us-east-1"
+    }
+  },
+  "metadata": {
+    "receivedAt": "2025-12-11T14:30:52.123456Z",
+    "processingTimeMs": 2
+  }
+}
+```
+
+### File Naming
+
+Files are named with the format: `<timestamp>_<method>_<ulid>.json`
+
+Example: `20251211T143052Z_GetProjectedCost_01JEK7X2J3K4M5N6P7Q8R9S0T1.json`
+
+## Use Cases
+
+### 1. Debug Plugin Integration
+
+See exactly what data Core sends to plugins:
+
+```bash
+PULUMICOST_RECORDER_OUTPUT_DIR=./debug ./bin/pulumicost cost projected --pulumi-json my-plan.json
+cat ./debug/*.json | jq '.request.resource'
+```
+
+### 2. Test Core Aggregation
+
+Generate mock data to test output formatting:
+
+```bash
+PULUMICOST_RECORDER_MOCK_RESPONSE=true ./bin/pulumicost cost projected \
+  --pulumi-json plan.json \
+  --output table
+```
+
+### 3. Contract Testing
+
+Use as a reference plugin in integration tests:
+
+```bash
+# In test setup
+export PULUMICOST_RECORDER_OUTPUT_DIR=/tmp/test-recordings
+export PULUMICOST_RECORDER_MOCK_RESPONSE=true
+
+# Run tests
+go test ./test/integration/... -v
+```
+
+## SDK Patterns Demonstrated
+
+This plugin demonstrates the following pluginsdk v0.4.6 patterns:
+
+1. **BasePlugin Embedding**: Using `*pluginsdk.BasePlugin` for common functionality
+2. **Request Validation**: Using `pluginsdk.ValidateProjectedCostRequest()` and similar helpers
+3. **Graceful Shutdown**: Context-based cancellation with signal handling
+4. **Structured Logging**: Using zerolog for consistent log output
+5. **Thread Safety**: Using sync.Mutex for concurrent request handling
+
+## Development
+
+### Running Tests
+
+```bash
+# Run all tests
+go test -v ./plugins/recorder/...
+
+# Run with coverage
+go test -cover ./plugins/recorder/...
+
+# Run benchmarks
+go test -bench=. ./plugins/recorder/...
+```
+
+### Code Structure
+
+```text
+plugins/recorder/
+├── cmd/
+│   └── main.go           # Plugin entry point
+├── config.go             # Configuration loading
+├── config_test.go        # Config tests
+├── mocker.go             # Mock response generation
+├── mocker_test.go        # Mocker tests
+├── plugin.go             # Main plugin implementation
+├── plugin_test.go        # Plugin tests
+├── recorder.go           # Request recording
+├── recorder_test.go      # Recorder tests
+├── plugin.manifest.json  # Plugin metadata
+└── README.md             # This file
+```
+
+## Troubleshooting
+
+### Plugin Not Found
+
+```bash
+# Check plugin directory structure
+ls -la ~/.pulumicost/plugins/recorder/
+
+# Verify binary is executable
+chmod +x ~/.pulumicost/plugins/recorder/0.1.0/pulumicost-plugin-recorder
+```
+
+### No Files Being Recorded
+
+```bash
+# Check output directory exists and is writable
+mkdir -p "$PULUMICOST_RECORDER_OUTPUT_DIR"
+touch "$PULUMICOST_RECORDER_OUTPUT_DIR/test.txt" && rm "$PULUMICOST_RECORDER_OUTPUT_DIR/test.txt"
+
+# Check plugin is being used
+./bin/pulumicost cost projected --debug --pulumi-json plan.json 2>&1 | grep recorder
+```
+
+### Mock Responses Not Working
+
+```bash
+# Verify environment variable is set correctly
+echo $PULUMICOST_RECORDER_MOCK_RESPONSE  # Should be "true"
+
+# Case-insensitive values work: true, TRUE, 1, yes, on
+export PULUMICOST_RECORDER_MOCK_RESPONSE=TRUE
+```
+
+## License
+
+Part of PulumiCost Core. See repository license for details.

--- a/plugins/recorder/cmd/main.go
+++ b/plugins/recorder/cmd/main.go
@@ -1,0 +1,88 @@
+// Package main provides the entry point for the recorder plugin.
+//
+// The recorder plugin is a reference implementation that:
+//   - Records all gRPC requests to JSON files for inspection
+//   - Optionally returns mock cost responses for testing
+//   - Demonstrates pluginsdk v0.4.6 patterns and best practices
+//
+// Configuration via environment variables:
+//   - PULUMICOST_RECORDER_OUTPUT_DIR: Directory for recorded files (default: ./recorded_data)
+//   - PULUMICOST_RECORDER_MOCK_RESPONSE: Enable mock responses (default: false)
+//
+// Usage:
+//
+//	# Start with TCP mode (default)
+//	./pulumicost-plugin-recorder
+//
+//	# Start with specific port
+//	PULUMICOST_PLUGIN_PORT=50051 ./pulumicost-plugin-recorder
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/rs/zerolog"
+	"github.com/rshade/pulumicost-core/plugins/recorder"
+	"github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+)
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	// Initialize logger
+	logger := zerolog.New(os.Stderr).With().
+		Timestamp().
+		Str("plugin", "recorder").
+		Logger()
+
+	// Set log level based on environment
+	if os.Getenv("PULUMICOST_LOG_LEVEL") == "debug" {
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	} else {
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	}
+
+	logger.Info().Msg("starting recorder plugin")
+
+	// Create cancellable context for graceful shutdown
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Set up signal handling for graceful shutdown
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigCh
+		logger.Info().Str("signal", sig.String()).Msg("received shutdown signal")
+		signal.Stop(sigCh)
+		cancel()
+	}()
+
+	// Load configuration from environment
+	cfg := recorder.LoadConfig()
+
+	// Create the plugin instance
+	plugin := recorder.NewRecorderPlugin(cfg, logger)
+	defer plugin.Shutdown()
+
+	// Configure and start the gRPC server
+	serveConfig := pluginsdk.ServeConfig{
+		Plugin: plugin,
+		Port:   0, // Use PULUMICOST_PLUGIN_PORT env var or random port
+		Logger: &logger,
+	}
+
+	// Serve until context is cancelled
+	if err := pluginsdk.Serve(ctx, serveConfig); err != nil {
+		logger.Error().Err(err).Msg("plugin server error")
+		return 1
+	}
+
+	logger.Info().Msg("recorder plugin stopped")
+	return 0
+}

--- a/plugins/recorder/config.go
+++ b/plugins/recorder/config.go
@@ -1,0 +1,64 @@
+// Package recorder implements a reference plugin that records all gRPC requests
+// and optionally returns mock cost responses.
+package recorder
+
+import (
+	"os"
+	"strings"
+)
+
+// Config holds runtime configuration for the recorder plugin.
+// Configuration is loaded from environment variables with sensible defaults.
+type Config struct {
+	// OutputDir is the directory where recorded JSON files are written.
+	// Default: "./recorded_data"
+	OutputDir string
+
+	// MockResponse enables randomized mock cost responses.
+	// When false (default), the plugin returns zero/empty costs.
+	MockResponse bool
+}
+
+// Environment variable names for configuration.
+const (
+	EnvOutputDir    = "PULUMICOST_RECORDER_OUTPUT_DIR"
+	EnvMockResponse = "PULUMICOST_RECORDER_MOCK_RESPONSE"
+)
+
+// Default configuration values.
+const (
+	DefaultOutputDir    = "./recorded_data"
+	DefaultMockResponse = false
+)
+
+// LoadConfig creates a Config from environment variables.
+// Missing variables use default values.
+func LoadConfig() *Config {
+	cfg := &Config{
+		OutputDir:    DefaultOutputDir,
+		MockResponse: DefaultMockResponse,
+	}
+
+	if dir := os.Getenv(EnvOutputDir); dir != "" {
+		cfg.OutputDir = dir
+	}
+
+	if mock := os.Getenv(EnvMockResponse); mock != "" {
+		cfg.MockResponse = parseBool(mock)
+	}
+
+	return cfg
+}
+
+// parseBool parses a boolean string case-insensitively.
+// Returns true for "true", "1", "yes", "on" (case-insensitive).
+// Returns false for all other values.
+func parseBool(s string) bool {
+	lower := strings.ToLower(strings.TrimSpace(s))
+	switch lower {
+	case "true", "1", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}

--- a/plugins/recorder/config_test.go
+++ b/plugins/recorder/config_test.go
@@ -1,0 +1,133 @@
+package recorder
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfig_Defaults(t *testing.T) {
+	// Clear environment variables
+	os.Unsetenv(EnvOutputDir)
+	os.Unsetenv(EnvMockResponse)
+
+	cfg := LoadConfig()
+
+	assert.Equal(t, DefaultOutputDir, cfg.OutputDir)
+	assert.Equal(t, DefaultMockResponse, cfg.MockResponse)
+}
+
+func TestLoadConfig_CustomOutputDir(t *testing.T) {
+	customDir := "/tmp/my-recordings"
+	os.Setenv(EnvOutputDir, customDir)
+	defer os.Unsetenv(EnvOutputDir)
+
+	cfg := LoadConfig()
+
+	assert.Equal(t, customDir, cfg.OutputDir)
+}
+
+func TestLoadConfig_MockResponseTrue(t *testing.T) {
+	testCases := []struct {
+		name  string
+		value string
+	}{
+		{"lowercase true", "true"},
+		{"uppercase TRUE", "TRUE"},
+		{"mixed case True", "True"},
+		{"numeric 1", "1"},
+		{"yes", "yes"},
+		{"YES", "YES"},
+		{"on", "on"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Setenv(EnvMockResponse, tc.value)
+			defer os.Unsetenv(EnvMockResponse)
+
+			cfg := LoadConfig()
+
+			assert.True(t, cfg.MockResponse, "expected MockResponse=true for value %q", tc.value)
+		})
+	}
+}
+
+func TestLoadConfig_MockResponseFalse(t *testing.T) {
+	testCases := []struct {
+		name  string
+		value string
+	}{
+		{"lowercase false", "false"},
+		{"uppercase FALSE", "FALSE"},
+		{"numeric 0", "0"},
+		{"empty string", ""},
+		{"no", "no"},
+		{"off", "off"},
+		{"invalid", "invalid"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.value == "" {
+				os.Unsetenv(EnvMockResponse)
+			} else {
+				os.Setenv(EnvMockResponse, tc.value)
+				defer os.Unsetenv(EnvMockResponse)
+			}
+
+			cfg := LoadConfig()
+
+			assert.False(t, cfg.MockResponse, "expected MockResponse=false for value %q", tc.value)
+		})
+	}
+}
+
+func TestLoadConfig_WithWhitespace(t *testing.T) {
+	os.Setenv(EnvMockResponse, "  true  ")
+	defer os.Unsetenv(EnvMockResponse)
+
+	cfg := LoadConfig()
+
+	assert.True(t, cfg.MockResponse)
+}
+
+func TestParseBool(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		{"true", true},
+		{"TRUE", true},
+		{"True", true},
+		{"1", true},
+		{"yes", true},
+		{"YES", true},
+		{"on", true},
+		{"ON", true},
+		{"false", false},
+		{"FALSE", false},
+		{"0", false},
+		{"no", false},
+		{"off", false},
+		{"", false},
+		{"anything", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := parseBool(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestConfigConstants(t *testing.T) {
+	// Verify constants are defined correctly
+	require.Equal(t, "PULUMICOST_RECORDER_OUTPUT_DIR", EnvOutputDir)
+	require.Equal(t, "PULUMICOST_RECORDER_MOCK_RESPONSE", EnvMockResponse)
+	require.Equal(t, "./recorded_data", DefaultOutputDir)
+	require.Equal(t, false, DefaultMockResponse)
+}

--- a/plugins/recorder/mocker.go
+++ b/plugins/recorder/mocker.go
@@ -1,0 +1,110 @@
+package recorder
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+
+	"github.com/rs/zerolog"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+)
+
+// Cost range constants for mock generation.
+const (
+	// MinProjectedCost is the minimum projected cost: $0.01 per month.
+	MinProjectedCost = 0.01
+	// MaxProjectedCost is the maximum projected cost: $1000 per month.
+	MaxProjectedCost = 1000.0
+
+	// MinActualCost is the minimum actual cost: $0.001 per day.
+	MinActualCost = 0.001
+	// MaxActualCost is the maximum actual cost: $100 per day.
+	MaxActualCost = 100.0
+
+	// HoursPerMonth is the standard hours per month for cost conversions.
+	HoursPerMonth = 730.0
+
+	// centsMultiplier is the multiplier for rounding costs to cents.
+	centsMultiplier = 100
+	// milliMultiplier is the multiplier for rounding costs to 3 decimal places.
+	milliMultiplier = 1000
+)
+
+// Mocker generates randomized but valid cost responses for testing.
+type Mocker struct {
+	logger zerolog.Logger
+}
+
+// NewMocker creates a new Mocker instance.
+func NewMocker(logger zerolog.Logger) *Mocker {
+	return &Mocker{
+		logger: logger.With().Str("component", "mocker").Logger(),
+	}
+}
+
+// GenerateProjectedCost generates a randomized monthly cost.
+// Uses log-scale distribution for realistic cost spread.
+func (m *Mocker) GenerateProjectedCost() float64 {
+	// Log-scale distribution: more small costs, fewer large costs
+	//nolint:gosec // G404: math/rand/v2 is appropriate for non-cryptographic mock data generation
+	cost := MinProjectedCost * math.Pow(MaxProjectedCost/MinProjectedCost, rand.Float64())
+	return math.Round(cost*centsMultiplier) / centsMultiplier // Round to cents
+}
+
+// GenerateActualCost generates a randomized daily cost.
+// Uses log-scale distribution for realistic cost spread.
+func (m *Mocker) GenerateActualCost() float64 {
+	//nolint:gosec // G404: math/rand/v2 is appropriate for non-cryptographic mock data generation
+	cost := MinActualCost * math.Pow(MaxActualCost/MinActualCost, rand.Float64())
+	return math.Round(cost*milliMultiplier) / milliMultiplier // Round to 3 decimal places
+}
+
+// CreateProjectedCostResponse creates a mock GetProjectedCostResponse.
+func (m *Mocker) CreateProjectedCostResponse() *pbc.GetProjectedCostResponse {
+	monthlyCost := m.GenerateProjectedCost()
+	hourlyCost := monthlyCost / HoursPerMonth
+
+	m.logger.Debug().
+		Float64("monthly_cost", monthlyCost).
+		Float64("hourly_cost", hourlyCost).
+		Msg("generated mock projected cost")
+
+	return &pbc.GetProjectedCostResponse{
+		CostPerMonth:  monthlyCost,
+		UnitPrice:     hourlyCost,
+		Currency:      "USD",
+		BillingDetail: fmt.Sprintf("Mock cost: $%.2f/month (recorder plugin)", monthlyCost),
+	}
+}
+
+// CreateActualCostResponse creates a mock GetActualCostResponse.
+func (m *Mocker) CreateActualCostResponse() *pbc.GetActualCostResponse {
+	cost := m.GenerateActualCost()
+
+	m.logger.Debug().
+		Float64("cost", cost).
+		Msg("generated mock actual cost")
+
+	return &pbc.GetActualCostResponse{
+		Results: []*pbc.ActualCostResult{
+			{
+				Source: "recorder-mock",
+				Cost:   cost,
+			},
+		},
+	}
+}
+
+// CreateEstimateCostResponse creates a mock EstimateCostResponse.
+func (m *Mocker) CreateEstimateCostResponse() *pbc.EstimateCostResponse {
+	monthlyCost := m.GenerateProjectedCost()
+
+	m.logger.Debug().
+		Float64("estimated_cost", monthlyCost).
+		Msg("generated mock estimated cost")
+
+	return &pbc.EstimateCostResponse{
+		CostMonthly: monthlyCost,
+		Currency:    "USD",
+	}
+}

--- a/plugins/recorder/mocker_test.go
+++ b/plugins/recorder/mocker_test.go
@@ -1,0 +1,130 @@
+package recorder
+
+import (
+	"os"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mockerTestLogger() zerolog.Logger {
+	return zerolog.New(os.Stderr).Level(zerolog.Disabled)
+}
+
+// T027: Unit test for Mocker.GenerateProjectedCost() range.
+func TestMocker_GenerateProjectedCost_Range(t *testing.T) {
+	mocker := NewMocker(mockerTestLogger())
+
+	// Generate many costs and verify they're all within range
+	for i := 0; i < 1000; i++ {
+		cost := mocker.GenerateProjectedCost()
+		assert.GreaterOrEqual(t, cost, MinProjectedCost,
+			"cost should be >= %f", MinProjectedCost)
+		assert.LessOrEqual(t, cost, MaxProjectedCost,
+			"cost should be <= %f", MaxProjectedCost)
+	}
+}
+
+// T028: Unit test for Mocker.GenerateActualCost() range.
+func TestMocker_GenerateActualCost_Range(t *testing.T) {
+	mocker := NewMocker(mockerTestLogger())
+
+	// Generate many costs and verify they're all within range
+	for i := 0; i < 1000; i++ {
+		cost := mocker.GenerateActualCost()
+		assert.GreaterOrEqual(t, cost, MinActualCost,
+			"cost should be >= %f", MinActualCost)
+		assert.LessOrEqual(t, cost, MaxActualCost,
+			"cost should be <= %f", MaxActualCost)
+	}
+}
+
+// T029: Unit test for mock response structure validity.
+func TestMocker_CreateProjectedCostResponse_Structure(t *testing.T) {
+	mocker := NewMocker(mockerTestLogger())
+
+	resp := mocker.CreateProjectedCostResponse()
+
+	require.NotNil(t, resp)
+	assert.Greater(t, resp.GetCostPerMonth(), float64(0))
+	assert.Greater(t, resp.GetUnitPrice(), float64(0))
+	assert.Equal(t, "USD", resp.GetCurrency())
+	assert.Contains(t, resp.GetBillingDetail(), "Mock cost")
+	assert.Contains(t, resp.GetBillingDetail(), "recorder plugin")
+
+	// Verify unit price is derived from monthly cost
+	expectedHourly := resp.GetCostPerMonth() / HoursPerMonth
+	assert.InDelta(t, expectedHourly, resp.GetUnitPrice(), 0.0001)
+}
+
+func TestMocker_CreateActualCostResponse_Structure(t *testing.T) {
+	mocker := NewMocker(mockerTestLogger())
+
+	resp := mocker.CreateActualCostResponse()
+
+	require.NotNil(t, resp)
+	require.Len(t, resp.GetResults(), 1)
+
+	result := resp.GetResults()[0]
+	assert.Equal(t, "recorder-mock", result.GetSource())
+	assert.Greater(t, result.GetCost(), float64(0))
+}
+
+func TestMocker_CreateEstimateCostResponse_Structure(t *testing.T) {
+	mocker := NewMocker(mockerTestLogger())
+
+	resp := mocker.CreateEstimateCostResponse()
+
+	require.NotNil(t, resp)
+	assert.Greater(t, resp.GetCostMonthly(), float64(0))
+	assert.Equal(t, "USD", resp.GetCurrency())
+}
+
+func TestMocker_CostDistribution(t *testing.T) {
+	mocker := NewMocker(mockerTestLogger())
+
+	// Generate costs and check distribution
+	// With log-scale, we should have more small costs than large ones
+	var smallCount, largeCount int
+	threshold := 100.0
+
+	for i := 0; i < 1000; i++ {
+		cost := mocker.GenerateProjectedCost()
+		if cost < threshold {
+			smallCount++
+		} else {
+			largeCount++
+		}
+	}
+
+	// Log-scale should produce more small values
+	// This is a probabilistic test, but with 1000 samples it should be reliable
+	t.Logf("Cost distribution: %d small (<%f), %d large", smallCount, threshold, largeCount)
+	assert.Greater(t, smallCount, largeCount,
+		"log-scale distribution should produce more small costs than large")
+}
+
+func TestMocker_Randomness(t *testing.T) {
+	mocker := NewMocker(mockerTestLogger())
+
+	// Generate several costs and ensure they're not all the same
+	costs := make(map[float64]bool)
+	for i := 0; i < 100; i++ {
+		costs[mocker.GenerateProjectedCost()] = true
+	}
+
+	// Should have many unique values - with rounding to cents, some duplicates are possible
+	// but we should still have a good variety
+	assert.Greater(t, len(costs), 50, "should generate diverse random costs")
+}
+
+func TestMockerConstants(t *testing.T) {
+	// Verify constants are reasonable
+	assert.Equal(t, 0.01, MinProjectedCost)
+	assert.Equal(t, 1000.0, MaxProjectedCost)
+	assert.Equal(t, 0.001, MinActualCost)
+	assert.Equal(t, 100.0, MaxActualCost)
+	assert.Equal(t, 730.0, HoursPerMonth)
+}

--- a/plugins/recorder/plugin.go
+++ b/plugins/recorder/plugin.go
@@ -1,0 +1,198 @@
+package recorder
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rs/zerolog"
+	"github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// RecorderPlugin implements the CostSourceService interface.
+// It records all incoming gRPC requests to JSON files and optionally
+// returns mock cost responses for testing purposes.
+//
+// This plugin serves as a reference implementation demonstrating
+// pluginsdk v0.4.6 patterns including:
+//   - BasePlugin embedding for common functionality
+//   - Request validation using SDK helpers
+//   - Graceful shutdown handling
+//   - Thread-safe operation
+//
+//nolint:revive // RecorderPlugin naming is intentional for clarity in external usage
+type RecorderPlugin struct {
+	*pluginsdk.BasePlugin
+
+	config   *Config
+	recorder *Recorder
+	mocker   *Mocker
+	logger   zerolog.Logger
+	mu       sync.Mutex
+}
+
+// NewRecorderPlugin creates a new recorder plugin instance.
+// The plugin is configured via the provided Config and will:
+//   - Record all requests to JSON files in Config.OutputDir
+//   - Return mock responses if Config.MockResponse is true
+//   - Return zero/empty costs if Config.MockResponse is false
+func NewRecorderPlugin(cfg *Config, logger zerolog.Logger) *RecorderPlugin {
+	base := pluginsdk.NewBasePlugin("recorder")
+
+	p := &RecorderPlugin{
+		BasePlugin: base,
+		config:     cfg,
+		logger:     logger.With().Str("component", "recorder-plugin").Logger(),
+	}
+
+	// Initialize recorder for capturing requests
+	p.recorder = NewRecorder(cfg.OutputDir, p.logger)
+
+	// Initialize mocker only if mock responses are enabled
+	if cfg.MockResponse {
+		p.mocker = NewMocker(p.logger)
+		p.logger.Info().Msg("mock response mode enabled")
+	}
+
+	p.logger.Info().
+		Str("output_dir", cfg.OutputDir).
+		Bool("mock_response", cfg.MockResponse).
+		Msg("recorder plugin initialized")
+
+	return p
+}
+
+// Name returns the plugin identifier.
+// This method satisfies the pluginsdk.Plugin interface.
+func (p *RecorderPlugin) Name() string {
+	return "recorder"
+}
+
+// GetProjectedCost handles projected cost requests.
+// It validates the request, records it to disk, and returns either:
+//   - Mock cost data (if MockResponse is enabled)
+//   - Zero cost with explanatory note (if MockResponse is disabled)
+func (p *RecorderPlugin) GetProjectedCost(
+	_ context.Context, req *pbc.GetProjectedCostRequest,
+) (*pbc.GetProjectedCostResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Validate request using pluginsdk v0.4.6 helpers
+	if err := pluginsdk.ValidateProjectedCostRequest(req); err != nil {
+		p.logger.Warn().Err(err).Msg("invalid GetProjectedCost request")
+		// Record invalid request for debugging purposes
+		_ = p.recorder.RecordRequest("GetProjectedCost", req)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
+	}
+
+	// Record the request to disk
+	if err := p.recorder.RecordRequest("GetProjectedCost", req); err != nil {
+		// Log warning but continue - recording failure shouldn't fail the request
+		p.logger.Warn().Err(err).Msg("failed to record request")
+	}
+
+	// Return mock or zero response
+	if p.mocker != nil {
+		return p.mocker.CreateProjectedCostResponse(), nil
+	}
+
+	// Return zero cost when mock mode is disabled
+	return &pbc.GetProjectedCostResponse{
+		CostPerMonth:  0.0,
+		UnitPrice:     0.0,
+		Currency:      "USD",
+		BillingDetail: "Recorder plugin - mock responses disabled",
+	}, nil
+}
+
+// GetActualCost handles actual cost requests.
+// It validates the request, records it to disk, and returns either:
+//   - Mock cost data (if MockResponse is enabled)
+//   - Empty results (if MockResponse is disabled)
+func (p *RecorderPlugin) GetActualCost(
+	_ context.Context, req *pbc.GetActualCostRequest,
+) (*pbc.GetActualCostResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Validate request using pluginsdk v0.4.6 helpers
+	if err := pluginsdk.ValidateActualCostRequest(req); err != nil {
+		p.logger.Warn().Err(err).Msg("invalid GetActualCost request")
+		// Record invalid request for debugging purposes
+		_ = p.recorder.RecordRequest("GetActualCost", req)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
+	}
+
+	// Record the request to disk
+	if err := p.recorder.RecordRequest("GetActualCost", req); err != nil {
+		// Log warning but continue - recording failure shouldn't fail the request
+		p.logger.Warn().Err(err).Msg("failed to record request")
+	}
+
+	// Return mock or empty response
+	if p.mocker != nil {
+		return p.mocker.CreateActualCostResponse(), nil
+	}
+
+	// Return empty results when mock mode is disabled
+	return &pbc.GetActualCostResponse{
+		Results: []*pbc.ActualCostResult{},
+	}, nil
+}
+
+// GetPricingSpec returns pricing specification for a resource type.
+// The recorder plugin returns an empty response as it doesn't have real pricing data.
+func (p *RecorderPlugin) GetPricingSpec(
+	_ context.Context, req *pbc.GetPricingSpecRequest,
+) (*pbc.GetPricingSpecResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Record the request to disk
+	if err := p.recorder.RecordRequest("GetPricingSpec", req); err != nil {
+		p.logger.Warn().Err(err).Msg("failed to record request")
+	}
+
+	// Return empty pricing spec
+	return &pbc.GetPricingSpecResponse{}, nil
+}
+
+// EstimateCost returns an estimated cost for a resource.
+// The recorder plugin returns zero or mock estimate based on configuration.
+func (p *RecorderPlugin) EstimateCost(
+	_ context.Context, req *pbc.EstimateCostRequest,
+) (*pbc.EstimateCostResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Record the request to disk
+	if err := p.recorder.RecordRequest("EstimateCost", req); err != nil {
+		p.logger.Warn().Err(err).Msg("failed to record request")
+	}
+
+	// Return mock or zero estimate
+	if p.mocker != nil {
+		return p.mocker.CreateEstimateCostResponse(), nil
+	}
+
+	return &pbc.EstimateCostResponse{
+		CostMonthly: 0.0,
+		Currency:    "USD",
+	}, nil
+}
+
+// Shutdown performs graceful shutdown of the plugin.
+// It flushes any pending writes and releases resources.
+func (p *RecorderPlugin) Shutdown() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.logger.Info().Msg("shutting down recorder plugin")
+
+	if p.recorder != nil {
+		p.recorder.Close()
+	}
+}

--- a/plugins/recorder/plugin.manifest.json
+++ b/plugins/recorder/plugin.manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "recorder",
+  "version": "0.1.0",
+  "description": "Reference plugin that records all gRPC requests and optionally returns mock responses",
+  "author": "PulumiCost Team",
+  "supported_providers": ["*"],
+  "protocols": ["grpc"],
+  "binary": "pulumicost-plugin-recorder",
+  "metadata": {
+    "repository": "https://github.com/rshade/pulumicost-core",
+    "docs": "https://github.com/rshade/pulumicost-core/tree/main/plugins/recorder",
+    "reference_implementation": true
+  }
+}

--- a/plugins/recorder/plugin_test.go
+++ b/plugins/recorder/plugin_test.go
@@ -1,0 +1,249 @@
+package recorder
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func testLogger() zerolog.Logger {
+	return zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.Disabled)
+}
+
+func TestNewRecorderPlugin(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &Config{
+		OutputDir:    tmpDir,
+		MockResponse: false,
+	}
+
+	plugin := NewRecorderPlugin(cfg, testLogger())
+
+	require.NotNil(t, plugin)
+	assert.Equal(t, "recorder", plugin.Name())
+	assert.NotNil(t, plugin.recorder)
+	assert.Nil(t, plugin.mocker) // Mock mode disabled
+}
+
+func TestNewRecorderPlugin_WithMockMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &Config{
+		OutputDir:    tmpDir,
+		MockResponse: true,
+	}
+
+	plugin := NewRecorderPlugin(cfg, testLogger())
+
+	require.NotNil(t, plugin)
+	assert.NotNil(t, plugin.mocker) // Mock mode enabled
+}
+
+func TestRecorderPlugin_Name(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &Config{OutputDir: tmpDir}
+	plugin := NewRecorderPlugin(cfg, testLogger())
+
+	assert.Equal(t, "recorder", plugin.Name())
+}
+
+func TestRecorderPlugin_GetProjectedCost_MockDisabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &Config{
+		OutputDir:    tmpDir,
+		MockResponse: false,
+	}
+	plugin := NewRecorderPlugin(cfg, testLogger())
+
+	req := &pbc.GetProjectedCostRequest{
+		Resource: &pbc.ResourceDescriptor{
+			ResourceType: "aws:ec2:Instance",
+			Provider:     "aws",
+			Sku:          "t3.medium",
+			Region:       "us-east-1",
+		},
+	}
+
+	resp, err := plugin.GetProjectedCost(context.Background(), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, float64(0), resp.GetCostPerMonth())
+	assert.Equal(t, "USD", resp.GetCurrency())
+	assert.Contains(t, resp.GetBillingDetail(), "mock responses disabled")
+}
+
+func TestRecorderPlugin_GetProjectedCost_MockEnabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &Config{
+		OutputDir:    tmpDir,
+		MockResponse: true,
+	}
+	plugin := NewRecorderPlugin(cfg, testLogger())
+
+	req := &pbc.GetProjectedCostRequest{
+		Resource: &pbc.ResourceDescriptor{
+			ResourceType: "aws:ec2:Instance",
+			Provider:     "aws",
+			Sku:          "t3.medium",
+			Region:       "us-east-1",
+		},
+	}
+
+	resp, err := plugin.GetProjectedCost(context.Background(), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Greater(t, resp.GetCostPerMonth(), float64(0))
+	assert.Equal(t, "USD", resp.GetCurrency())
+	assert.Contains(t, resp.GetBillingDetail(), "Mock cost")
+}
+
+func TestRecorderPlugin_GetActualCost_MockDisabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &Config{
+		OutputDir:    tmpDir,
+		MockResponse: false,
+	}
+	plugin := NewRecorderPlugin(cfg, testLogger())
+
+	now := time.Now()
+	req := &pbc.GetActualCostRequest{
+		ResourceId: "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0",
+		Start:      timestamppb.New(now.Add(-24 * time.Hour)),
+		End:        timestamppb.New(now),
+	}
+
+	resp, err := plugin.GetActualCost(context.Background(), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.GetResults())
+}
+
+func TestRecorderPlugin_GetActualCost_MockEnabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &Config{
+		OutputDir:    tmpDir,
+		MockResponse: true,
+	}
+	plugin := NewRecorderPlugin(cfg, testLogger())
+
+	now := time.Now()
+	req := &pbc.GetActualCostRequest{
+		ResourceId: "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0",
+		Start:      timestamppb.New(now.Add(-24 * time.Hour)),
+		End:        timestamppb.New(now),
+	}
+
+	resp, err := plugin.GetActualCost(context.Background(), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.GetResults(), 1)
+	assert.Equal(t, "recorder-mock", resp.GetResults()[0].GetSource())
+	assert.Greater(t, resp.GetResults()[0].GetCost(), float64(0))
+}
+
+func TestRecorderPlugin_GetPricingSpec(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &Config{OutputDir: tmpDir}
+	plugin := NewRecorderPlugin(cfg, testLogger())
+
+	req := &pbc.GetPricingSpecRequest{
+		Resource: &pbc.ResourceDescriptor{
+			ResourceType: "aws:ec2:Instance",
+			Provider:     "aws",
+		},
+	}
+
+	resp, err := plugin.GetPricingSpec(context.Background(), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+func TestRecorderPlugin_EstimateCost_MockDisabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &Config{
+		OutputDir:    tmpDir,
+		MockResponse: false,
+	}
+	plugin := NewRecorderPlugin(cfg, testLogger())
+
+	req := &pbc.EstimateCostRequest{
+		ResourceType: "aws:ec2:Instance",
+	}
+
+	resp, err := plugin.EstimateCost(context.Background(), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, float64(0), resp.GetCostMonthly())
+	assert.Equal(t, "USD", resp.GetCurrency())
+}
+
+func TestRecorderPlugin_EstimateCost_MockEnabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &Config{
+		OutputDir:    tmpDir,
+		MockResponse: true,
+	}
+	plugin := NewRecorderPlugin(cfg, testLogger())
+
+	req := &pbc.EstimateCostRequest{
+		ResourceType: "aws:ec2:Instance",
+	}
+
+	resp, err := plugin.EstimateCost(context.Background(), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Greater(t, resp.GetCostMonthly(), float64(0))
+	assert.Equal(t, "USD", resp.GetCurrency())
+}
+
+func TestRecorderPlugin_Shutdown(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &Config{OutputDir: tmpDir}
+	plugin := NewRecorderPlugin(cfg, testLogger())
+
+	// Should not panic
+	plugin.Shutdown()
+}
+
+func TestRecorderPlugin_ThreadSafety(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &Config{
+		OutputDir:    tmpDir,
+		MockResponse: true,
+	}
+	plugin := NewRecorderPlugin(cfg, testLogger())
+
+	// Run multiple concurrent requests
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := &pbc.GetProjectedCostRequest{
+				Resource: &pbc.ResourceDescriptor{
+					ResourceType: "aws:ec2:Instance",
+					Provider:     "aws",
+				},
+			}
+			_, _ = plugin.GetProjectedCost(context.Background(), req)
+		}()
+	}
+
+	wg.Wait()
+
+	// No panic = thread-safe
+}

--- a/plugins/recorder/recorder.go
+++ b/plugins/recorder/recorder.go
@@ -1,0 +1,173 @@
+package recorder
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/rs/zerolog"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// Recorder handles serialization of gRPC requests to JSON files.
+// It is thread-safe and handles I/O errors gracefully.
+type Recorder struct {
+	outputDir string
+	logger    zerolog.Logger
+	mu        sync.Mutex
+	disabled  bool // Set to true if output directory is not writable
+}
+
+// RecordedRequest represents a captured gRPC request.
+type RecordedRequest struct {
+	Timestamp string          `json:"timestamp"`
+	Method    string          `json:"method"`
+	RequestID string          `json:"requestId"`
+	Request   json.RawMessage `json:"request"`
+	Metadata  RequestMetadata `json:"metadata"`
+}
+
+// RequestMetadata contains optional metadata about the request.
+type RequestMetadata struct {
+	ReceivedAt       string `json:"receivedAt"`
+	ProcessingTimeMs int64  `json:"processingTimeMs"`
+}
+
+// NewRecorder creates a new Recorder instance.
+// It creates the output directory if it doesn't exist.
+func NewRecorder(outputDir string, logger zerolog.Logger) *Recorder {
+	r := &Recorder{
+		outputDir: outputDir,
+		logger:    logger.With().Str("component", "recorder").Logger(),
+	}
+
+	// Create output directory if it doesn't exist
+	if err := os.MkdirAll(outputDir, 0750); err != nil {
+		r.logger.Error().Err(err).Str("dir", outputDir).Msg("failed to create output directory")
+		r.disabled = true
+		return r
+	}
+
+	// Verify directory is writable
+	testFile := filepath.Join(outputDir, ".write_test")
+	if err := os.WriteFile(testFile, []byte("test"), 0600); err != nil {
+		r.logger.Error().Err(err).Str("dir", outputDir).Msg("output directory is not writable")
+		r.disabled = true
+		return r
+	}
+	_ = os.Remove(testFile) // Best effort cleanup
+
+	r.logger.Info().Str("dir", outputDir).Msg("recorder initialized")
+	return r
+}
+
+// RecordRequest serializes a gRPC request to a JSON file.
+// It returns an error if the write fails, but the caller should
+// typically log and continue rather than failing the request.
+func (r *Recorder) RecordRequest(method string, req proto.Message) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.disabled {
+		return errors.New("recorder disabled: output directory not writable")
+	}
+
+	startTime := time.Now().UTC()
+
+	// Generate unique filename
+	filename := r.generateFilename(method)
+	filePath := filepath.Join(r.outputDir, filename)
+
+	// Serialize the protobuf request to JSON
+	requestJSON, err := r.serializeRequest(req)
+	if err != nil {
+		return fmt.Errorf("failed to serialize request: %w", err)
+	}
+
+	// Create the recorded request structure
+	recorded := RecordedRequest{
+		Timestamp: startTime.Format(time.RFC3339),
+		Method:    method,
+		RequestID: ulid.Make().String(),
+		Request:   requestJSON,
+		Metadata: RequestMetadata{
+			ReceivedAt:       startTime.Format(time.RFC3339Nano),
+			ProcessingTimeMs: time.Since(startTime).Milliseconds(),
+		},
+	}
+
+	// Marshal to JSON with indentation
+	data, err := json.MarshalIndent(recorded, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal recorded request: %w", err)
+	}
+
+	// Write to file
+	if writeErr := os.WriteFile(filePath, data, 0600); writeErr != nil {
+		// Check for disk full
+		if isDiskFullError(writeErr) {
+			r.logger.Warn().Err(writeErr).Msg("disk full - disabling recording")
+			r.disabled = true
+		}
+		return fmt.Errorf("failed to write file: %w", writeErr)
+	}
+
+	r.logger.Debug().
+		Str("file", filename).
+		Str("method", method).
+		Msg("recorded request")
+
+	return nil
+}
+
+// generateFilename creates a unique filename for a recorded request.
+// The format is: <timestamp>_<method>_<ulid>.json.
+func (r *Recorder) generateFilename(method string) string {
+	timestamp := time.Now().UTC().Format("20060102T150405Z")
+	id := ulid.Make()
+	return fmt.Sprintf("%s_%s_%s.json", timestamp, method, id.String())
+}
+
+// serializeRequest converts a protobuf message to JSON.
+func (r *Recorder) serializeRequest(req proto.Message) (json.RawMessage, error) {
+	opts := protojson.MarshalOptions{
+		Multiline:       true,
+		Indent:          "  ",
+		EmitUnpopulated: true,
+	}
+	data, err := opts.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(data), nil
+}
+
+// Close performs cleanup when the recorder is shutting down.
+func (r *Recorder) Close() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.logger.Info().Msg("recorder closed")
+}
+
+// isDiskFullError checks if an error indicates disk full condition.
+func isDiskFullError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Check for permission errors first - these are not disk full
+	if os.IsPermission(err) {
+		return false
+	}
+	// Check error message for common disk full indicators
+	errMsg := err.Error()
+	return strings.Contains(errMsg, "no space left on device") ||
+		strings.Contains(errMsg, "disk quota exceeded") ||
+		strings.Contains(errMsg, "ENOSPC")
+}

--- a/plugins/recorder/recorder_test.go
+++ b/plugins/recorder/recorder_test.go
@@ -1,0 +1,339 @@
+package recorder
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func silentLogger() zerolog.Logger {
+	return zerolog.New(os.Stderr).Level(zerolog.Disabled)
+}
+
+// T013: Unit test for Recorder.Record().
+func TestRecorder_RecordRequest(t *testing.T) {
+	tmpDir := t.TempDir()
+	recorder := NewRecorder(tmpDir, silentLogger())
+
+	req := &pbc.GetProjectedCostRequest{
+		Resource: &pbc.ResourceDescriptor{
+			ResourceType: "aws:ec2:Instance",
+			Provider:     "aws",
+			Sku:          "t3.medium",
+			Region:       "us-east-1",
+		},
+	}
+
+	err := recorder.RecordRequest("GetProjectedCost", req)
+	require.NoError(t, err)
+
+	// Verify file was created
+	files, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	// Verify file name format
+	filename := files[0].Name()
+	assert.True(t, strings.HasSuffix(filename, ".json"))
+	assert.Contains(t, filename, "GetProjectedCost")
+	assert.Contains(t, filename, "_")
+
+	// Verify file content is valid JSON
+	content, err := os.ReadFile(filepath.Join(tmpDir, filename))
+	require.NoError(t, err)
+
+	var recorded RecordedRequest
+	err = json.Unmarshal(content, &recorded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "GetProjectedCost", recorded.Method)
+	assert.NotEmpty(t, recorded.RequestID)
+	assert.NotEmpty(t, recorded.Timestamp)
+	assert.NotNil(t, recorded.Request)
+}
+
+// T014: Unit test for generateFilename() ULID format.
+func TestRecorder_GenerateFilename(t *testing.T) {
+	tmpDir := t.TempDir()
+	recorder := NewRecorder(tmpDir, silentLogger())
+
+	filename := recorder.generateFilename("TestMethod")
+
+	// Should match format: <timestamp>_<method>_<ulid>.json
+	parts := strings.Split(strings.TrimSuffix(filename, ".json"), "_")
+	require.Len(t, parts, 3, "filename should have 3 parts: timestamp_method_ulid")
+
+	// Verify timestamp format (20060102T150405Z)
+	timestamp := parts[0]
+	_, err := time.Parse("20060102T150405Z", timestamp)
+	assert.NoError(t, err, "timestamp should be valid ISO8601 compact format")
+
+	// Verify method name
+	assert.Equal(t, "TestMethod", parts[1])
+
+	// Verify ULID format (26 characters, uppercase alphanumeric)
+	ulid := parts[2]
+	assert.Len(t, ulid, 26, "ULID should be 26 characters")
+	for _, c := range ulid {
+		assert.True(t, (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z'),
+			"ULID should contain only uppercase alphanumeric characters")
+	}
+}
+
+// T015: Unit test for directory creation.
+func TestRecorder_DirectoryCreation(t *testing.T) {
+	// Create a path that doesn't exist
+	tmpDir := t.TempDir()
+	nestedDir := filepath.Join(tmpDir, "nested", "recording", "dir")
+
+	recorder := NewRecorder(nestedDir, silentLogger())
+
+	// Directory should be created
+	info, err := os.Stat(nestedDir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	// Should be able to record
+	req := &pbc.GetProjectedCostRequest{
+		Resource: &pbc.ResourceDescriptor{
+			ResourceType: "test:type",
+		},
+	}
+	err = recorder.RecordRequest("Test", req)
+	assert.NoError(t, err)
+	assert.False(t, recorder.disabled)
+}
+
+// T016a: Unit test for malformed request handling.
+func TestRecorder_MalformedRequestHandling(t *testing.T) {
+	tmpDir := t.TempDir()
+	recorder := NewRecorder(tmpDir, silentLogger())
+
+	// Record a nil request (edge case)
+	// This should still create a file with the nil serialized
+	err := recorder.RecordRequest("NilRequest", nil)
+	// protojson.Marshal handles nil gracefully
+	require.NoError(t, err)
+
+	// Verify file was created even for nil request
+	files, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+	assert.Len(t, files, 1)
+}
+
+// T025: Handle edge case: non-writable directory.
+func TestRecorder_NonWritableDirectory(t *testing.T) {
+	// Skip on Windows where permission model is different
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	readOnlyDir := filepath.Join(tmpDir, "readonly")
+	err := os.MkdirAll(readOnlyDir, 0555) // Read + execute only
+	require.NoError(t, err)
+
+	recorder := NewRecorder(readOnlyDir, silentLogger())
+
+	// Recorder should be disabled due to non-writable directory
+	assert.True(t, recorder.disabled)
+
+	// Recording should fail with error
+	req := &pbc.GetProjectedCostRequest{}
+	err = recorder.RecordRequest("Test", req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "disabled")
+}
+
+// T047: Ensure thread-safety with sync.Mutex.
+func TestRecorder_ThreadSafety(t *testing.T) {
+	tmpDir := t.TempDir()
+	recorder := NewRecorder(tmpDir, silentLogger())
+
+	// Run concurrent recordings
+	var wg sync.WaitGroup
+	concurrency := 100
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := &pbc.GetProjectedCostRequest{
+				Resource: &pbc.ResourceDescriptor{
+					ResourceType: "test:type",
+					Provider:     "test",
+				},
+			}
+			_ = recorder.RecordRequest("ConcurrentTest", req)
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify all files were created
+	files, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+	assert.Len(t, files, concurrency, "all concurrent recordings should succeed")
+
+	// Verify no duplicate filenames (ULIDs should be unique)
+	filenames := make(map[string]bool)
+	for _, f := range files {
+		assert.False(t, filenames[f.Name()], "duplicate filename found: %s", f.Name())
+		filenames[f.Name()] = true
+	}
+}
+
+func TestRecorder_SerializeRequest(t *testing.T) {
+	tmpDir := t.TempDir()
+	recorder := NewRecorder(tmpDir, silentLogger())
+
+	req := &pbc.GetProjectedCostRequest{
+		Resource: &pbc.ResourceDescriptor{
+			ResourceType: "aws:ec2:Instance",
+			Provider:     "aws",
+			Sku:          "t3.medium",
+			Region:       "us-east-1",
+			Tags: map[string]string{
+				"environment": "production",
+			},
+		},
+	}
+
+	data, err := recorder.serializeRequest(req)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	// Verify it's valid JSON
+	var parsed map[string]interface{}
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+
+	// Verify resource fields are present
+	resource, ok := parsed["resource"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "aws:ec2:Instance", resource["resourceType"])
+}
+
+func TestRecorder_Close(t *testing.T) {
+	tmpDir := t.TempDir()
+	recorder := NewRecorder(tmpDir, silentLogger())
+
+	// Should not panic
+	recorder.Close()
+}
+
+// T058a: Benchmark test validating <10ms recording overhead.
+func BenchmarkRecorder_RecordRequest(b *testing.B) {
+	tmpDir := b.TempDir()
+	recorder := NewRecorder(tmpDir, silentLogger())
+
+	req := &pbc.GetProjectedCostRequest{
+		Resource: &pbc.ResourceDescriptor{
+			ResourceType: "aws:ec2:Instance",
+			Provider:     "aws",
+			Sku:          "t3.medium",
+			Region:       "us-east-1",
+		},
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = recorder.RecordRequest("Benchmark", req)
+	}
+}
+
+// T041a: Concurrent request stress test (100+ parallel requests).
+func TestRecorder_StressTest(t *testing.T) {
+	tmpDir := t.TempDir()
+	recorder := NewRecorder(tmpDir, silentLogger())
+
+	// Run 100+ concurrent recordings
+	var wg sync.WaitGroup
+	concurrency := 150
+
+	start := time.Now()
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := &pbc.GetProjectedCostRequest{
+				Resource: &pbc.ResourceDescriptor{
+					ResourceType: "aws:ec2:Instance",
+					Provider:     "aws",
+				},
+			}
+			_ = recorder.RecordRequest("StressTest", req)
+		}()
+	}
+
+	wg.Wait()
+	duration := time.Since(start)
+
+	// Verify all files were created
+	files, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+	assert.Len(t, files, concurrency)
+
+	// Log performance metrics
+	t.Logf("Stress test: %d requests in %v (%.2f req/s)",
+		concurrency, duration, float64(concurrency)/duration.Seconds())
+}
+
+// Test isDiskFullError function.
+func TestIsDiskFullError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "no space left on device",
+			err:      errors.New("no space left on device"),
+			expected: true,
+		},
+		{
+			name:     "disk quota exceeded",
+			err:      errors.New("disk quota exceeded"),
+			expected: true,
+		},
+		{
+			name:     "ENOSPC error",
+			err:      errors.New("write failed: ENOSPC"),
+			expected: true,
+		},
+		{
+			name:     "permission denied",
+			err:      os.ErrPermission,
+			expected: false,
+		},
+		{
+			name:     "generic error",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isDiskFullError(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/specs/104-recorder-plugin/checklists/requirements.md
+++ b/specs/104-recorder-plugin/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Reference Recorder Plugin for DevTools
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- The specification is ready for `/speckit.clarify` or `/speckit.plan`
+- The GitHub issue (#274) provided comprehensive requirements, reducing need for clarification
+- Assumptions section documents reasonable defaults (USD currency, JSON format, env vars for config)
+- Out of Scope section clearly bounds the feature (no replay, no remote storage, no Budget/Recommendation interfaces yet)
+- **Dependency**: pulumicost-spec v0.4.6+ required for request validation helpers (FR-008, FR-015)

--- a/specs/104-recorder-plugin/contracts/cost-source-service.md
+++ b/specs/104-recorder-plugin/contracts/cost-source-service.md
@@ -1,0 +1,246 @@
+# Contract: CostSourceService Implementation
+
+**Date**: 2025-12-11
+**Feature**: 104-recorder-plugin
+
+## Overview
+
+The Recorder plugin implements the `CostSourceService` gRPC interface from pulumicost-spec. This document specifies the exact contract the recorder fulfills.
+
+## Service Definition
+
+```protobuf
+// From pulumicost-spec/proto/pulumicost/v1/cost_source.proto
+service CostSourceService {
+  rpc Name(NameRequest) returns (NameResponse);
+  rpc GetProjectedCost(GetProjectedCostRequest) returns (GetProjectedCostResponse);
+  rpc GetActualCost(GetActualCostRequest) returns (GetActualCostResponse);
+}
+```
+
+## RPC Contracts
+
+### 1. Name
+
+**Purpose**: Return plugin identification.
+
+**Request**: Empty `NameRequest`
+
+**Response**:
+
+```json
+{
+  "name": "recorder"
+}
+```
+
+**Behavior**:
+
+- Always returns "recorder"
+- Records request to JSON file
+- No error conditions
+
+### 2. GetProjectedCost
+
+**Purpose**: Calculate projected cost for a resource (or return mock).
+
+**Request**:
+
+```json
+{
+  "resource": {
+    "resourceType": "aws:ec2:Instance",
+    "provider": "aws",
+    "sku": "t3.medium",
+    "region": "us-east-1",
+    "tags": {
+      "instanceType": "t3.medium",
+      "environment": "production"
+    }
+  }
+}
+```
+
+**Response (Mock Mode = false)**:
+
+```json
+{
+  "costPerMonth": 0.0,
+  "unitPrice": 0.0,
+  "currency": "USD",
+  "billingDetail": "Recorder plugin - mock responses disabled"
+}
+```
+
+**Response (Mock Mode = true)**:
+
+```json
+{
+  "costPerMonth": 73.42,
+  "unitPrice": 0.1006,
+  "currency": "USD",
+  "billingDetail": "Mock cost: $73.42/month (recorder plugin)"
+}
+```
+
+**Behavior**:
+
+1. Validate request using pluginsdk v0.4.6 validation helpers
+2. Record full request to JSON file
+3. If MockResponse enabled: Generate randomized cost ($0.01-$1000/month)
+4. If MockResponse disabled: Return zero cost with explanatory note
+5. Return response
+
+**Error Conditions**:
+
+| Condition | gRPC Status | Message |
+|-----------|-------------|---------|
+| Invalid request (validation fails) | `INVALID_ARGUMENT` | Validation error details |
+| Recording fails (disk full, etc.) | Continue with warning | Logged, not returned to client |
+
+### 3. GetActualCost
+
+**Purpose**: Return historical cost data (or mock).
+
+**Request**:
+
+```json
+{
+  "resourceId": "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0",
+  "start": "2025-12-01T00:00:00Z",
+  "end": "2025-12-11T00:00:00Z",
+  "tags": {
+    "environment": "production"
+  }
+}
+```
+
+**Response (Mock Mode = false)**:
+
+```json
+{
+  "results": []
+}
+```
+
+**Response (Mock Mode = true)**:
+
+```json
+{
+  "results": [
+    {
+      "source": "recorder-mock",
+      "cost": 24.56
+    }
+  ]
+}
+```
+
+**Behavior**:
+
+1. Validate request using pluginsdk v0.4.6 validation helpers
+2. Record full request to JSON file
+3. If MockResponse enabled: Generate randomized cost result
+4. If MockResponse disabled: Return empty results array
+5. Return response
+
+**Error Conditions**:
+
+| Condition | gRPC Status | Message |
+|-----------|-------------|---------|
+| Invalid request (validation fails) | `INVALID_ARGUMENT` | Validation error details |
+| Recording fails (disk full, etc.) | Continue with warning | Logged, not returned to client |
+
+## Recorded Request Format
+
+All requests are recorded regardless of mock mode setting.
+
+**File Location**: `<OutputDir>/<timestamp>_<method>_<ulid>.json`
+
+**Schema**:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["timestamp", "method", "requestId", "request"],
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO8601 timestamp when request was received"
+    },
+    "method": {
+      "type": "string",
+      "enum": ["Name", "GetProjectedCost", "GetActualCost"],
+      "description": "gRPC method name"
+    },
+    "requestId": {
+      "type": "string",
+      "pattern": "^[0-9A-Z]{26}$",
+      "description": "ULID unique identifier"
+    },
+    "request": {
+      "type": "object",
+      "description": "Full protobuf request as JSON (protojson format)"
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "receivedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "processingTimeMs": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `PULUMICOST_RECORDER_OUTPUT_DIR` | string | `./recorded_data` | Directory for recorded files |
+| `PULUMICOST_RECORDER_MOCK_RESPONSE` | bool | `false` | Enable mock response generation |
+
+## Plugin Discovery
+
+**Binary Name**: `pulumicost-plugin-recorder`
+
+**Installation Path**: `~/.pulumicost/plugins/recorder/<version>/pulumicost-plugin-recorder`
+
+**Manifest** (`plugin.manifest.json`):
+
+```json
+{
+  "name": "recorder",
+  "version": "0.1.0",
+  "description": "Reference plugin that records all gRPC requests and optionally returns mock responses",
+  "author": "PulumiCost Team",
+  "supported_providers": ["*"],
+  "protocols": ["grpc"],
+  "binary": "pulumicost-plugin-recorder",
+  "metadata": {
+    "repository": "https://github.com/rshade/pulumicost-core",
+    "docs": "https://github.com/rshade/pulumicost-core/tree/main/plugins/recorder",
+    "reference_implementation": true
+  }
+}
+```
+
+## Conformance Requirements
+
+The recorder plugin MUST:
+
+1. Respond to all three CostSourceService RPCs
+2. Record all requests to JSON files (unless I/O fails)
+3. Return valid protobuf responses (never panic)
+4. Handle graceful shutdown on SIGINT/SIGTERM
+5. Support both TCP (--port) and stdio (--stdio) modes
+6. Use pluginsdk v0.4.6+ validation helpers
+7. Pass `pulumicost plugin validate` checks

--- a/specs/104-recorder-plugin/data-model.md
+++ b/specs/104-recorder-plugin/data-model.md
@@ -1,0 +1,179 @@
+# Data Model: Reference Recorder Plugin
+
+**Date**: 2025-12-11
+**Feature**: 104-recorder-plugin
+
+## Entities
+
+### 1. Config
+
+Runtime configuration loaded from environment variables.
+
+| Field | Type | Source | Default | Description |
+|-------|------|--------|---------|-------------|
+| OutputDir | string | `PULUMICOST_RECORDER_OUTPUT_DIR` | `./recorded_data` | Directory for recorded JSON files |
+| MockResponse | bool | `PULUMICOST_RECORDER_MOCK_RESPONSE` | `false` | Enable randomized mock responses |
+
+**Validation Rules**:
+
+- OutputDir: Must be a valid path; created if not exists
+- MockResponse: Parsed from "true"/"false"/"1"/"0" (case-insensitive)
+
+### 2. RecordedRequest
+
+Represents a serialized gRPC request captured to disk.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Timestamp | string (ISO8601) | When request was received (UTC) |
+| Method | string | gRPC method name (e.g., "GetProjectedCost") |
+| RequestID | string (ULID) | Unique identifier for this request |
+| Request | object | Full protobuf request serialized as JSON |
+| Metadata | RequestMetadata | Optional metadata about the request |
+
+**File Naming**:
+
+```text
+<timestamp>_<method>_<ulid>.json
+Example: 20251211T143052Z_GetProjectedCost_01JEK7X2J3K4M5N6P7Q8R9S0T1.json
+```
+
+**JSON Structure**:
+
+```json
+{
+  "timestamp": "2025-12-11T14:30:52Z",
+  "method": "GetProjectedCost",
+  "requestId": "01JEK7X2J3K4M5N6P7Q8R9S0T1",
+  "request": {
+    "resource": {
+      "resourceType": "aws:ec2:Instance",
+      "provider": "aws",
+      "sku": "t3.medium",
+      "region": "us-east-1",
+      "tags": {
+        "instanceType": "t3.medium",
+        "environment": "production"
+      }
+    }
+  },
+  "metadata": {
+    "receivedAt": "2025-12-11T14:30:52.123456Z",
+    "processingTimeMs": 2
+  }
+}
+```
+
+### 3. RequestMetadata
+
+Optional metadata captured alongside the request.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| ReceivedAt | string (RFC3339Nano) | Precise timestamp when request arrived |
+| ProcessingTimeMs | int64 | Time spent processing request (milliseconds) |
+
+### 4. MockCostResponse
+
+Internal representation for generating mock responses (not persisted).
+
+| Field | Type | Range | Description |
+|-------|------|-------|-------------|
+| MonthlyCost | float64 | $0.01 - $1000 | Randomized monthly cost |
+| HourlyCost | float64 | Derived | MonthlyCost / 730 |
+| Currency | string | "USD" | Always USD for mock responses |
+| BillingDetail | string | - | Human-readable mock indicator |
+
+**Generation Algorithm**:
+
+```go
+// Log-scale distribution for realistic cost spread
+cost := minCost * math.Pow(maxCost/minCost, rand.Float64())
+```
+
+### 5. RecorderPlugin
+
+Main plugin struct implementing CostSourceService.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| BasePlugin | *pluginsdk.BasePlugin | Embedded SDK base (provides Matcher, Calculator) |
+| config | *Config | Runtime configuration |
+| recorder | *Recorder | Request serialization handler |
+| mocker | *Mocker | Mock response generator (nil if disabled) |
+| mu | sync.Mutex | Protects shared state |
+
+**State Transitions**:
+
+```text
+[Created] --> [Initialized] --> [Serving] --> [Shutting Down] --> [Stopped]
+     |              |               |                |
+     +-- NewRecorderPlugin()       |                |
+                    +-- Serve()    |                |
+                                   +-- Signal/Cancel
+                                                    +-- Shutdown()
+```
+
+## Relationships
+
+```text
+RecorderPlugin
+├── Config (1:1) - Configuration loaded at startup
+├── Recorder (1:1) - Handles request serialization
+│   └── RecordedRequest (1:N) - Each request creates one file
+└── Mocker (0:1) - Only present if MockResponse=true
+    └── MockCostResponse (transient) - Generated per request
+```
+
+## File System Layout
+
+```text
+<OutputDir>/
+├── 20251211T143052Z_Name_01JEK7X2J3K4M5N6P7Q8R9S0T1.json
+├── 20251211T143052Z_GetProjectedCost_01JEK7X2J3K4M5N6P7Q8R9S1T2.json
+├── 20251211T143053Z_GetProjectedCost_01JEK7X2J3K4M5N6P7Q8R9S2T3.json
+├── 20251211T143054Z_GetActualCost_01JEK7X2J3K4M5N6P7Q8R9S3T4.json
+└── ... (one file per request)
+```
+
+## Protocol Buffer Types (from pulumicost-spec)
+
+The plugin uses these types from `github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1`:
+
+### Input Types
+
+- `NameRequest` - Empty request for Name RPC
+- `GetProjectedCostRequest` - Contains ResourceDescriptor
+- `GetActualCostRequest` - Contains ResourceId, Start, End timestamps, Tags
+
+### Output Types
+
+- `NameResponse` - Contains Name string
+- `GetProjectedCostResponse` - Contains CostPerMonth, UnitPrice, Currency, BillingDetail
+- `GetActualCostResponse` - Contains Results array of ActualCostResult
+
+### Shared Types
+
+- `ResourceDescriptor` - ResourceType, Provider, Sku, Region, Tags map
+- `ActualCostResult` - Source, Cost fields for historical data
+
+## Validation Rules
+
+### FR-015 Request Validation (pluginsdk v0.4.6)
+
+Before processing any request, validate using SDK helpers:
+
+```go
+// GetProjectedCost validation
+if err := pluginsdk.ValidateProjectedCostRequest(req); err != nil {
+    // Record invalid request for debugging
+    r.recorder.RecordInvalidRequest("GetProjectedCost", req, err)
+    return nil, status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
+}
+```
+
+### Output Directory Validation
+
+- Create directory if not exists: `os.MkdirAll(dir, 0755)`
+- Check write permissions on startup
+- Log warning and disable recording if not writable

--- a/specs/104-recorder-plugin/plan.md
+++ b/specs/104-recorder-plugin/plan.md
@@ -1,0 +1,120 @@
+# Implementation Plan: Reference Recorder Plugin for DevTools
+
+**Branch**: `104-recorder-plugin` | **Date**: 2025-12-11 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/104-recorder-plugin/spec.md`
+
+## Summary
+
+Implement a reference "Recorder" plugin within pulumicost-core that captures all gRPC requests to JSON files and optionally returns mock cost responses. This plugin serves as both a developer tool for inspecting Core-to-plugin data shapes and a canonical reference implementation demonstrating pluginsdk v0.4.6 patterns.
+
+**Technical Approach**: Build as a standalone plugin in `plugins/recorder/` using the pluginsdk from pulumicost-spec v0.4.6+. The plugin will implement CostSourceService, serialize requests to JSON, and generate randomized mock responses when configured.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.5
+**Primary Dependencies**:
+
+- `github.com/rshade/pulumicost-spec v0.4.6+` (pluginsdk, protobuf definitions)
+- `github.com/oklog/ulid/v2` (ULID generation for filenames)
+- `github.com/rs/zerolog` (structured logging)
+- `google.golang.org/grpc` (gRPC server/transport)
+
+**Storage**: Local filesystem (`./recorded_data` default, configurable via env var)
+**Testing**: `go test` with testify, mock plugin infrastructure from `test/mocks/plugin/`
+**Target Platform**: Linux (amd64, arm64), macOS (amd64, arm64), Windows (amd64)
+**Project Type**: Single plugin binary within monorepo
+**Performance Goals**: Recording should add <10ms overhead per request (dev tool, not production-critical)
+**Constraints**: Must work with existing plugin discovery in `~/.pulumicost/plugins/`
+**Scale/Scope**: Dev tool; typical usage: dozens to hundreds of requests per session
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Verify compliance with PulumiCost Core Constitution (`.specify/memory/constitution.md`):
+
+- [x] **Plugin-First Architecture**: This IS a plugin implementing CostSourceService via gRPC
+- [x] **Test-Driven Development**: Tests planned with 80%+ coverage target, critical paths at 95%
+- [x] **Cross-Platform Compatibility**: Will build on Linux, macOS, Windows (amd64, arm64)
+- [x] **Documentation as Code**: README.md, quickstart.md, and inline code comments planned
+- [x] **Protocol Stability**: Uses existing pulumicost-spec v0.4.6 protocol, no changes required
+- [x] **Quality Gates**: CI workflow will run tests, lint, security scan, cross-platform builds
+- [x] **Multi-Repo Coordination**: Depends on pulumicost-spec v0.4.6 (already released)
+
+**Violations Requiring Justification**: None - full compliance
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/104-recorder-plugin/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (gRPC service definitions)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+plugins/recorder/
+├── main.go              # Plugin entry point and gRPC server setup
+├── plugin.go            # RecorderPlugin struct implementing CostSourceService
+├── recorder.go          # Request serialization to JSON files
+├── mocker.go            # Mock response generation (randomized costs)
+├── config.go            # Configuration from environment variables
+├── plugin.manifest.json # Plugin metadata for registry
+├── README.md            # Plugin documentation
+├── recorder_test.go     # Unit tests for recorder
+├── plugin_test.go       # Unit tests for plugin struct
+├── config_test.go       # Unit tests for configuration
+└── mocker_test.go       # Unit tests for mock generation
+
+# Build output
+bin/
+└── pulumicost-plugin-recorder  # Built binary (cross-platform)
+
+# Test integration
+test/
+├── integration/
+│   └── recorder_test.go        # Integration tests with recorder plugin
+└── fixtures/
+    └── recorder/               # Test fixtures for recorder tests
+```
+
+**Structure Decision**: Plugin lives in `plugins/recorder/` within the monorepo. This keeps it close to Core for CI/CD integration and contract testing while maintaining clear separation as a standalone plugin binary. The `plugins/` directory is new and establishes the pattern for in-repo reference plugins.
+
+## Complexity Tracking
+
+No violations - complexity tracking not required.
+
+## Post-Design Constitution Re-Check
+
+*Performed after Phase 1 design completion.*
+
+- [x] **Plugin-First Architecture**: ✅ Confirmed - CostSourceService implementation via gRPC
+- [x] **Test-Driven Development**: ✅ Confirmed - Unit tests in recorder_test.go, integration tests planned
+- [x] **Cross-Platform Compatibility**: ✅ Confirmed - Standard Go, no platform-specific code
+- [x] **Documentation as Code**: ✅ Confirmed - quickstart.md, contracts/, data-model.md created
+- [x] **Protocol Stability**: ✅ Confirmed - Uses existing v0.4.6 protocol, no changes
+- [x] **Quality Gates**: ✅ Confirmed - Makefile target integrates with CI
+- [x] **Multi-Repo Coordination**: ✅ Confirmed - pulumicost-spec v0.4.6 dependency documented
+
+**Post-Design Status**: All constitution principles satisfied. Ready for task generation.
+
+## Generated Artifacts
+
+| Artifact | Path | Description |
+|----------|------|-------------|
+| Research | [research.md](research.md) | SDK patterns, serialization, configuration decisions |
+| Data Model | [data-model.md](data-model.md) | Entity definitions, validation rules, state transitions |
+| Contract | [contracts/cost-source-service.md](contracts/cost-source-service.md) | gRPC interface specification |
+| Quickstart | [quickstart.md](quickstart.md) | Developer guide (~10 min) |
+
+## Next Steps
+
+Run `/speckit.tasks` to generate actionable task list from this plan.

--- a/specs/104-recorder-plugin/quickstart.md
+++ b/specs/104-recorder-plugin/quickstart.md
@@ -1,0 +1,186 @@
+# Quickstart: Recorder Plugin
+
+**Time to complete**: ~10 minutes
+
+This guide shows how to build, install, and use the Recorder plugin to inspect gRPC requests from PulumiCost Core.
+
+## Prerequisites
+
+- Go 1.25.5+
+- pulumicost-core built (`make build`)
+- A Pulumi plan JSON file (optional, for testing)
+
+## Build and Install the Plugin
+
+```bash
+# From pulumicost-core repository root
+make install-recorder
+
+# Verify installation
+./bin/pulumicost plugin list
+```
+
+Expected output:
+
+```text
+PLUGIN     VERSION  PATH
+recorder   0.1.0    ~/.pulumicost/plugins/recorder/0.1.0/pulumicost-plugin-recorder
+```
+
+## Basic Usage
+
+### Inspect Request Data (Default Mode)
+
+Run with a sample Pulumi plan to capture requests:
+
+```bash
+# Set output directory (optional, defaults to ./recorded_data)
+export PULUMICOST_RECORDER_OUTPUT_DIR=./my-recordings
+
+# Run cost calculation
+./bin/pulumicost cost projected --pulumi-json examples/plans/aws-simple-plan.json
+
+# View recorded requests
+ls -la ./my-recordings/
+cat ./my-recordings/*.json | jq .
+```
+
+### Enable Mock Responses
+
+For testing Core's aggregation logic without real costs:
+
+```bash
+# Enable mock mode
+export PULUMICOST_RECORDER_MOCK_RESPONSE=true
+
+# Run cost calculation (will show randomized costs)
+./bin/pulumicost cost projected --pulumi-json examples/plans/aws-simple-plan.json --output json
+```
+
+Example output with mock mode:
+
+```json
+{
+  "results": [
+    {
+      "resourceType": "aws:ec2:Instance",
+      "adapter": "recorder",
+      "currency": "USD",
+      "monthly": 73.42,
+      "notes": "Mock cost: $73.42/month (recorder plugin)"
+    }
+  ]
+}
+```
+
+## Configuration Reference
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `PULUMICOST_RECORDER_OUTPUT_DIR` | `./recorded_data` | Directory for JSON files |
+| `PULUMICOST_RECORDER_MOCK_RESPONSE` | `false` | Enable randomized responses |
+
+## Recorded Request Format
+
+Each request creates a JSON file:
+
+```text
+./recorded_data/
+├── 20251211T143052Z_Name_01JEK7X2J3K4M5N6P7Q8R9S0T1.json
+├── 20251211T143052Z_GetProjectedCost_01JEK7X2J3K4M5N6P7Q8R9S1T2.json
+└── 20251211T143053Z_GetProjectedCost_01JEK7X2J3K4M5N6P7Q8R9S2T3.json
+```
+
+Example file content:
+
+```json
+{
+  "timestamp": "2025-12-11T14:30:52Z",
+  "method": "GetProjectedCost",
+  "requestId": "01JEK7X2J3K4M5N6P7Q8R9S1T2",
+  "request": {
+    "resource": {
+      "resourceType": "aws:ec2:Instance",
+      "provider": "aws",
+      "sku": "t3.medium",
+      "region": "us-east-1",
+      "tags": {
+        "instanceType": "t3.medium"
+      }
+    }
+  }
+}
+```
+
+## Use Cases
+
+### 1. Debug Plugin Integration
+
+See exactly what data Core sends to plugins:
+
+```bash
+PULUMICOST_RECORDER_OUTPUT_DIR=./debug ./bin/pulumicost cost projected --pulumi-json my-plan.json
+cat ./debug/*.json | jq '.request.resource'
+```
+
+### 2. Test Core Aggregation
+
+Generate mock data to test output formatting:
+
+```bash
+PULUMICOST_RECORDER_MOCK_RESPONSE=true ./bin/pulumicost cost projected \
+  --pulumi-json examples/plans/aws-simple-plan.json \
+  --output table
+```
+
+### 3. Contract Testing
+
+Use as a reference plugin in integration tests:
+
+```bash
+# In test setup
+export PULUMICOST_RECORDER_OUTPUT_DIR=/tmp/test-recordings
+export PULUMICOST_RECORDER_MOCK_RESPONSE=true
+
+# Run tests
+go test ./test/integration/... -v
+```
+
+## Troubleshooting
+
+### Plugin Not Found
+
+```bash
+# Check plugin directory structure
+ls -la ~/.pulumicost/plugins/recorder/
+
+# Verify binary is executable
+chmod +x ~/.pulumicost/plugins/recorder/0.1.0/pulumicost-plugin-recorder
+```
+
+### No Files Being Recorded
+
+```bash
+# Check output directory exists and is writable
+mkdir -p "$PULUMICOST_RECORDER_OUTPUT_DIR"
+touch "$PULUMICOST_RECORDER_OUTPUT_DIR/test.txt" && rm "$PULUMICOST_RECORDER_OUTPUT_DIR/test.txt"
+
+# Check plugin is being used (not falling back to specs)
+./bin/pulumicost cost projected --debug --pulumi-json plan.json 2>&1 | grep recorder
+```
+
+### Mock Responses Not Working
+
+```bash
+# Verify environment variable is set correctly
+echo $PULUMICOST_RECORDER_MOCK_RESPONSE  # Should be "true"
+
+# Check for typos (case-insensitive)
+export PULUMICOST_RECORDER_MOCK_RESPONSE=TRUE  # Also works
+```
+
+## Next Steps
+
+- Read the [full plugin documentation](../../plugins/recorder/README.md)
+- Study the [source code](../../plugins/recorder/) as a reference implementation
+- Use recorded data to build your own plugin

--- a/specs/104-recorder-plugin/research.md
+++ b/specs/104-recorder-plugin/research.md
@@ -1,0 +1,281 @@
+# Research: Reference Recorder Plugin for DevTools
+
+**Date**: 2025-12-11
+**Feature**: 104-recorder-plugin
+
+## Research Topics
+
+### 1. pluginsdk v0.4.6 Patterns
+
+**Research Task**: Find best practices for using pluginsdk v0.4.6 request validation helpers.
+
+**Decision**: Use pluginsdk.BasePlugin with embedded struct pattern, register all providers with wildcard matcher, and use request validation helpers before processing.
+
+**Rationale**: The aws-example plugin demonstrates this pattern effectively. The v0.4.6 release adds validation helpers that should be demonstrated in the recorder as a reference implementation.
+
+**Pattern**:
+
+```go
+type RecorderPlugin struct {
+    *pluginsdk.BasePlugin
+    config *Config
+    recorder *Recorder
+}
+
+func NewRecorderPlugin(cfg *Config) *RecorderPlugin {
+    base := pluginsdk.NewBasePlugin("recorder")
+    // Register as universal handler (accepts all resources)
+    base.Matcher().AddProvider("*")
+
+    return &RecorderPlugin{
+        BasePlugin: base,
+        config: cfg,
+        recorder: NewRecorder(cfg.OutputDir),
+    }
+}
+```
+
+**Alternatives Considered**:
+
+- Direct protobuf implementation without SDK: Rejected - violates reference implementation goal
+- Selective resource registration: Rejected - recorder should capture ALL requests
+
+### 2. JSON Serialization for Protobuf Messages
+
+**Research Task**: Best practices for serializing gRPC protobuf messages to human-readable JSON.
+
+**Decision**: Use `protojson.Marshal` from `google.golang.org/protobuf/encoding/protojson` with indent formatting.
+
+**Rationale**: Standard protobuf JSON encoding ensures field names match proto definitions and handles all proto types correctly (timestamps, enums, oneofs).
+
+**Pattern**:
+
+```go
+import "google.golang.org/protobuf/encoding/protojson"
+
+func (r *Recorder) SerializeRequest(req proto.Message) ([]byte, error) {
+    opts := protojson.MarshalOptions{
+        Multiline:       true,
+        Indent:          "  ",
+        EmitUnpopulated: true,  // Include zero values for completeness
+    }
+    return opts.Marshal(req)
+}
+```
+
+**Alternatives Considered**:
+
+- Standard `encoding/json`: Rejected - doesn't handle proto-specific types properly
+- Binary protobuf format: Rejected - not human-readable, defeats inspection purpose
+
+### 3. Thread-Safe File Writing
+
+**Research Task**: Best practices for concurrent file writes with unique filenames.
+
+**Decision**: Use ULID for unique identifiers (time-ordered, no collisions), sync.Mutex for recorder state, individual file writes are atomic via os.WriteFile.
+
+**Rationale**: ULIDs are monotonically increasing and contain timestamp, making recorded files naturally sorted by time. Mutex protects shared state; file writes are atomic.
+
+**Pattern**:
+
+```go
+import "github.com/oklog/ulid/v2"
+
+func generateFilename(method string) string {
+    timestamp := time.Now().UTC().Format("20060102T150405Z")
+    id := ulid.Make()
+    return fmt.Sprintf("%s_%s_%s.json", timestamp, method, id.String())
+}
+```
+
+**Alternatives Considered**:
+
+- UUID v4: Rejected - not time-ordered, harder to correlate with events
+- Timestamp only: Rejected - potential collisions under concurrent load
+- Sequence numbers: Rejected - requires persistent state
+
+### 4. Mock Response Generation
+
+**Research Task**: Best practices for generating randomized but valid cost responses.
+
+**Decision**: Use deterministic ranges for cost values ($0.01 - $1000/month for projected, $0.001 - $100/day for actual). Use SDK Calculator for response building.
+
+**Rationale**: Ranges should be realistic enough to test aggregation logic but clearly fake. SDK Calculator ensures protocol compliance.
+
+**Pattern**:
+
+```go
+import "math/rand"
+
+func (m *Mocker) GenerateProjectedCost() float64 {
+    // Range: $0.01 to $1000 per month (log scale for realistic distribution)
+    min := 0.01
+    max := 1000.0
+    return min * math.Pow(max/min, rand.Float64())
+}
+
+func (m *Mocker) CreateProjectedCostResponse() *pb.GetProjectedCostResponse {
+    cost := m.GenerateProjectedCost()
+    return m.plugin.Calculator().CreateProjectedCostResponse(
+        "USD",
+        cost / 730, // Convert monthly to hourly
+        fmt.Sprintf("Mock cost: $%.2f/month", cost),
+    )
+}
+```
+
+**Alternatives Considered**:
+
+- Fixed responses: Rejected - doesn't test aggregation edge cases
+- Truly random (negative values possible): Rejected - would break Core assertions
+- Seeded random: Considered for reproducibility, but not required for dev tool
+
+### 5. Environment Variable Configuration
+
+**Research Task**: Best practices for plugin configuration via environment variables.
+
+**Decision**: Use standard `os.Getenv` with defaults, parse booleans case-insensitively, log configuration at startup.
+
+**Rationale**: Consistent with Core patterns (PULUMICOST_* prefix). Simple, no external config library needed.
+
+**Pattern**:
+
+```go
+type Config struct {
+    OutputDir    string
+    MockResponse bool
+}
+
+func LoadConfig() *Config {
+    cfg := &Config{
+        OutputDir:    "./recorded_data",
+        MockResponse: false,
+    }
+
+    if dir := os.Getenv("PULUMICOST_RECORDER_OUTPUT_DIR"); dir != "" {
+        cfg.OutputDir = dir
+    }
+
+    if mock := os.Getenv("PULUMICOST_RECORDER_MOCK_RESPONSE"); mock != "" {
+        cfg.MockResponse = strings.EqualFold(mock, "true") || mock == "1"
+    }
+
+    return cfg
+}
+```
+
+**Alternatives Considered**:
+
+- YAML config file: Rejected - adds complexity, env vars match plugin pattern
+- Viper/Cobra flags: Rejected - plugin receives only --port/--stdio from launcher
+
+### 6. Graceful Shutdown Pattern
+
+**Research Task**: Best practices for graceful shutdown in gRPC plugins.
+
+**Decision**: Use context cancellation with signal handling, defer cleanup in main, flush recorder on shutdown.
+
+**Rationale**: Matches aws-example pattern. Ensures pending writes complete before exit.
+
+**Pattern**:
+
+```go
+func main() {
+    ctx, cancel := context.WithCancel(context.Background())
+    defer cancel()
+
+    // Signal handling
+    sigCh := make(chan os.Signal, 1)
+    signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+    go func() {
+        <-sigCh
+        cancel()
+    }()
+
+    plugin := NewRecorderPlugin(LoadConfig())
+    defer plugin.Shutdown() // Flush pending writes
+
+    config := pluginsdk.ServeConfig{
+        Plugin: plugin,
+        Port:   0,
+    }
+
+    if err := pluginsdk.Serve(ctx, config); err != nil {
+        os.Exit(1)
+    }
+}
+```
+
+**Alternatives Considered**:
+
+- No explicit shutdown: Rejected - could lose buffered data
+- Fixed timeout: Considered but context cancellation is cleaner
+
+### 7. Plugin Manifest Structure
+
+**Research Task**: Best practices for plugin.manifest.json format.
+
+**Decision**: Follow manifest.yaml pattern from aws-example, use JSON for consistency with other JSON outputs.
+
+**Rationale**: Registry expects optional manifest for validation; JSON is more portable.
+
+**Pattern**:
+
+```json
+{
+  "name": "recorder",
+  "version": "0.1.0",
+  "description": "Reference plugin that records all gRPC requests and optionally returns mock responses",
+  "author": "PulumiCost Team",
+  "supported_providers": ["*"],
+  "protocols": ["grpc"],
+  "binary": "pulumicost-plugin-recorder",
+  "metadata": {
+    "repository": "https://github.com/rshade/pulumicost-core",
+    "docs": "https://github.com/rshade/pulumicost-core/tree/main/plugins/recorder",
+    "reference_implementation": true
+  }
+}
+```
+
+**Alternatives Considered**:
+
+- YAML format: Rejected - JSON matches other recorded outputs
+- No manifest: Rejected - spec requires FR-014
+
+### 8. Build System Integration
+
+**Research Task**: Best practices for adding plugin build target to Makefile.
+
+**Decision**: Add `build-recorder` target that builds to `bin/pulumicost-plugin-recorder`, include in CI workflow.
+
+**Rationale**: Consistent with existing build patterns, cross-platform via GOOS/GOARCH.
+
+**Pattern**:
+
+```makefile
+.PHONY: build-recorder
+build-recorder:
+	go build -o bin/pulumicost-plugin-recorder ./plugins/recorder
+
+.PHONY: build-all
+build-all: build build-recorder
+```
+
+**Alternatives Considered**:
+
+- Separate Makefile in plugins/recorder: Rejected - harder to maintain
+- Shell script: Rejected - Makefile is standard in this project
+
+## Summary
+
+All research topics resolved. No blocking unknowns remain. Key decisions:
+
+1. **SDK Pattern**: Embedded BasePlugin with wildcard provider matcher
+2. **Serialization**: protojson with indentation
+3. **Unique IDs**: ULID for time-ordered, collision-free filenames
+4. **Mock Values**: Log-scale random in realistic ranges
+5. **Config**: Environment variables with PULUMICOST_RECORDER_* prefix
+6. **Shutdown**: Context cancellation with signal handling
+7. **Manifest**: JSON format with reference implementation metadata
+8. **Build**: Makefile target `build-recorder`

--- a/specs/104-recorder-plugin/spec.md
+++ b/specs/104-recorder-plugin/spec.md
@@ -1,0 +1,144 @@
+# Feature Specification: Reference Recorder Plugin for DevTools
+
+**Feature Branch**: `104-recorder-plugin`
+**Created**: 2025-12-11
+**Status**: Draft
+**Input**: User description: "Add Reference Recorder Plugin for DevTools - canonical reference implementation and developer tool for inspecting data shapes and testing Core interactions without external dependencies"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Request Data Inspection (Priority: P1)
+
+As a plugin developer, I want to capture and inspect the exact gRPC requests that PulumiCost Core sends to plugins, so that I can understand data shapes, field values, and request structures without building a full plugin first.
+
+**Why this priority**: This directly addresses the "Blind Integration" problem - plugin developers cannot currently see what data the Core sends. This is the primary value proposition of the recorder plugin.
+
+**Independent Test**: Can be tested by running the recorder against a sample Pulumi plan and verifying that JSON files are created containing full request payloads.
+
+**Acceptance Scenarios**:
+
+1. **Given** the recorder plugin is configured with an output directory, **When** `pulumicost cost projected` is executed with a Pulumi plan, **Then** each request is saved as a separate JSON file with timestamp, method name, and unique identifier in the filename.
+2. **Given** the recorder is running with default configuration, **When** a request is processed, **Then** the JSON output includes all fields: resource types, providers, tags, regions, SKUs, and any other request metadata.
+3. **Given** the output directory does not exist, **When** the recorder starts, **Then** the directory is created automatically with appropriate permissions.
+
+---
+
+### User Story 2 - Mock Response Generation (Priority: P2)
+
+As a Core developer, I want the recorder to generate randomized but valid cost responses, so that I can test aggregation logic, output formatting, and reporting features without requiring real cloud credentials or external services.
+
+**Why this priority**: This enables testing Core's aggregation and reporting logic in isolation. Without mock responses, developers need real cloud integrations to test end-to-end flows.
+
+**Independent Test**: Can be tested by running the recorder with mock mode enabled and verifying that responses contain valid cost data structures with randomized values.
+
+**Acceptance Scenarios**:
+
+1. **Given** mock response mode is enabled, **When** `GetProjectedCost` is called, **Then** the recorder returns a valid response with randomized cost values in USD currency.
+2. **Given** mock response mode is enabled, **When** `GetActualCost` is called, **Then** the recorder returns a valid response with randomized historical cost records following FOCUS 1.2 format.
+3. **Given** mock response mode is disabled (default), **When** any cost method is called, **Then** the recorder returns empty/default responses indicating no cost data available.
+
+---
+
+### User Story 3 - Reference Implementation Study (Priority: P3)
+
+As a new plugin developer, I want to study a complete, working plugin implementation that demonstrates best practices, so that I can use it as a template for building my own plugin.
+
+**Why this priority**: While documentation helps, seeing working code is invaluable. The recorder serves as executable documentation of SDK patterns.
+
+**Independent Test**: Can be tested by verifying the plugin builds, runs, and demonstrates all SDK features mentioned in documentation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reads the recorder source code, **When** they examine the implementation, **Then** they see examples of all gRPC interfaces (CostSource methods), error handling, and SDK builder usage.
+2. **Given** a developer wants to create a new plugin, **When** they copy the recorder structure, **Then** they have a working foundation that includes configuration handling, graceful shutdown, and logging patterns.
+3. **Given** the recorder is built and installed, **When** `pulumicost plugin validate` is run, **Then** the recorder passes all validation checks as a conformant plugin.
+
+---
+
+### User Story 4 - Contract Testing Support (Priority: P4)
+
+As a Core maintainer, I want to use the recorder as a target for contract tests, so that I can detect regressions in plugin orchestration without depending on external plugins.
+
+**Why this priority**: Internal testing reduces dependency on external repositories and speeds up CI feedback loops.
+
+**Independent Test**: Can be tested by running Core's plugin integration tests against the recorder and verifying test pass/fail behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** the recorder is installed in the plugins directory, **When** Core's plugin integration tests run, **Then** the recorder is discovered and responds correctly to all protocol methods.
+2. **Given** Core makes a breaking change to the plugin protocol, **When** CI runs against the recorder, **Then** tests fail clearly indicating the contract violation.
+
+---
+
+### Edge Cases
+
+- What happens when the output directory is not writable? Plugin should log an error and continue operating without recording.
+- What happens when disk space runs out during recording? Plugin should handle gracefully, log warning, and stop recording while continuing to respond to requests.
+- How does the recorder handle malformed requests? Plugin should record the raw request anyway (for debugging purposes) and return appropriate gRPC error codes.
+- What happens with very large requests (e.g., plans with thousands of resources)? Each request is recorded individually; system limits (file size, disk space) are respected.
+- What happens if multiple Core instances call the recorder simultaneously? Plugin must be thread-safe and use unique identifiers to prevent filename collisions.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST implement all CostSourceService gRPC methods: `Name()`, `GetProjectedCost()`, and `GetActualCost()`.
+- **FR-002**: System MUST serialize every incoming gRPC request to a JSON file when request capture is enabled.
+- **FR-003**: System MUST use the filename format `<ISO8601-timestamp>_<method-name>_<ULID>.json` for recorded files.
+- **FR-004**: System MUST support configuring the output directory via `PULUMICOST_RECORDER_OUTPUT_DIR` environment variable (default: `./recorded_data`).
+- **FR-005**: System MUST support enabling/disabling mock responses via `PULUMICOST_RECORDER_MOCK_RESPONSE` environment variable (default: `false`).
+- **FR-006**: System MUST generate randomized but structurally valid cost responses when mock mode is enabled.
+- **FR-007**: System MUST return empty/default responses when mock mode is disabled.
+- **FR-008**: System MUST use the pluginsdk library from pulumicost-spec v0.4.6 or later for SDK patterns (BasePlugin, Matcher, Serve, request validation helpers).
+- **FR-009**: System MUST create the output directory if it does not exist.
+- **FR-010**: System MUST support both TCP (ProcessLauncher) and stdio (StdioLauncher) communication modes.
+- **FR-011**: System MUST handle graceful shutdown on SIGINT/SIGTERM, flushing any pending writes.
+- **FR-012**: System MUST be thread-safe for concurrent requests.
+- **FR-013**: System MUST follow the standard plugin binary naming convention: `pulumicost-plugin-recorder`.
+- **FR-014**: System MUST include a `plugin.manifest.json` file with plugin metadata.
+- **FR-015**: System MUST use the pluginsdk request validation helpers (from v0.4.6) to validate incoming requests before processing, demonstrating best practices for input sanitation.
+
+### Key Entities
+
+- **RecordedRequest**: Represents a captured gRPC request containing timestamp, method name, unique ID, full request payload, and optional metadata (client info, duration).
+- **MockCostResponse**: Represents a generated mock response including randomized cost values, currency (USD), billing details, and FOCUS 1.2 compliant structure for actual costs.
+- **PluginConfiguration**: Represents runtime configuration including output directory path, mock mode enabled flag, and any future configuration options.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Plugin developers can inspect complete request data within 5 minutes of running the recorder (measured by time to first recorded file).
+- **SC-002**: Core developers can run full end-to-end tests using mock responses without any external credentials or services.
+- **SC-003**: The recorder plugin passes all Core plugin validation checks (`pulumicost plugin validate`).
+- **SC-004**: Recorded JSON files are human-readable and contain all fields present in the original gRPC requests.
+- **SC-005**: Mock responses are valid according to the pulumicost-spec protocol definitions (can be deserialized without errors).
+- **SC-006**: The recorder integrates with the standard build system via a single command (`make build-recorder`).
+- **SC-007**: CI/CD pipeline builds and tests the recorder on every commit to detect protocol regressions.
+- **SC-008**: Documentation enables a new developer to use the recorder within 10 minutes (quickstart guide).
+
+## Dependencies
+
+- **pulumicost-spec v0.4.6+**: Required for pluginsdk with request validation helpers
+  - Release: https://github.com/rshade/pulumicost-spec/releases/tag/v0.4.6
+  - Key features used: BasePlugin, Matcher, Serve, request validation helpers, FOCUS 1.2 builders
+  - The v0.4.6 release adds request validation helpers that enable proper input sanitation and error handling
+
+## Assumptions
+
+- The pulumicost-spec SDK (`pluginsdk`) v0.4.6+ provides all necessary building blocks (BasePlugin, Matcher, Serve, builders, validation helpers).
+- The recorder will be shipped as part of pulumicost-core releases or as an easily buildable target.
+- JSON is the appropriate format for recorded data (human-readable, widely supported).
+- Environment variables are the preferred configuration mechanism (consistent with Core patterns).
+- The recorder does not need to persist state across restarts (ephemeral recording).
+- Mock responses use USD as the default currency.
+- The recorder targets development/testing use cases, not production deployments.
+
+## Out of Scope
+
+- Replay functionality (playing back recorded requests to test plugins)
+- Encryption or compression of recorded data
+- Remote storage integration (S3, GCS, etc.)
+- Web UI for browsing recorded data
+- Real cloud cost lookups or integrations
+- Budget and Recommendation gRPC interfaces (future enhancement)

--- a/specs/104-recorder-plugin/tasks.md
+++ b/specs/104-recorder-plugin/tasks.md
@@ -1,0 +1,267 @@
+# Tasks: Reference Recorder Plugin for DevTools
+
+**Input**: Design documents from `/specs/104-recorder-plugin/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Per Constitution Principle II (Test-Driven Development), tests are MANDATORY and must be written BEFORE implementation. All code changes must maintain minimum 80% test coverage (95% for critical paths).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Plugin source**: `plugins/recorder/`
+- **Tests**: `plugins/recorder/*_test.go` (unit), `test/integration/` (integration)
+- **Build output**: `bin/pulumicost-plugin-recorder`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and basic structure
+
+- [x] T001 Create plugin directory structure at plugins/recorder/
+- [x] T002 [P] Initialize Go module for plugin with go.mod in plugins/recorder/ (using main module - monorepo pattern)
+- [x] T003 [P] Add pulumicost-spec v0.4.6+ dependency to plugins/recorder/go.mod (upgraded main go.mod to v0.4.6)
+- [x] T004 [P] Add Makefile target `build-recorder` in Makefile
+- [x] T005 [P] Create plugin.manifest.json in plugins/recorder/plugin.manifest.json
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T006 Implement Config struct and LoadConfig() in plugins/recorder/config.go
+- [x] T007 [P] Create RecorderPlugin struct with BasePlugin embedding in plugins/recorder/plugin.go
+- [x] T008 [P] Implement NewRecorderPlugin() factory in plugins/recorder/plugin.go
+- [x] T009 Implement Name() RPC handler in plugins/recorder/plugin.go
+- [x] T010 Implement main() with signal handling and pluginsdk.Serve() in plugins/recorder/cmd/main.go
+- [x] T011 [P] Add test for Config loading in plugins/recorder/config_test.go
+- [x] T012 [P] Add test for NewRecorderPlugin() in plugins/recorder/plugin_test.go
+- [x] T012a [P] Add test for both TCP and stdio communication modes in plugins/recorder/plugin_test.go
+
+**Checkpoint**: Foundation ready - plugin can start and respond to Name() calls
+
+---
+
+## Phase 3: User Story 1 - Request Data Inspection (Priority: P1) MVP
+
+**Goal**: Capture and serialize all gRPC requests to JSON files for developer inspection
+
+**Independent Test**: Run recorder with sample plan, verify JSON files created with full request data
+
+### Tests for User Story 1 (MANDATORY - TDD Required)
+
+- [x] T013 [P] [US1] Unit test for Recorder.Record() in plugins/recorder/recorder_test.go
+- [x] T014 [P] [US1] Unit test for generateFilename() ULID format in plugins/recorder/recorder_test.go
+- [x] T015 [P] [US1] Unit test for directory creation in plugins/recorder/recorder_test.go
+- [x] T016 [P] [US1] Integration test for request recording in test/integration/recorder_test.go (covered by unit tests)
+- [x] T016a [P] [US1] Unit test for malformed request handling in plugins/recorder/recorder_test.go
+
+### Implementation for User Story 1
+
+- [x] T017 [US1] Create Recorder struct in plugins/recorder/recorder.go
+- [x] T018 [US1] Implement NewRecorder() with output directory setup in plugins/recorder/recorder.go
+- [x] T019 [US1] Implement generateFilename() with ULID in plugins/recorder/recorder.go
+- [x] T020 [US1] Implement serializeRequest() using protojson in plugins/recorder/recorder.go
+- [x] T021 [US1] Implement Record() method to write JSON files in plugins/recorder/recorder.go
+- [x] T022 [US1] Wire Recorder into GetProjectedCost() handler in plugins/recorder/plugin.go
+- [x] T023 [US1] Wire Recorder into GetActualCost() handler in plugins/recorder/plugin.go
+- [x] T024 [US1] Add request validation using pluginsdk v0.4.6 helpers in plugins/recorder/plugin.go
+- [x] T025 [US1] Handle edge case: non-writable directory in plugins/recorder/recorder.go
+- [x] T026 [US1] Handle edge case: disk full (graceful degradation) in plugins/recorder/recorder.go
+
+**Checkpoint**: User Story 1 complete - recorder captures all requests to JSON files
+
+---
+
+## Phase 4: User Story 2 - Mock Response Generation (Priority: P2)
+
+**Goal**: Generate randomized but valid cost responses when mock mode is enabled
+
+**Independent Test**: Run recorder with MOCK_RESPONSE=true, verify randomized costs returned
+
+### Tests for User Story 2 (MANDATORY - TDD Required)
+
+- [x] T027 [P] [US2] Unit test for Mocker.GenerateProjectedCost() range in plugins/recorder/mocker_test.go
+- [x] T028 [P] [US2] Unit test for Mocker.GenerateActualCost() range in plugins/recorder/mocker_test.go
+- [x] T029 [P] [US2] Unit test for mock response structure validity in plugins/recorder/mocker_test.go
+- [x] T030 [P] [US2] Integration test for mock mode toggle in test/integration/recorder_test.go (covered by unit tests)
+
+### Implementation for User Story 2
+
+- [x] T031 [US2] Create Mocker struct in plugins/recorder/mocker.go
+- [x] T032 [US2] Implement NewMocker() constructor in plugins/recorder/mocker.go
+- [x] T033 [US2] Implement GenerateProjectedCost() with log-scale random in plugins/recorder/mocker.go
+- [x] T034 [US2] Implement CreateProjectedCostResponse() using SDK Calculator in plugins/recorder/mocker.go
+- [x] T035 [US2] Implement GenerateActualCost() for historical data mock in plugins/recorder/mocker.go
+- [x] T036 [US2] Implement CreateActualCostResponse() in plugins/recorder/mocker.go
+- [x] T037 [US2] Wire Mocker into GetProjectedCost() when MockResponse=true in plugins/recorder/plugin.go
+- [x] T038 [US2] Wire Mocker into GetActualCost() when MockResponse=true in plugins/recorder/plugin.go
+- [x] T039 [US2] Implement default (zero cost) response when MockResponse=false in plugins/recorder/plugin.go
+
+**Checkpoint**: User Story 2 complete - recorder returns mock costs when enabled
+
+---
+
+## Phase 5: User Story 3 - Reference Implementation Study (Priority: P3)
+
+**Goal**: Ensure code quality and documentation serve as exemplary reference implementation
+
+**Independent Test**: Code passes linting, achieves 80%+ coverage, demonstrates all SDK patterns
+
+### Tests for User Story 3 (MANDATORY - TDD Required)
+
+- [x] T040 [P] [US3] Verify 80%+ test coverage across all files in plugins/recorder/ (83.5% achieved)
+- [x] T041 [P] [US3] Verify all exported symbols have godoc comments in plugins/recorder/
+- [x] T041a [P] [US3] Add concurrent request stress test (100+ parallel requests) in plugins/recorder/recorder_test.go
+
+### Implementation for User Story 3
+
+- [x] T042 [P] [US3] Add comprehensive godoc comments to all exported types in plugins/recorder/
+- [x] T043 [P] [US3] Add inline code comments explaining SDK patterns in plugins/recorder/plugin.go
+- [x] T044 [US3] Create README.md with usage examples in plugins/recorder/README.md
+- [x] T045 [US3] Add zerolog structured logging throughout plugin in plugins/recorder/
+- [x] T046 [US3] Implement graceful shutdown with Shutdown() method in plugins/recorder/plugin.go
+- [x] T047 [US3] Ensure thread-safety with sync.Mutex in plugins/recorder/recorder.go
+- [x] T048 [US3] Run `make lint` and fix any issues in plugins/recorder/
+
+**Checkpoint**: User Story 3 complete - recorder is a high-quality reference implementation
+
+---
+
+## Phase 6: User Story 4 - Contract Testing Support (Priority: P4)
+
+**Goal**: Enable Core's integration tests to use recorder for contract testing
+
+**Independent Test**: Core's plugin integration tests pass using recorder as target
+
+### Tests for User Story 4 (MANDATORY - TDD Required)
+
+- [x] T049 [P] [US4] Integration test verifying plugin discovery in test/integration/recorder_test.go
+- [x] T050 [P] [US4] Contract test validating all RPC responses in test/integration/recorder_test.go
+
+### Implementation for User Story 4
+
+- [x] T051 [US4] Ensure binary builds to correct path bin/pulumicost-plugin-recorder
+- [x] T052 [US4] Add CI workflow step to build recorder in .github/workflows/ci.yml
+- [x] T053 [US4] Add CI workflow step to run recorder integration tests in .github/workflows/ci.yml
+- [x] T054 [US4] Create test fixture for recorder at test/fixtures/recorder/
+- [x] T055 [US4] Document plugin installation in quickstart for contract testing in plugins/recorder/README.md
+
+**Checkpoint**: User Story 4 complete - recorder works as contract test target
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final improvements and validation
+
+- [x] T056 [P] Run full test suite with `make test` and verify all pass
+- [x] T057 [P] Run `make lint` and verify clean output
+- [x] T058 [P] Verify cross-platform build with GOOS/GOARCH variations
+- [x] T058a [P] Add benchmark test validating <10ms recording overhead in plugins/recorder/recorder_test.go
+- [x] T059 Validate quickstart.md end-to-end from specs/104-recorder-plugin/quickstart.md
+- [x] T060 Run `pulumicost plugin validate` on installed recorder
+- [x] T061 Update CLAUDE.md with recorder plugin documentation
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-6)**: All depend on Foundational phase completion
+  - User stories can then proceed in priority order (P1 → P2 → P3 → P4)
+  - Each story builds on previous but remains independently testable
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - No dependencies on other stories - **MVP**
+- **User Story 2 (P2)**: Can start after US1 - Extends GetProjectedCost/GetActualCost handlers
+- **User Story 3 (P3)**: Can start after US2 - Improves quality of existing code
+- **User Story 4 (P4)**: Can start after US3 - Focuses on CI/CD integration
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Foundation before handlers
+- Handlers before edge cases
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- All Setup tasks marked [P] can run in parallel
+- All tests within a story marked [P] can run in parallel
+- Foundational tasks T007, T008, T011, T012 can run in parallel
+- Polish tasks T056, T057, T058 can run in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch all tests for User Story 1 together:
+Task: "Unit test for Recorder.Record() in plugins/recorder/recorder_test.go"
+Task: "Unit test for generateFilename() ULID format in plugins/recorder/recorder_test.go"
+Task: "Unit test for directory creation in plugins/recorder/recorder_test.go"
+Task: "Integration test for request recording in test/integration/recorder_test.go"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL - blocks all stories)
+3. Complete Phase 3: User Story 1 (Request Recording)
+4. **STOP and VALIDATE**: Test recorder captures requests to JSON
+5. Deploy/demo if ready - developers can now inspect request data
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add User Story 1 → Test independently → **MVP: Data Inspection works**
+3. Add User Story 2 → Test independently → Mock responses enabled
+4. Add User Story 3 → Test independently → Reference quality achieved
+5. Add User Story 4 → Test independently → CI/CD integration complete
+6. Each story adds value without breaking previous stories
+
+### Solo Developer Strategy
+
+Execute in priority order:
+
+1. Phase 1 (Setup): ~30 min
+2. Phase 2 (Foundation): ~1 hour
+3. Phase 3 (US1 - MVP): ~2 hours
+4. Phase 4 (US2): ~1.5 hours
+5. Phase 5 (US3): ~1 hour
+6. Phase 6 (US4): ~1 hour
+7. Phase 7 (Polish): ~30 min
+
+**Total Estimate**: ~8 hours for complete implementation
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Verify tests fail before implementing
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Constitution requires 80% coverage minimum, 95% for critical paths

--- a/test/fixtures/recorder/README.md
+++ b/test/fixtures/recorder/README.md
@@ -1,0 +1,3 @@
+# Recorder Test Fixtures
+
+This directory contains test fixtures for the recorder plugin.

--- a/test/integration/recorder_test.go
+++ b/test/integration/recorder_test.go
@@ -1,0 +1,133 @@
+// Package integration_test provides integration tests for the recorder plugin.
+package integration_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rshade/pulumicost-core/internal/pluginhost"
+	"github.com/rshade/pulumicost-core/internal/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRecorderPlugin_Integration verifies that the recorder plugin can be discovered and used.
+func TestRecorderPlugin_Integration(t *testing.T) {
+	// Locate the plugin binary
+	_, filename, _, _ := runtime.Caller(0)
+	projectRoot := filepath.Join(filepath.Dir(filename), "../..")
+	binPath := filepath.Join(projectRoot, "bin", "pulumicost-plugin-recorder")
+
+	if runtime.GOOS == "windows" {
+		binPath += ".exe"
+	}
+
+	// Verify binary exists
+	if _, err := os.Stat(binPath); os.IsNotExist(err) {
+		t.Skipf("Plugin binary not found at %s. Run 'make build-recorder' first.", binPath)
+	}
+
+	// Create a temporary directory for recording
+	tempDir, err := os.MkdirTemp("", "recorder-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Configure environment variables for the plugin process
+	// Using t.Setenv ensures automatic cleanup and isolation
+	t.Setenv("PULUMICOST_RECORDER_OUTPUT_DIR", tempDir)
+	t.Setenv("PULUMICOST_RECORDER_MOCK_RESPONSE", "true")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Launch the plugin
+	launcher := pluginhost.NewProcessLauncher()
+	client, err := pluginhost.NewClient(ctx, launcher, binPath)
+	require.NoError(t, err, "Failed to launch recorder plugin")
+	defer client.Close()
+
+	// T049: Verify discovery/name
+	assert.Equal(t, "recorder", client.Name)
+
+	// T050: Contract test - Validate RPC responses
+
+	// 1. GetProjectedCost
+	reqProjected := &proto.GetProjectedCostRequest{
+		Resources: []*proto.ResourceDescriptor{
+			{
+				Type:     "aws:ec2/instance:Instance",
+				Provider: "aws",
+				Properties: map[string]string{
+					"instanceType":     "t3.micro",
+					"availabilityZone": "us-east-1a", // For region extraction
+				},
+			},
+		},
+	}
+
+	respProjected, err := client.API.GetProjectedCost(ctx, reqProjected)
+	require.NoError(t, err)
+	require.NotEmpty(t, respProjected.Results)
+
+	result := respProjected.Results[0]
+	assert.Equal(t, "USD", result.Currency)
+	// Since we enabled mock response, we expect non-zero cost
+	assert.Greater(t, result.MonthlyCost, 0.0)
+
+	// 2. GetActualCost
+	now := time.Now()
+	start := now.Add(-24 * time.Hour).Unix()
+	end := now.Unix()
+
+	reqActual := &proto.GetActualCostRequest{
+		ResourceIDs: []string{"i-1234567890abcdef0"},
+		StartTime:   start,
+		EndTime:     end,
+	}
+
+	respActual, err := client.API.GetActualCost(ctx, reqActual)
+	require.NoError(t, err)
+	assert.NotEmpty(t, respActual.Results)
+
+	// Verify that files were recorded
+	// The recorder plugin writes files asynchronously; poll with timeout
+	var files []os.DirEntry
+	require.Eventually(t, func() bool {
+		var err error
+		files, err = os.ReadDir(tempDir)
+		return err == nil && len(files) >= 2
+	}, 2*time.Second, 50*time.Millisecond, "Expected recorded JSON files")
+
+	// Check file content
+	foundProjected := false
+	foundActual := false
+
+	for _, file := range files {
+		contentBytes, err := os.ReadFile(filepath.Join(tempDir, file.Name()))
+		require.NoError(t, err)
+		content := string(contentBytes)
+
+		if strings.Contains(content, "method") {
+			if strings.Contains(content, "GetProjectedCost") {
+				assert.Contains(
+					t, content, "aws:ec2/instance:Instance",
+					"GetProjectedCost file should contain resource type",
+				)
+				foundProjected = true
+			} else if strings.Contains(content, "GetActualCost") {
+				assert.Contains(
+					t, content, "i-1234567890abcdef0",
+					"GetActualCost file should contain resource ID",
+				)
+				foundActual = true
+			}
+		}
+	}
+	assert.True(t, foundProjected, "Should have recorded a GetProjectedCost request")
+	assert.True(t, foundActual, "Should have recorded a GetActualCost request")
+}


### PR DESCRIPTION
Implements reference recorder plugin that captures all gRPC requests to JSON files and optionally returns mock cost responses. This plugin serves as both a developer debugging tool and a canonical reference implementation demonstrating pluginsdk v0.4.6 patterns.

- **Request Recording**: Captures gRPC requests to JSON with ULID filenames
- **Mock Responses**: Optional randomized but valid cost responses for testing
- **Thread Safety**: sync.Mutex protection for concurrent request handling
- **Graceful Degradation**: Handles disk full and permission errors safely

- `plugins/recorder/` - Complete plugin implementation:
  - `plugin.go` - CostSourceService implementation with pluginsdk v0.4.6
  - `recorder.go` - Request serialization with improved disk error detection
  - `mocker.go` - Mock response generation with randomized costs
  - `config.go` - Environment variable configuration
  - `cmd/main.go` - Entry point with signal handling
- `test/integration/recorder_test.go` - Integration tests for plugin
- `test/fixtures/recorder/` - Test fixtures for recorder plugin testing
- `.github/workflows/ci.yml` - Added recorder build and test jobs
- `Makefile` - Added `build-recorder` target
- `.gitignore` - Added `recorded_data/` output directory
- `CLAUDE.md` - Added comprehensive recorder plugin documentation

Environment variables:

- `PULUMICOST_RECORDER_OUTPUT_DIR` (default: `./recorded_data`)
- `PULUMICOST_RECORDER_MOCK_RESPONSE` (default: `false`)

- [x] Unit tests pass with 86.3% coverage (`go test ./plugins/recorder/...`)
- [x] Integration tests pass (`go test ./test/integration/recorder_test.go`)
- [x] Benchmark validates less than 10ms recording overhead
- [x] Cross-platform builds verified (linux/darwin/windows, amd64/arm64)
- [x] Plugin discovery works (`pulumicost plugin list`)
- [x] Plugin validation passes (`pulumicost plugin validate`)
- [x] Quickstart workflow validated (recording and mock modes)
- [x] Linting passes (`make lint`)
- [x] All validation passes (`make validate`)

fixes #274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Recorder Plugin that logs cost API requests to disk and can emit mock cost responses for testing.

* **Documentation**
  * Added comprehensive docs and README for the Recorder Plugin with config, usage, and examples.

* **Tests**
  * Added unit and integration tests validating recorder behavior, mock responses, concurrency, and file output.

* **Chores**
  * CI updated to build and run integration tests for the plugin; new make targets for building/installing the plugin; gitignore updated for recorded data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->