### PR TITLE
feat(proto): add pre-flight request validation using pluginsdk

### DIFF
--- a/specs/107-preflight-validation/checklists/requirements.md
+++ b/specs/107-preflight-validation/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Pre-Flight Request Validation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on first iteration
+- Issue #233 provided sufficient detail to avoid clarification questions
+- pluginsdk validation functions already exist (v0.4.11), so the "Blocked by" dependency noted in the issue is resolved
+- Ready for `/speckit.clarify` or `/speckit.plan`

--- a/specs/107-preflight-validation/data-model.md
+++ b/specs/107-preflight-validation/data-model.md
@@ -1,0 +1,121 @@
+# Data Model: Pre-Flight Request Validation
+
+**Feature**: 107-preflight-validation
+**Date**: 2025-12-29
+
+## Existing Types (No Changes Required)
+
+This feature uses existing types - no new data model entities are introduced.
+
+### CostResult (internal/proto/adapter.go:210-219)
+
+```go
+type CostResult struct {
+    Currency       string
+    MonthlyCost    float64
+    HourlyCost     float64
+    Notes          string                          // ← Validation errors go here
+    CostBreakdown  map[string]float64
+    Sustainability map[string]SustainabilityMetric
+}
+```
+
+**Validation Error Pattern**: `Notes: "VALIDATION: <error message>"`
+
+### ActualCostResult (internal/proto/adapter.go:240-247)
+
+```go
+type ActualCostResult struct {
+    Currency       string
+    TotalCost      float64
+    CostBreakdown  map[string]float64
+    Sustainability map[string]SustainabilityMetric
+}
+```
+
+**Note**: ActualCostResult doesn't have a Notes field. Validation errors for actual cost are tracked through the existing ErrorDetail mechanism.
+
+### ErrorDetail (internal/proto/adapter.go:21-28)
+
+```go
+type ErrorDetail struct {
+    ResourceType string
+    ResourceID   string
+    PluginName   string
+    Error        error                            // ← Wrapped validation error
+    Timestamp    time.Time
+}
+```
+
+**Validation Error Pattern**: `Error: fmt.Errorf("pre-flight validation failed: %w", validationErr)`
+
+### CostResultWithErrors (internal/proto/adapter.go:30-34)
+
+```go
+type CostResultWithErrors struct {
+    Results []*CostResult
+    Errors  []ErrorDetail
+}
+```
+
+**Behavior**: Validation errors are captured in `Errors` slice alongside plugin errors. The `HasErrors()` and `ErrorSummary()` methods work unchanged.
+
+## Protobuf Types (from pluginsdk)
+
+### pbc.GetProjectedCostRequest
+
+```go
+// Validated by pluginsdk.ValidateProjectedCostRequest()
+type GetProjectedCostRequest struct {
+    Resource *ResourceDescriptor
+}
+
+type ResourceDescriptor struct {
+    Id           string
+    Provider     string              // REQUIRED: must be non-empty
+    ResourceType string              // REQUIRED: must be non-empty
+    Sku          string              // REQUIRED: must be non-empty
+    Region       string              // REQUIRED: must be non-empty
+    Tags         map[string]string
+    Utilization  float64             // OPTIONAL: if set, must be 0.0-1.0
+}
+```
+
+### pbc.GetActualCostRequest
+
+```go
+// Validated by pluginsdk.ValidateActualCostRequest()
+type GetActualCostRequest struct {
+    ResourceId string               // REQUIRED: must be non-empty
+    Start      *timestamppb.Timestamp // REQUIRED: must be non-nil
+    End        *timestamppb.Timestamp // REQUIRED: must be non-nil, must be after Start
+    Tags       map[string]string
+}
+```
+
+## Validation Rules Summary
+
+| Field | Rule | Error Message |
+|-------|------|---------------|
+| Provider | Non-empty | "provider is empty" |
+| ResourceType | Non-empty | "resourceType is empty" |
+| SKU | Non-empty | "SKU is empty: use mapping.ExtractAWSSKU()..." |
+| Region | Non-empty | "region is empty: use mapping.ExtractAWSRegion()..." |
+| Utilization | 0.0 ≤ x ≤ 1.0 | "utilization must be between 0.0 and 1.0" |
+| ResourceId | Non-empty | "resourceId is empty" |
+| Start | Non-nil | "start time is required" |
+| End | Non-nil, > Start | "end time is required" / "end time must be after start time" |
+
+## State Transitions
+
+N/A - Validation is stateless. Each request is validated independently.
+
+## Relationships
+
+```text
+GetProjectedCostRequest (internal) → pbc.GetProjectedCostRequest (proto) → Validation → gRPC call
+                                      ↑
+                                      └── resolveSKUAndRegion() extracts SKU/Region from Properties
+```
+
+The validation occurs after the internal request is converted to a protobuf request but before the gRPC call is made.

--- a/specs/107-preflight-validation/plan.md
+++ b/specs/107-preflight-validation/plan.md
@@ -1,0 +1,225 @@
+# Implementation Plan: Pre-Flight Request Validation
+
+**Branch**: `107-preflight-validation` | **Date**: 2025-12-29 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/107-preflight-validation/spec.md`
+
+## Summary
+
+Integrate `pluginsdk.ValidateProjectedCostRequest()` and `pluginsdk.ValidateActualCostRequest()` from pulumicost-spec v0.4.11+ for pre-flight request validation in `internal/proto/adapter.go`. This catches malformed requests before gRPC calls to plugins, providing actionable error messages and reducing plugin round-trip latency for invalid requests.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.5
+**Primary Dependencies**: github.com/rshade/pulumicost-spec/sdk/go/pluginsdk v0.4.11+, zerolog v1.34.0
+**Storage**: N/A (validation is stateless)
+**Testing**: go test with table-driven tests, mock clients
+**Target Platform**: Linux (amd64, arm64), macOS (amd64, arm64), Windows (amd64)
+**Project Type**: Single CLI tool
+**Performance Goals**: <100ns per validation call (zero-allocation happy path)
+**Constraints**: No breaking changes to existing API signatures
+**Scale/Scope**: Validates 1-1000 resources per request
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Verify compliance with PulumiCost Core Constitution (`.specify/memory/constitution.md`):
+
+- [x] **Plugin-First Architecture**: This is orchestration logic in Core that uses shared pluginsdk validation - not a provider integration
+- [x] **Test-Driven Development**: Unit tests planned for all validation integration points (80%+ coverage target)
+- [x] **Cross-Platform Compatibility**: Pure Go code, no platform-specific behavior
+- [x] **Documentation as Code**: Will update CLAUDE.md with validation patterns
+- [x] **Protocol Stability**: Uses existing pluginsdk functions, no protocol changes
+- [x] **Implementation Completeness**: All validation paths fully implemented, no stubs or TODOs
+- [x] **Quality Gates**: Will run make lint && make test before completion
+- [x] **Multi-Repo Coordination**: Depends on pluginsdk v0.4.11+ (already integrated)
+
+**Violations Requiring Justification**: None
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/107-preflight-validation/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (minimal - dependencies resolved)
+├── data-model.md        # Phase 1 output (existing types, no new entities)
+├── quickstart.md        # Phase 1 output (usage examples)
+├── contracts/           # Phase 1 output (N/A - internal API, no external contracts)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+internal/proto/
+├── adapter.go           # Primary integration point - add validation calls
+└── adapter_test.go      # Add validation test cases
+
+internal/logging/
+└── logging.go           # Existing - use FromContext for WARN logs
+```
+
+**Structure Decision**: Minimal footprint - validation is added to existing functions in `adapter.go`. No new files needed. Test cases added to existing `adapter_test.go`.
+
+## Complexity Tracking
+
+No Constitution violations - this is a straightforward integration of existing pluginsdk functions.
+
+## Design Decisions
+
+### D1: Validation Location
+
+**Decision**: Validate in `clientAdapter.GetProjectedCost()` and `clientAdapter.GetActualCost()` methods (adapter layer), not in the higher-level `GetProjectedCostWithErrors`/`GetActualCostWithErrors` functions.
+
+**Rationale**:
+
+- The adapter methods construct the protobuf request (`pbc.GetProjectedCostRequest`), which is what `pluginsdk.ValidateProjectedCostRequest()` validates
+- Validation after request construction, before gRPC call maximizes coverage
+- Higher-level functions deal with internal types, not protobuf types
+
+### D2: Error Handling Strategy
+
+**Decision**: On validation failure, return an error from the adapter method (consistent with existing error handling).
+
+**Rationale**:
+
+- The existing pattern in `GetProjectedCostWithErrors` already handles errors from `client.GetProjectedCost()` calls
+- Validation errors will be captured in `ErrorDetail` with "pre-flight validation failed" prefix
+- Maintains consistency with existing error tracking infrastructure
+
+### D3: Logging Integration
+
+**Decision**: Log validation failures at WARN level using `logging.FromContext(ctx)` before returning the error.
+
+**Rationale**:
+
+- Consistent with existing logging patterns in the codebase
+- WARN level is appropriate for user-fixable issues
+- Context propagation ensures trace_id correlation
+
+### D4: Notes Prefix for Validation Errors
+
+**Decision**: Use `"VALIDATION: %v"` prefix in Notes field to distinguish from plugin errors (which use `"ERROR: %v"`).
+
+**Rationale**:
+
+- Meets SC-002: "Validation errors are distinguished from plugin errors"
+- Clear visual distinction in output
+- Users can grep/filter on prefix
+
+## Integration Points
+
+### GetProjectedCost (adapter.go:427-491)
+
+```go
+// Current: constructs pbc.GetProjectedCostRequest then calls c.client.GetProjectedCost
+// Change: Add validation after request construction, before gRPC call
+
+func (c *clientAdapter) GetProjectedCost(...) (*GetProjectedCostResponse, error) {
+    for _, resource := range in.Resources {
+        sku, region := resolveSKUAndRegion(resource.Provider, resource.Properties)
+
+        req := &pbc.GetProjectedCostRequest{
+            Resource: &pbc.ResourceDescriptor{...},
+        }
+
+        // NEW: Pre-flight validation
+        if err := pluginsdk.ValidateProjectedCostRequest(req); err != nil {
+            log := logging.FromContext(ctx)
+            log.Warn().Ctx(ctx).
+                Str("resource_type", resource.Type).
+                Err(err).
+                Msg("pre-flight validation failed")
+            // Skip this resource, append placeholder result
+            results = append(results, &CostResult{
+                Currency:    "USD",
+                MonthlyCost: 0,
+                Notes:       fmt.Sprintf("VALIDATION: %v", err),
+            })
+            continue
+        }
+
+        resp, err := c.client.GetProjectedCost(ctx, req, opts...)
+        // ... existing handling
+    }
+}
+```
+
+### GetActualCost (adapter.go:493-560)
+
+```go
+// Similar pattern for actual cost validation
+func (c *clientAdapter) GetActualCost(...) (*GetActualCostResponse, error) {
+    for _, resourceID := range in.ResourceIDs {
+        req := &pbc.GetActualCostRequest{
+            ResourceId: resourceID,
+            Start:      timestamppb.New(time.Unix(in.StartTime, 0)),
+            End:        timestamppb.New(time.Unix(in.EndTime, 0)),
+            Tags:       make(map[string]string),
+        }
+
+        // NEW: Pre-flight validation
+        if err := pluginsdk.ValidateActualCostRequest(req); err != nil {
+            log := logging.FromContext(ctx)
+            log.Warn().Ctx(ctx).
+                Str("resource_id", resourceID).
+                Err(err).
+                Msg("pre-flight validation failed for actual cost")
+            // Skip this resource, append placeholder result
+            results = append(results, &ActualCostResult{
+                Currency:   "USD",
+                TotalCost:  0,
+            })
+            continue
+        }
+
+        resp, err := c.client.GetActualCost(ctx, req, opts...)
+        // ... existing handling
+    }
+}
+```
+
+## Test Strategy
+
+### Unit Tests to Add (adapter_test.go)
+
+1. **TestGetProjectedCost_ValidationFailure_EmptyProvider**
+   - Input: Resource with empty Provider field
+   - Expected: VALIDATION note, no gRPC call made
+
+2. **TestGetProjectedCost_ValidationFailure_EmptySKU**
+   - Input: Resource with empty SKU (no instanceType in properties)
+   - Expected: VALIDATION note, no gRPC call made
+
+3. **TestGetProjectedCost_ValidationFailure_EmptyRegion**
+   - Input: Resource with empty region (no region/availabilityZone)
+   - Expected: VALIDATION note, no gRPC call made
+
+4. **TestGetProjectedCost_ValidationFailure_MixedValidInvalid**
+   - Input: [valid resource, invalid resource, valid resource]
+   - Expected: Valid resources call plugin, invalid gets VALIDATION note
+
+5. **TestGetActualCost_ValidationFailure_EmptyResourceID**
+   - Input: Empty resource ID
+   - Expected: VALIDATION note, no gRPC call made
+
+6. **TestGetActualCost_ValidationFailure_InvalidTimeRange**
+   - Input: EndTime before StartTime
+   - Expected: VALIDATION note, no gRPC call made
+
+### Test Coverage Target
+
+- `clientAdapter.GetProjectedCost`: 95% (critical path)
+- `clientAdapter.GetActualCost`: 95% (critical path)
+- Overall `internal/proto`: 85%+
+
+## Implementation Sequence
+
+1. **Add import** for `pluginsdk` package (already importing `mapping` subpackage)
+2. **Add validation to GetProjectedCost** with logging and placeholder results
+3. **Add validation to GetActualCost** with logging and placeholder results
+4. **Add unit tests** for all validation failure scenarios
+5. **Run make lint && make test** to verify quality gates
+6. **Update CLAUDE.md** with validation pattern documentation

--- a/specs/107-preflight-validation/quickstart.md
+++ b/specs/107-preflight-validation/quickstart.md
@@ -1,0 +1,143 @@
+# Quickstart: Pre-Flight Request Validation
+
+**Feature**: 107-preflight-validation
+**Date**: 2025-12-29
+
+## Overview
+
+Pre-flight validation catches malformed requests before they reach plugins, providing actionable error messages that help users fix issues quickly.
+
+## What Changes
+
+### Before (without pre-flight validation)
+
+```bash
+$ pulumicost cost projected --pulumi-json plan.json
+
+# Generic error from plugin (after waiting for gRPC call)
+ERROR: rpc error: code = InvalidArgument desc = invalid request
+```
+
+### After (with pre-flight validation)
+
+```bash
+$ pulumicost cost projected --pulumi-json plan.json
+
+# Clear validation error with guidance (no plugin call made)
+VALIDATION: SKU is empty: use mapping.ExtractAWSSKU() or mapping.ExtractSKU() to extract from resource properties
+
+# Resource still appears in output with $0.00 cost
+Resource                  | Monthly Cost | Notes
+aws:ec2:Instance         | $0.00        | VALIDATION: SKU is empty...
+```
+
+## How to Fix Common Validation Errors
+
+### "provider is empty"
+
+**Cause**: The Pulumi plan doesn't include provider information for the resource.
+
+**Fix**: Ensure your Pulumi program uses explicit provider configuration:
+
+```typescript
+// Pulumi TypeScript
+const instance = new aws.ec2.Instance("my-instance", {
+    instanceType: "t3.micro",
+    // ...
+});
+```
+
+### "SKU is empty"
+
+**Cause**: The resource doesn't have instance type/size information.
+
+**Fix**: Ensure your resource includes sizing properties:
+
+```typescript
+// EC2 Instance - instanceType is required
+const instance = new aws.ec2.Instance("my-instance", {
+    instanceType: "t3.micro",  // ← Required for cost calculation
+    ami: "ami-12345678",
+});
+
+// RDS Instance - instanceClass is required
+const db = new aws.rds.Instance("my-db", {
+    instanceClass: "db.t3.micro",  // ← Required for cost calculation
+    engine: "postgres",
+});
+```
+
+### "region is empty"
+
+**Cause**: The resource doesn't include region information.
+
+**Fix**: Either include region in resource properties or set environment variables:
+
+```bash
+# Option 1: Environment variable
+export AWS_REGION=us-east-1
+pulumicost cost projected --pulumi-json plan.json
+
+# Option 2: Ensure Pulumi plan includes availabilityZone
+```
+
+### "end time must be after start time"
+
+**Cause**: The `--end` flag is before the `--start` flag for actual cost queries.
+
+**Fix**: Correct the time range:
+
+```bash
+# Wrong
+pulumicost cost actual --start 2025-01-15 --end 2025-01-01
+
+# Correct
+pulumicost cost actual --start 2025-01-01 --end 2025-01-15
+```
+
+## Debug Logging
+
+Enable debug logging to see validation failures with full context:
+
+```bash
+$ pulumicost cost projected --debug --pulumi-json plan.json
+
+# Log output includes:
+# {"level":"warn","resource_type":"aws:ec2:Instance","error":"SKU is empty...","trace_id":"...","message":"pre-flight validation failed"}
+```
+
+## Output Format
+
+Validation errors appear in the Notes column with a `VALIDATION:` prefix to distinguish them from plugin errors (which use `ERROR:`):
+
+| Prefix | Source | Example |
+|--------|--------|---------|
+| `VALIDATION:` | Pre-flight check | Missing SKU, empty provider |
+| `ERROR:` | Plugin call | Connection refused, timeout |
+
+## Testing Validation Behavior
+
+To verify validation is working correctly:
+
+```bash
+# Create a minimal plan with missing data
+cat > test-plan.json << 'EOF'
+{
+  "steps": [
+    {
+      "op": "create",
+      "urn": "urn:pulumi:dev::test::aws:ec2:Instance::my-instance",
+      "newState": {
+        "type": "aws:ec2:Instance",
+        "inputs": {}
+      }
+    }
+  ]
+}
+EOF
+
+# Run with validation
+pulumicost cost projected --pulumi-json test-plan.json
+
+# Expected: VALIDATION error for missing instanceType (SKU)
+```

--- a/specs/107-preflight-validation/research.md
+++ b/specs/107-preflight-validation/research.md
@@ -1,0 +1,87 @@
+# Research: Pre-Flight Request Validation
+
+**Feature**: 107-preflight-validation
+**Date**: 2025-12-29
+
+## Dependencies Resolution
+
+### pluginsdk Validation Functions
+
+**Decision**: Use `pluginsdk.ValidateProjectedCostRequest()` and `pluginsdk.ValidateActualCostRequest()` from pulumicost-spec v0.4.11+.
+
+**Rationale**:
+
+- Functions are already designed for dual-use (Core pre-flight + Plugin defense-in-depth)
+- Zero-allocation on happy path (<100ns target)
+- Actionable error messages guide users to fix issues
+- Already integrated in current go.mod (v0.4.11)
+
+**Alternatives considered**:
+
+- Custom validation in Core: Rejected - duplicates logic, creates drift risk
+- No validation: Rejected - poor UX with cryptic plugin errors
+
+### Validation Order (from pluginsdk documentation)
+
+`ValidateProjectedCostRequest` checks (fail-fast):
+
+1. Request nil check
+2. Resource nil check
+3. Provider empty check
+4. ResourceType empty check
+5. SKU empty check (with mapping helper guidance)
+6. Region empty check (with mapping helper guidance)
+7. Global utilization range check (if non-zero)
+8. Resource-level utilization range check (if provided)
+
+`ValidateActualCostRequest` checks (fail-fast):
+
+1. Request nil check
+2. ResourceId empty check
+3. StartTime nil check
+4. EndTime nil check
+5. TimeRange validation (EndTime must be after StartTime)
+
+### Logging Integration
+
+**Decision**: Use `logging.FromContext(ctx)` for structured logging with trace_id.
+
+**Rationale**:
+
+- Already established pattern in codebase
+- Trace ID correlation for debugging
+- WARN level appropriate for user-fixable issues
+
+**Alternatives considered**:
+
+- Direct zerolog: Rejected - loses context/trace_id
+- DEBUG level: Rejected - validation failures are noteworthy, not verbose debug
+
+## Technical Research
+
+### Import Path
+
+```go
+// Current import (for mapping)
+import "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk/mapping"
+
+// New import needed (for validation)
+import "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+```
+
+Both imports can coexist since `mapping` is a subpackage.
+
+### Error Message Format
+
+pluginsdk validation errors are structured as actionable messages:
+
+- `"SKU is empty: use mapping.ExtractAWSSKU() or mapping.ExtractSKU() to extract from resource properties"`
+- `"provider is empty"`
+- `"resourceType is empty"`
+- `"region is empty: use mapping.ExtractAWSRegion() or mapping.ExtractRegion() to extract from resource properties"`
+
+These messages directly guide users to fix issues.
+
+## No Outstanding Research Items
+
+All dependencies are resolved. No NEEDS CLARIFICATION items remain.

--- a/specs/107-preflight-validation/spec.md
+++ b/specs/107-preflight-validation/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: Pre-Flight Request Validation
+
+**Feature Branch**: `107-preflight-validation`
+**Created**: 2025-12-29
+**Status**: Draft
+**Input**: GitHub Issue #233 - Adopt pluginsdk/validation.go for pre-flight request validation
+
+## User Scenarios & Testing
+
+### User Story 1 - Clear Error Messages Before Plugin Calls (Priority: P1)
+
+As a developer using pulumicost to estimate infrastructure costs, I want to receive clear, actionable error messages when my resource definitions are incomplete, so that I can fix issues before waiting for plugin timeouts or cryptic gRPC errors.
+
+**Why this priority**: This directly addresses the core user pain point - generic "InvalidArgument" errors from plugins provide no guidance on what's wrong. Pre-flight validation with actionable messages ("SKU empty - use mapping.ExtractAWSSKU()") helps developers fix issues quickly.
+
+**Independent Test**: Can be fully tested by running `pulumicost cost projected` with an incomplete Pulumi plan (missing instance type) and verifying the error message includes specific guidance.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Pulumi plan with an EC2 instance missing the `instanceType` property, **When** the user runs `pulumicost cost projected --pulumi-json plan.json`, **Then** the output shows a warning with guidance about the missing SKU and the resource is marked with $0.00 cost and an explanatory note.
+
+2. **Given** a Pulumi plan with resources from multiple providers where some are valid and some are missing region, **When** the user runs projected cost calculation, **Then** valid resources return costs while invalid ones show validation errors with specific missing fields.
+
+3. **Given** a resource with empty provider field, **When** pre-flight validation runs, **Then** the error message indicates "provider is empty" and processing continues with a placeholder result.
+
+---
+
+### User Story 2 - Consistent Validation Between Core and Plugins (Priority: P2)
+
+As a plugin developer, I want Core to use the same validation logic that plugins use, so that validation behavior is predictable and plugins don't receive requests that would fail the same validation checks.
+
+**Why this priority**: Consistency reduces debugging complexity - if Core validates using the same rules, plugins won't receive malformed requests that they would also reject, eliminating redundant error paths.
+
+**Independent Test**: Can be tested by comparing validation results between Core pre-flight checks and plugin-side validation for the same malformed request.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Core uses `pluginsdk.ValidateProjectedCostRequest()`, **When** a request would fail plugin-side validation, **Then** it fails Core pre-flight validation with the same error type.
+
+2. **Given** a valid request passes Core pre-flight validation, **When** sent to a conformant plugin, **Then** it should not fail plugin-side validation.
+
+---
+
+### User Story 3 - Debug Logging for Validation Failures (Priority: P3)
+
+As an operator troubleshooting cost calculation issues, I want validation failures to be logged with full context (resource type, trace ID), so that I can diagnose issues in production without enabling verbose debugging.
+
+**Why this priority**: Observability is important but not critical for MVP - the feature works without detailed logging, but logging improves operability.
+
+**Independent Test**: Can be tested by running with `--debug` flag and verifying validation failures appear in logs with resource context.
+
+**Acceptance Scenarios**:
+
+1. **Given** debug logging is enabled, **When** pre-flight validation fails for a resource, **Then** the log entry includes resource_type, trace_id, and the validation error.
+
+2. **Given** normal logging level, **When** pre-flight validation fails, **Then** a WARN-level message appears with the resource type and error summary.
+
+---
+
+### Edge Cases
+
+- What happens when all resources in a request fail validation? The command should still complete with all placeholder results showing validation errors.
+- What happens when validation fails but the resource would have been skipped anyway (unsupported provider)? Validation failure takes precedence and is reported.
+- What happens with partially populated properties (SKU present but region empty)? Each field is validated independently; only the first failure is reported (fail-fast).
+- How are utilization range errors reported? If utilization is outside [0.0, 1.0], the error message includes the invalid value.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST call `pluginsdk.ValidateProjectedCostRequest()` for each resource before making the gRPC call to the plugin.
+- **FR-002**: System MUST call `pluginsdk.ValidateActualCostRequest()` before making actual cost gRPC calls.
+- **FR-003**: When validation fails, System MUST add a placeholder CostResult with MonthlyCost=0 and Notes containing the validation error.
+- **FR-004**: When validation fails, System MUST log the failure at WARN level with resource context (type, trace_id, error).
+- **FR-005**: When validation fails, System MUST continue processing remaining resources (fail-fast per resource, not per batch).
+- **FR-006**: Validation errors MUST be included in the ErrorDetail slice returned by `GetProjectedCostWithErrors`.
+- **FR-007**: System MUST NOT send requests to plugins when pre-flight validation fails.
+
+### Key Entities
+
+- **CostResultWithErrors**: Extended with ErrorDetail entries for validation failures (existing type, new error category).
+- **ErrorDetail**: Captures validation failure context including resource type, error message, and timestamp (existing type, new error source).
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Users can identify and fix resource definition issues from the error message alone without needing to inspect debug logs.
+- **SC-002**: Validation errors are distinguished from plugin errors in the output (different error prefix or note format).
+- **SC-003**: Resources with validation errors appear in output with $0.00 cost and explanatory note rather than being silently dropped.
+- **SC-004**: Processing time for malformed resources is reduced by avoiding plugin round-trips (pre-flight validation is faster than plugin call + error).
+
+## Dependencies
+
+- **pluginsdk v0.4.11+**: Already integrated - contains `ValidateProjectedCostRequest()` and `ValidateActualCostRequest()` functions.
+- **zerolog logging**: Already integrated for structured logging with trace ID support.
+
+## Assumptions
+
+- The pluginsdk validation functions provide error messages that are sufficiently actionable for users (verified by reviewing function documentation).
+- Existing error handling patterns in `GetProjectedCostWithErrors` and `GetActualCostWithErrors` support the addition of validation-specific errors.
+- The fail-fast per-resource approach (continue processing remaining resources) is the desired behavior rather than batch failure.
+- Performance impact of validation is negligible (<100ns per resource as documented in pluginsdk).
+
+## Out of Scope
+
+- Changing the pluginsdk validation logic itself (that's in pulumicost-spec).
+- Adding validation for GetRecommendations requests (future enhancement if needed).
+- Retry logic for validation failures (validation failures are deterministic, not transient).

--- a/specs/107-preflight-validation/tasks.md
+++ b/specs/107-preflight-validation/tasks.md
@@ -1,0 +1,171 @@
+# Tasks: Pre-Flight Request Validation
+
+**Input**: Design documents from `/specs/107-preflight-validation/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Tests**: Per Constitution Principle II (Test-Driven Development), tests are MANDATORY and
+must be written BEFORE implementation. All code changes must maintain minimum 80% test coverage
+(95% for critical paths).
+
+**Completeness**: Per Constitution Principle VI (Implementation Completeness), all tasks MUST be
+fully implemented. Stub functions, placeholders, and TODO comments are strictly forbidden.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Add required import for pluginsdk validation
+
+- [x] T001 [US1] Add pluginsdk import to `internal/proto/adapter.go` alongside existing mapping import
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No foundational work needed - existing infrastructure supports this feature
+
+**Note**: The following already exist and require no changes:
+
+- `logging.FromContext(ctx)` for structured logging with trace_id
+- `CostResult.Notes` field for validation error messages
+- `CostResultWithErrors.Errors` for ErrorDetail tracking
+- pluginsdk v0.4.11 already in go.mod
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Clear Error Messages Before Plugin Calls (Priority: P1) 🎯 MVP
+
+**Goal**: Provide actionable validation errors for GetProjectedCost requests before sending to plugins
+
+**Independent Test**: Run `pulumicost cost projected --pulumi-json plan.json` with incomplete
+plan and verify VALIDATION: prefix in notes
+
+### Tests for User Story 1 (MANDATORY - TDD Required) ⚠️
+
+> **CONSTITUTION REQUIREMENT: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T002 [P] [US1] Unit test `TestGetProjectedCost_ValidationFailure_EmptyProvider` in `internal/proto/adapter_test.go`
+- [x] T003 [P] [US1] Unit test `TestGetProjectedCost_ValidationFailure_EmptySKU` in `internal/proto/adapter_test.go`
+- [x] T004 [P] [US1] Unit test `TestGetProjectedCost_ValidationFailure_EmptyRegion` in `internal/proto/adapter_test.go`
+- [x] T005 [P] [US1] Unit test `TestGetProjectedCost_ValidationFailure_MixedValidInvalid` in `internal/proto/adapter_test.go`
+
+### Implementation for User Story 1
+
+- [x] T006 [US1] Add pre-flight validation call after request construction in `GetProjectedCostWithErrors()` at `internal/proto/adapter.go:68-162`
+- [x] T007 [US1] Add WARN-level logging with resource_type and trace_id context for validation failures
+- [x] T008 [US1] Add placeholder CostResult with `Notes: "VALIDATION: <error>"` on validation failure
+- [x] T009 [US1] Verify tests pass with `go test -v ./internal/proto/... -run TestGetProjectedCost_ValidationFailure`
+
+**Checkpoint**: User Story 1 complete - GetProjectedCost validation works with actionable error messages
+
+---
+
+## Phase 4: User Story 2 - Consistent Validation for Actual Costs (Priority: P2)
+
+**Goal**: Apply same validation pattern to GetActualCost requests for consistency
+
+**Independent Test**: Test actual cost validation with empty resourceId or invalid time range
+
+### Tests for User Story 2 (MANDATORY - TDD Required) ⚠️
+
+- [x] T010 [P] [US2] Unit test `TestGetActualCost_ValidationFailure_EmptyResourceID` in `internal/proto/adapter_test.go`
+- [x] T011 [P] [US2] Unit test `TestGetActualCost_ValidationFailure_InvalidTimeRange` in `internal/proto/adapter_test.go`
+
+### Implementation for User Story 2
+
+- [x] T012 [US2] Add pre-flight validation call in `GetActualCostWithErrors()` at `internal/proto/adapter.go:164-267`
+- [x] T013 [US2] Add WARN-level logging with resource_id and trace_id context for validation failures
+- [x] T014 [US2] Add placeholder CostResult with VALIDATION note on validation failure
+- [x] T015 [US2] Verify tests pass with `go test -v ./internal/proto/... -run TestGetActualCost_ValidationFailure`
+
+**Checkpoint**: User Story 2 complete - GetActualCost validation works with same patterns as US1
+
+---
+
+## Phase 5: User Story 3 - Debug Logging for Validation Failures (Priority: P3)
+
+**Goal**: Ensure validation failures include full context for troubleshooting
+
+**Note**: This story is integrated into US1 and US2 implementation (T007, T013). Verify logging works correctly.
+
+### Verification for User Story 3
+
+- [x] T016 [US3] Verify WARN-level log includes resource_type (projected) or resource_id (actual), trace_id, and error message
+- [x] T017 [US3] Manual test: Verified log output format matches quickstart.md examples (see test output)
+
+**Checkpoint**: User Story 3 complete - Logging provides full context for troubleshooting
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Quality gates and documentation
+
+- [x] T018 Run `make lint` and fix any issues
+- [x] T019 Run `make test` and verify 80%+ coverage for modified code
+- [x] T020 [P] Update `CLAUDE.md` with validation pattern documentation under "Key Patterns" section
+- [x] T021 Run quickstart.md validation: unit tests verify validation behavior as documented
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - import statement only
+- **Foundational (Phase 2)**: N/A - using existing infrastructure
+- **User Story 1 (Phase 3)**: Depends on Phase 1 (import)
+- **User Story 2 (Phase 4)**: Can proceed in parallel with US1 after Phase 1, but may share test patterns
+- **User Story 3 (Phase 5)**: Verification only - logging integrated into US1/US2
+- **Polish (Phase 6)**: Depends on all user stories complete
+
+### Within Each User Story
+
+- Tests (T002-T005, T010-T011) MUST be written and FAIL before implementation
+- Implementation (T006-T008, T012-T014) follows tests
+- Verification (T009, T015) confirms tests pass
+
+### Parallel Opportunities
+
+- T002, T003, T004, T005 can all run in parallel (different test functions, same file)
+- T010, T011 can run in parallel
+- US1 and US2 can be developed in parallel after Phase 1
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (add import)
+2. Write tests T002-T005 (should fail)
+3. Implement T006-T008
+4. Run T009 verification
+5. **STOP and VALIDATE**: Test US1 independently with sample plan
+
+### Full Implementation
+
+1. Complete US1 as MVP
+2. Add US2 tests (T010-T011) and implementation (T012-T014)
+3. Verify US3 logging (T016-T017)
+4. Run quality gates (T018-T021)
+
+---
+
+## Notes
+
+- [P] tasks = different test functions, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Tests use existing mock client patterns from adapter_test.go
+- Validation errors use "VALIDATION:" prefix per design decision D4 in plan.md
+- No new files created - all changes to existing adapter.go and adapter_test.go


### PR DESCRIPTION
## Summary

Integrates `pluginsdk.ValidateProjectedCostRequest()` and `pluginsdk.ValidateActualCostRequest()` from pulumicost-spec v0.4.11 to catch malformed requests before gRPC calls to plugins. This provides actionable error messages with a "VALIDATION:" prefix that guide users to fix issues like empty provider, missing SKU, or invalid time ranges without waiting for plugin timeouts or cryptic gRPC errors.

## Test plan

- [x] `make lint` passes with zero issues
- [x] `make test` passes (proto package: 50.7% coverage)
- [x] Unit tests verify validation catches empty provider, SKU, region
- [x] Unit tests verify validation catches empty resource ID and invalid time range
- [x] Unit tests verify mixed valid/invalid resources are handled correctly
- [x] Validation logs at WARN level with resource context

## Changes

### Modified files

- `internal/proto/adapter.go` - Added pre-flight validation in `GetProjectedCostWithErrors()` and `GetActualCostWithErrors()` using pluginsdk validation functions before gRPC calls
- `internal/proto/adapter_test.go` - Added 6 new test functions for validation failure scenarios (empty provider, SKU, region, resource ID, invalid time range, mixed valid/invalid)
- `CLAUDE.md` - Added "Pre-Flight Request Validation" section under Key Patterns documenting the validation pattern

Closes #233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pre‑flight validation for projected and actual cost requests; invalid inputs yield placeholder $0 results labeled with a "VALIDATION:" note and skip plugin calls.
  * Validation failures are logged at WARN with resource context.

* **Documentation**
  * Added a Pre‑Flight Request Validation section describing flow and messaging.

* **Tests**
  * Expanded test coverage for multiple validation scenarios (empty provider/SKU/region, invalid IDs/time ranges, mixed valid/invalid).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->