### PR TITLE
feat(cli): add cost recommendations command with action type filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ See `.specify/memory/constitution.md` for non-negotiable principles:
 1. **CLI Layer** (`internal/cli/`) - Cobra-based commands:
    - `cost projected` - Estimate costs from Pulumi preview JSON
    - `cost actual` - Fetch historical costs with time ranges/grouping
+   - `cost recommendations` - Get cost optimization recommendations with action type filtering
    - `plugin list/validate/install/remove/update/certify` - Plugin management
    - `analyzer serve` - Pulumi Analyzer gRPC server for zero-click cost estimation
 
@@ -187,6 +188,21 @@ Plugins communicate via gRPC using protocol buffers from `pulumicost-spec`:
 - `Name()` - Plugin identification
 - `GetProjectedCost()` - Estimated costs for resources
 - `GetActualCost()` - Historical costs from cloud APIs
+- `GetRecommendations()` - Cost optimization recommendations
+
+### Action Type Utilities (`internal/proto/action_types.go`)
+
+Shared utilities for recommendation action type handling:
+
+- `ActionTypeLabel(at pbc.RecommendationActionType) string` - Human-readable label for display
+- `ActionTypeLabelFromString(actionType string) string` - Label from string (for stored values)
+- `ParseActionType(s string) (pbc.RecommendationActionType, error)` - Parse single action type
+- `ParseActionTypeFilter(filter string) ([]pbc.RecommendationActionType, error)` - Parse comma-separated filter
+- `ValidActionTypes() []string` - List of valid action type names (excludes UNSPECIFIED)
+- `MatchesActionType(recType string, types []pbc.RecommendationActionType) bool` - Filter matching
+
+Valid action types: RIGHTSIZE, TERMINATE, PURCHASE_COMMITMENT, ADJUST_REQUESTS, MODIFY,
+DELETE_UNUSED, MIGRATE, CONSOLIDATE, SCHEDULE, REFACTOR, OTHER
 
 ## Documentation
 
@@ -935,6 +951,8 @@ CodeRabbit now:
 5. **Integrates with existing CI/CD** tools and workflows
 
 ## Active Technologies
+- Go 1.25.5 + pulumicost-spec v0.4.11 (pluginsdk), cobra v1.10.1, (108-action-type-enum)
+- N/A (stateless enum mapping) (108-action-type-enum)
 
 - Go 1.25.5 + pluginsdk v0.4.11+, zerolog v1.34.0; N/A storage (validation is stateless) (107-preflight-validation)
 - Go 1.25.5 + github.com/rshade/pulumicost-spec v0.4.11 (pluginsdk) (106-analyzer-recommendations)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,6 +135,19 @@ guardrails in `CONTEXT.md`.
 | Spot Market Advisor | PricingTier | Cyan style | N/A | SpotHistory |
 | Dev Mode | UsageProfile | --profile | Burstable | IOPS warn |
 
+## Naming & Branding
+
+- [ ] **Project Rename**
+  - *Objective*: Replace the dry `pulumicost` name with a stronger brand identity.
+  - *Current Leader*: **Tailly** (CLI: `tally`)
+    - *Vibe*: Developer-friendly, ecosystem-native (the "Tail" of the Pulumi Platypus).
+    - *Command*: `tally cost projected` (avoiding `tail` conflict, preserving clear verb structure).
+    - *Mascot Potential*: High (Platypus).
+  - *Alternative*: **FinFocus** (CLI: `fin`)
+    - *Vibe*: Enterprise, compliance-focused (FinOps FOCUS spec).
+    - *Command*: `fin cost projected`.
+  - *Decision*: Leaning towards **Tailly** for better DX, while acknowledging **FinFocus** has stronger enterprise signaling.
+
 ### Strategic Research Items (The "Detailed Horizon")
 
 - [ ] **Markdown "Cost-Change" Report & CI/CD Bridge**

--- a/internal/cli/cost_recommendations.go
+++ b/internal/cli/cost_recommendations.go
@@ -1,0 +1,373 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/rshade/pulumicost-core/internal/config"
+	"github.com/rshade/pulumicost-core/internal/engine"
+	"github.com/rshade/pulumicost-core/internal/logging"
+	"github.com/rshade/pulumicost-core/internal/proto"
+	"github.com/spf13/cobra"
+)
+
+// Note: The engine.Recommendation struct has these fields:
+// - ResourceID string
+// - Type string (maps from proto ActionType)
+// - Description string
+// - EstimatedSavings float64
+// - Currency string
+
+// costRecommendationsParams holds the parameters for the recommendations command execution.
+type costRecommendationsParams struct {
+	planPath string
+	adapter  string
+	output   string
+	filter   []string
+}
+
+// NewCostRecommendationsCmd creates the "recommendations" subcommand that fetches cost optimization
+// recommendations for resources described in a Pulumi preview JSON.
+//
+// The command is configured with flags:
+//   - --pulumi-json (required): path to Pulumi preview JSON output
+//   - --adapter: restrict to a specific adapter plugin
+//   - --output: output format (table, json, ndjson; defaults from configuration)
+//   - --filter: filter expressions for recommendations (e.g., 'action=MIGRATE')
+//
+// The returned *cobra.Command is ready to be added to the CLI command tree.
+func NewCostRecommendationsCmd() *cobra.Command {
+	var params costRecommendationsParams
+
+	cmd := &cobra.Command{
+		Use:   "recommendations",
+		Short: "Get cost optimization recommendations",
+		Long: `Fetch cost optimization recommendations for resources from cloud provider APIs and plugins.
+
+Valid action types for filtering:
+  RIGHTSIZE, TERMINATE, PURCHASE_COMMITMENT, ADJUST_REQUESTS, MODIFY,
+  DELETE_UNUSED, MIGRATE, CONSOLIDATE, SCHEDULE, REFACTOR, OTHER`,
+		Example: `  # Get all cost optimization recommendations
+  pulumicost cost recommendations --pulumi-json plan.json
+
+  # Output recommendations as JSON
+  pulumicost cost recommendations --pulumi-json plan.json --output json
+
+  # Filter recommendations by action type
+  pulumicost cost recommendations --pulumi-json plan.json --filter "action=MIGRATE"
+
+  # Filter by multiple action types (comma-separated)
+  pulumicost cost recommendations --pulumi-json plan.json --filter "action=RIGHTSIZE,TERMINATE"
+
+  # Use a specific adapter plugin
+  pulumicost cost recommendations --pulumi-json plan.json --adapter kubecost`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeCostRecommendations(cmd, params)
+		},
+	}
+
+	cmd.Flags().
+		StringVar(&params.planPath, "pulumi-json", "", "Path to Pulumi preview JSON output (required)")
+	cmd.Flags().StringVar(&params.adapter, "adapter", "", "Use only the specified adapter plugin")
+
+	// Use configuration default if no output format specified
+	defaultFormat := config.GetDefaultOutputFormat()
+	cmd.Flags().StringVar(&params.output, "output", defaultFormat, "Output format: table, json, or ndjson")
+	cmd.Flags().StringArrayVar(&params.filter, "filter", []string{},
+		"Filter expressions (e.g., 'action=MIGRATE,RIGHTSIZE')")
+
+	_ = cmd.MarkFlagRequired("pulumi-json")
+
+	return cmd
+}
+
+// executeCostRecommendations orchestrates the recommendations workflow for a Pulumi plan.
+// It loads and maps resources, opens adapter plugins, fetches recommendations, applies filters,
+// and renders the output.
+//
+// cmd is the Cobra command whose context and output writer are used.
+// params supplies the plan path, adapter, output format, and filter expressions.
+//
+// Returns an error when resource loading fails, plugins cannot be opened, recommendation
+// fetching fails, or output rendering fails.
+func executeCostRecommendations(cmd *cobra.Command, params costRecommendationsParams) error {
+	ctx := cmd.Context()
+	log := logging.FromContext(ctx)
+
+	log.Debug().Ctx(ctx).Str("operation", "cost_recommendations").Str("plan_path", params.planPath).
+		Msg("starting recommendations fetch")
+
+	// Setup audit context for logging
+	auditParams := map[string]string{
+		"pulumi_json": params.planPath,
+		"output":      params.output,
+	}
+	if len(params.filter) > 0 {
+		auditParams["filter"] = strings.Join(params.filter, ",")
+	}
+	audit := newAuditContext(ctx, "cost recommendations", auditParams)
+
+	// Load and map resources from Pulumi plan
+	resources, err := loadAndMapResources(ctx, params.planPath, audit)
+	if err != nil {
+		return err
+	}
+
+	// Open plugin connections
+	clients, cleanup, err := openPlugins(ctx, params.adapter, audit)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	// Fetch recommendations from engine
+	result, err := engine.New(clients, nil).GetRecommendationsForResources(ctx, resources)
+	if err != nil {
+		log.Error().Ctx(ctx).Err(err).Msg("failed to fetch recommendations")
+		audit.logFailure(ctx, err)
+		return fmt.Errorf("fetching recommendations: %w", err)
+	}
+
+	// Apply action type filters if specified
+	filteredRecommendations := result.Recommendations
+	for _, f := range params.filter {
+		if f != "" {
+			filtered, filterErr := applyActionTypeFilter(ctx, filteredRecommendations, f)
+			if filterErr != nil {
+				return filterErr
+			}
+			filteredRecommendations = filtered
+		}
+	}
+
+	// Create filtered result for rendering
+	filteredResult := &engine.RecommendationsResult{
+		Recommendations: filteredRecommendations,
+		Errors:          result.Errors,
+		TotalSavings:    calculateTotalSavings(filteredRecommendations),
+		Currency:        result.Currency,
+	}
+
+	// Render output
+	if renderErr := RenderRecommendationsOutput(ctx, cmd, params.output, filteredResult); renderErr != nil {
+		return renderErr
+	}
+
+	log.Info().Ctx(ctx).Str("operation", "cost_recommendations").
+		Int("recommendation_count", len(filteredRecommendations)).
+		Dur("duration_ms", time.Since(audit.start)).
+		Msg("recommendations fetch complete")
+
+	audit.logSuccess(ctx, len(filteredRecommendations), filteredResult.TotalSavings)
+	return nil
+}
+
+// applyActionTypeFilter filters recommendations by action type based on a filter expression.
+// Filter format: "action=TYPE1,TYPE2,..."
+// Matching is case-insensitive. Returns error for invalid action types.
+func applyActionTypeFilter(
+	ctx context.Context,
+	recommendations []engine.Recommendation,
+	filter string,
+) ([]engine.Recommendation, error) {
+	log := logging.FromContext(ctx)
+
+	// Parse filter expression: "action=MIGRATE,RIGHTSIZE"
+	parts := strings.SplitN(filter, "=", 2) //nolint:mnd // key=value format
+	if len(parts) != 2 {                    //nolint:mnd // key=value has 2 parts
+		return recommendations, nil // Not an action filter, return unchanged
+	}
+
+	key := strings.TrimSpace(strings.ToLower(parts[0]))
+	if key != "action" {
+		return recommendations, nil // Not an action filter, return unchanged
+	}
+
+	// Parse and validate action types using proto utilities
+	actionTypesStr := strings.TrimSpace(parts[1])
+	actionTypes, err := proto.ParseActionTypeFilter(actionTypesStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid action type filter: %w", err)
+	}
+
+	// Filter recommendations using proto.MatchesActionType
+	var filtered []engine.Recommendation
+	for _, rec := range recommendations {
+		if proto.MatchesActionType(rec.Type, actionTypes) {
+			filtered = append(filtered, rec)
+		}
+	}
+
+	log.Debug().Ctx(ctx).
+		Int("original_count", len(recommendations)).
+		Int("filtered_count", len(filtered)).
+		Str("filter", filter).
+		Msg("applied action type filter")
+
+	return filtered, nil
+}
+
+// calculateTotalSavings calculates the total estimated savings from recommendations.
+func calculateTotalSavings(recommendations []engine.Recommendation) float64 {
+	var total float64
+	for _, rec := range recommendations {
+		total += rec.EstimatedSavings
+	}
+	return total
+}
+
+// RenderRecommendationsOutput routes the recommendations results to the appropriate
+// rendering function based on the output format.
+func RenderRecommendationsOutput(
+	_ context.Context,
+	cmd *cobra.Command,
+	outputFormat string,
+	result *engine.RecommendationsResult,
+) error {
+	fmtType := engine.OutputFormat(config.GetOutputFormat(outputFormat))
+
+	// Validate format is supported
+	if !isValidOutputFormat(fmtType) {
+		return fmt.Errorf("unsupported output format: %s", fmtType)
+	}
+
+	switch fmtType {
+	case engine.OutputJSON:
+		return renderRecommendationsJSON(cmd.OutOrStdout(), result)
+	case engine.OutputNDJSON:
+		return renderRecommendationsNDJSON(cmd.OutOrStdout(), result)
+	case engine.OutputTable:
+		return renderRecommendationsTable(cmd.OutOrStdout(), result)
+	default:
+		return renderRecommendationsTable(cmd.OutOrStdout(), result)
+	}
+}
+
+// tabPadding is the minimum column padding for tabwriter output.
+const tabPadding = 2
+
+// renderRecommendationsTable renders recommendations in table format.
+func renderRecommendationsTable(w io.Writer, result *engine.RecommendationsResult) error {
+	tw := tabwriter.NewWriter(w, 0, 0, tabPadding, ' ', 0)
+
+	// Header
+	fmt.Fprintln(tw, "RESOURCE\tACTION TYPE\tDESCRIPTION\tSAVINGS")
+	fmt.Fprintln(tw, "--------\t-----------\t-----------\t-------")
+
+	// Recommendations
+	for _, rec := range result.Recommendations {
+		savings := ""
+		if rec.EstimatedSavings > 0 {
+			savings = fmt.Sprintf("%.2f %s", rec.EstimatedSavings, rec.Currency)
+		}
+
+		// Truncate long descriptions
+		description := rec.Description
+		const maxDescLen = 50
+		if len(description) > maxDescLen {
+			description = description[:maxDescLen-3] + "..."
+		}
+
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+			rec.ResourceID,
+			formatActionTypeLabel(rec.Type),
+			description,
+			savings,
+		)
+	}
+
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("flushing table writer: %w", err)
+	}
+
+	// Summary
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Total Recommendations: %d\n", len(result.Recommendations))
+	if result.TotalSavings > 0 {
+		fmt.Fprintf(w, "Total Estimated Savings: %.2f %s\n", result.TotalSavings, result.Currency)
+	}
+
+	// Errors
+	if result.HasErrors() {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "ERRORS")
+		fmt.Fprintln(w, "======")
+		fmt.Fprintln(w, result.ErrorSummary())
+	}
+
+	return nil
+}
+
+// renderRecommendationsJSON renders recommendations in JSON format.
+func renderRecommendationsJSON(w io.Writer, result *engine.RecommendationsResult) error {
+	output := recommendationsJSONOutput{
+		Recommendations: make([]recommendationJSON, 0, len(result.Recommendations)),
+		TotalSavings:    result.TotalSavings,
+		Currency:        result.Currency,
+		Errors:          result.Errors,
+	}
+
+	for _, rec := range result.Recommendations {
+		jsonRec := recommendationJSON{
+			ResourceID:       rec.ResourceID,
+			ActionType:       rec.Type,
+			Description:      rec.Description,
+			EstimatedSavings: rec.EstimatedSavings,
+			Currency:         rec.Currency,
+		}
+		output.Recommendations = append(output.Recommendations, jsonRec)
+	}
+
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(output); err != nil {
+		return fmt.Errorf("encoding JSON: %w", err)
+	}
+	return nil
+}
+
+// renderRecommendationsNDJSON renders recommendations in NDJSON format.
+func renderRecommendationsNDJSON(w io.Writer, result *engine.RecommendationsResult) error {
+	encoder := json.NewEncoder(w)
+
+	for _, rec := range result.Recommendations {
+		jsonRec := recommendationJSON{
+			ResourceID:       rec.ResourceID,
+			ActionType:       rec.Type,
+			Description:      rec.Description,
+			EstimatedSavings: rec.EstimatedSavings,
+			Currency:         rec.Currency,
+		}
+		if err := encoder.Encode(jsonRec); err != nil {
+			return fmt.Errorf("encoding NDJSON: %w", err)
+		}
+	}
+	return nil
+}
+
+// formatActionTypeLabel returns a human-readable label for an action type.
+// Uses the proto utilities for consistent label formatting across the codebase.
+func formatActionTypeLabel(actionType string) string {
+	return proto.ActionTypeLabelFromString(actionType)
+}
+
+// JSON output structures for recommendations.
+type recommendationsJSONOutput struct {
+	Recommendations []recommendationJSON         `json:"recommendations"`
+	TotalSavings    float64                      `json:"total_savings"`
+	Currency        string                       `json:"currency"`
+	Errors          []engine.RecommendationError `json:"errors,omitempty"`
+}
+
+type recommendationJSON struct {
+	ResourceID       string  `json:"resource_id"`
+	ActionType       string  `json:"action_type"`
+	Description      string  `json:"description"`
+	EstimatedSavings float64 `json:"estimated_savings,omitempty"`
+	Currency         string  `json:"currency,omitempty"`
+}

--- a/internal/cli/cost_recommendations_test.go
+++ b/internal/cli/cost_recommendations_test.go
@@ -1,0 +1,377 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rshade/pulumicost-core/internal/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// T001: Test NewCostRecommendationsCmd() creates a valid command.
+func TestNewCostRecommendationsCmd(t *testing.T) {
+	cmd := cli.NewCostRecommendationsCmd()
+
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "recommendations", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+	assert.NotEmpty(t, cmd.Example)
+}
+
+// T001: Test command has required flags.
+func TestNewCostRecommendationsCmd_Flags(t *testing.T) {
+	cmd := cli.NewCostRecommendationsCmd()
+
+	// Check pulumi-json flag exists and is required
+	pulumiJSONFlag := cmd.Flags().Lookup("pulumi-json")
+	require.NotNil(t, pulumiJSONFlag, "pulumi-json flag should exist")
+
+	// Check other expected flags
+	adapterFlag := cmd.Flags().Lookup("adapter")
+	require.NotNil(t, adapterFlag, "adapter flag should exist")
+
+	outputFlag := cmd.Flags().Lookup("output")
+	require.NotNil(t, outputFlag, "output flag should exist")
+
+	filterFlag := cmd.Flags().Lookup("filter")
+	require.NotNil(t, filterFlag, "filter flag should exist")
+}
+
+// T001: Test command fails without required pulumi-json flag.
+func TestNewCostRecommendationsCmd_RequiredFlags(t *testing.T) {
+	cmd := cli.NewCostRecommendationsCmd()
+
+	// Execute without required flag should fail
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "pulumi-json")
+}
+
+// T002: Test table output format rendering.
+func TestCostRecommendationsCmd_TableOutput(t *testing.T) {
+	// Create a temporary plan file
+	planJSON := `{
+		"version": 3,
+		"steps": [
+			{
+				"op": "create",
+				"urn": "urn:pulumi:test::test::aws:ec2/instance:Instance::test-instance",
+				"type": "aws:ec2/instance:Instance",
+				"newState": {
+					"type": "aws:ec2/instance:Instance",
+					"inputs": {
+						"instanceType": "t3.micro",
+						"availabilityZone": "us-east-1a"
+					}
+				}
+			}
+		]
+	}`
+
+	tmpDir := t.TempDir()
+	planPath := filepath.Join(tmpDir, "plan.json")
+	err := os.WriteFile(planPath, []byte(planJSON), 0o600)
+	require.NoError(t, err)
+
+	cmd := cli.NewCostRecommendationsCmd()
+	var outBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&outBuf)
+
+	// Execute with table output (default)
+	cmd.SetArgs([]string{"--pulumi-json", planPath, "--output", "table"})
+	// Command will fail without plugins, but that's expected
+	// We're testing that the command infrastructure works
+	_ = cmd.Execute()
+
+	// The output should contain some text (even if empty recommendations)
+	// In a full integration test with plugins, we'd check for table headers
+}
+
+// T002: Test JSON output format rendering.
+func TestCostRecommendationsCmd_JSONOutput(t *testing.T) {
+	planJSON := `{
+		"version": 3,
+		"steps": [
+			{
+				"op": "create",
+				"urn": "urn:pulumi:test::test::aws:ec2/instance:Instance::test-instance",
+				"type": "aws:ec2/instance:Instance",
+				"newState": {
+					"type": "aws:ec2/instance:Instance",
+					"inputs": {
+						"instanceType": "t3.micro"
+					}
+				}
+			}
+		]
+	}`
+
+	tmpDir := t.TempDir()
+	planPath := filepath.Join(tmpDir, "plan.json")
+	err := os.WriteFile(planPath, []byte(planJSON), 0o600)
+	require.NoError(t, err)
+
+	cmd := cli.NewCostRecommendationsCmd()
+	var outBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&outBuf)
+
+	cmd.SetArgs([]string{"--pulumi-json", planPath, "--output", "json"})
+	_ = cmd.Execute()
+
+	// If output is produced, it should be valid JSON
+	output := strings.TrimSpace(outBuf.String())
+	if output != "" && strings.HasPrefix(output, "{") {
+		var result map[string]interface{}
+		jsonErr := json.Unmarshal([]byte(output), &result)
+		assert.NoError(t, jsonErr, "JSON output should be valid JSON")
+	}
+}
+
+// T002: Test NDJSON output format rendering.
+func TestCostRecommendationsCmd_NDJSONOutput(t *testing.T) {
+	planJSON := `{
+		"version": 3,
+		"steps": []
+	}`
+
+	tmpDir := t.TempDir()
+	planPath := filepath.Join(tmpDir, "plan.json")
+	err := os.WriteFile(planPath, []byte(planJSON), 0o600)
+	require.NoError(t, err)
+
+	cmd := cli.NewCostRecommendationsCmd()
+	var outBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&outBuf)
+
+	cmd.SetArgs([]string{"--pulumi-json", planPath, "--output", "ndjson"})
+	_ = cmd.Execute()
+
+	// NDJSON output should have each line as valid JSON (if any output)
+	output := strings.TrimSpace(outBuf.String())
+	if output != "" {
+		lines := strings.Split(output, "\n")
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if line != "" && strings.HasPrefix(line, "{") {
+				var item map[string]interface{}
+				jsonErr := json.Unmarshal([]byte(line), &item)
+				assert.NoError(t, jsonErr, "each NDJSON line should be valid JSON")
+			}
+		}
+	}
+}
+
+// T003: Test --filter flag parsing with action types.
+func TestCostRecommendationsCmd_FilterFlag(t *testing.T) {
+	cmd := cli.NewCostRecommendationsCmd()
+
+	// Check filter flag accepts array values
+	filterFlag := cmd.Flags().Lookup("filter")
+	require.NotNil(t, filterFlag)
+
+	// Test filter flag can be set
+	err := cmd.Flags().Set("filter", "action=MIGRATE")
+	assert.NoError(t, err)
+}
+
+// T003: Test multiple filter values.
+func TestCostRecommendationsCmd_MultipleFilters(t *testing.T) {
+	planJSON := `{
+		"version": 3,
+		"steps": []
+	}`
+
+	tmpDir := t.TempDir()
+	planPath := filepath.Join(tmpDir, "plan.json")
+	err := os.WriteFile(planPath, []byte(planJSON), 0o600)
+	require.NoError(t, err)
+
+	cmd := cli.NewCostRecommendationsCmd()
+	var outBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&outBuf)
+
+	// Test with multiple filter values
+	cmd.SetArgs([]string{
+		"--pulumi-json", planPath,
+		"--filter", "action=MIGRATE,RIGHTSIZE",
+		"--output", "json",
+	})
+	_ = cmd.Execute()
+
+	// Command should process without panic
+}
+
+// T003: Test case-insensitive filter matching.
+func TestCostRecommendationsCmd_CaseInsensitiveFilter(t *testing.T) {
+	planJSON := `{
+		"version": 3,
+		"steps": []
+	}`
+
+	tmpDir := t.TempDir()
+	planPath := filepath.Join(tmpDir, "plan.json")
+	err := os.WriteFile(planPath, []byte(planJSON), 0o600)
+	require.NoError(t, err)
+
+	cmd := cli.NewCostRecommendationsCmd()
+	var outBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&outBuf)
+
+	// Test lowercase filter values
+	cmd.SetArgs([]string{
+		"--pulumi-json", planPath,
+		"--filter", "action=migrate",
+		"--output", "json",
+	})
+	_ = cmd.Execute()
+
+	// Command should process without panic (case insensitivity tested in proto package)
+}
+
+// Test invalid plan path error handling.
+func TestCostRecommendationsCmd_InvalidPlanPath(t *testing.T) {
+	cmd := cli.NewCostRecommendationsCmd()
+	var outBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&outBuf)
+
+	cmd.SetArgs([]string{"--pulumi-json", "/nonexistent/path/plan.json"})
+	err := cmd.Execute()
+
+	assert.Error(t, err)
+}
+
+// Test unsupported output format error.
+func TestCostRecommendationsCmd_UnsupportedOutputFormat(t *testing.T) {
+	planJSON := `{"version": 3, "steps": []}`
+
+	tmpDir := t.TempDir()
+	planPath := filepath.Join(tmpDir, "plan.json")
+	err := os.WriteFile(planPath, []byte(planJSON), 0o600)
+	require.NoError(t, err)
+
+	cmd := cli.NewCostRecommendationsCmd()
+	var outBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&outBuf)
+
+	cmd.SetArgs([]string{"--pulumi-json", planPath, "--output", "invalid"})
+	err = cmd.Execute()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported output format")
+}
+
+// T022: Test action type filter parsing in CLI command with valid types.
+func TestCostRecommendationsCmd_ValidActionTypeFilter(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter string
+	}{
+		{"single type MIGRATE", "action=MIGRATE"},
+		{"single type RIGHTSIZE", "action=RIGHTSIZE"},
+		{"single type TERMINATE", "action=TERMINATE"},
+		{"single type CONSOLIDATE", "action=CONSOLIDATE"},
+		{"single type SCHEDULE", "action=SCHEDULE"},
+		{"single type REFACTOR", "action=REFACTOR"},
+		{"single type OTHER", "action=OTHER"},
+		{"multiple types", "action=MIGRATE,RIGHTSIZE,TERMINATE"},
+		{"lowercase", "action=migrate"},
+		{"mixed case", "action=Migrate,RIGHTSIZE"},
+		{"with spaces", "action=MIGRATE , RIGHTSIZE"},
+	}
+
+	planJSON := `{"version": 3, "steps": []}`
+	tmpDir := t.TempDir()
+	planPath := filepath.Join(tmpDir, "plan.json")
+	err := os.WriteFile(planPath, []byte(planJSON), 0o600)
+	require.NoError(t, err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := cli.NewCostRecommendationsCmd()
+			var outBuf bytes.Buffer
+			cmd.SetOut(&outBuf)
+			cmd.SetErr(&outBuf)
+
+			cmd.SetArgs([]string{
+				"--pulumi-json", planPath,
+				"--filter", tt.filter,
+				"--output", "json",
+			})
+			// Should not error due to filter parsing
+			// (may error due to no plugins, but filter is valid)
+			_ = cmd.Execute()
+		})
+	}
+}
+
+// T023: Test invalid action type filter error message listing all 11 valid types.
+func TestCostRecommendationsCmd_InvalidActionTypeFilterError(t *testing.T) {
+	planJSON := `{"version": 3, "steps": []}`
+	tmpDir := t.TempDir()
+	planPath := filepath.Join(tmpDir, "plan.json")
+	err := os.WriteFile(planPath, []byte(planJSON), 0o600)
+	require.NoError(t, err)
+
+	cmd := cli.NewCostRecommendationsCmd()
+	var outBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&outBuf)
+
+	cmd.SetArgs([]string{
+		"--pulumi-json", planPath,
+		"--filter", "action=INVALID_TYPE",
+		"--output", "json",
+	})
+	err = cmd.Execute()
+
+	// Should error with invalid action type
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid action type")
+
+	// Error message should list valid types
+	errMsg := err.Error()
+	validTypes := []string{"RIGHTSIZE", "TERMINATE", "MIGRATE", "CONSOLIDATE", "SCHEDULE", "REFACTOR", "OTHER"}
+	for _, vt := range validTypes {
+		assert.Contains(t, errMsg, vt, "error should list valid type: %s", vt)
+	}
+}
+
+// T023: Test empty action type filter error.
+func TestCostRecommendationsCmd_EmptyActionTypeFilter(t *testing.T) {
+	planJSON := `{"version": 3, "steps": []}`
+	tmpDir := t.TempDir()
+	planPath := filepath.Join(tmpDir, "plan.json")
+	err := os.WriteFile(planPath, []byte(planJSON), 0o600)
+	require.NoError(t, err)
+
+	cmd := cli.NewCostRecommendationsCmd()
+	var outBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&outBuf)
+
+	cmd.SetArgs([]string{
+		"--pulumi-json", planPath,
+		"--filter", "action=",
+		"--output", "json",
+	})
+	err = cmd.Execute()
+
+	// Should error with empty filter value
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid action type filter")
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -60,10 +60,10 @@ const rootCmdExample = `  # Calculate projected costs from a Pulumi plan
   # Set configuration values
   pulumicost config set output.default_format json`
 
-// newCostCmd creates the cost command group with projected and actual subcommands.
+// newCostCmd creates the cost command group with projected, actual, and recommendations subcommands.
 func newCostCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "cost", Short: "Cost calculation commands"}
-	cmd.AddCommand(NewCostProjectedCmd(), NewCostActualCmd())
+	cmd.AddCommand(NewCostProjectedCmd(), NewCostActualCmd(), NewCostRecommendationsCmd())
 	return cmd
 }
 

--- a/internal/proto/action_types.go
+++ b/internal/proto/action_types.go
@@ -1,0 +1,176 @@
+package proto
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+)
+
+// actionTypeLabels maps RecommendationActionType enum values to human-readable labels.
+// These labels are used for display in TUI and table output.
+//
+//nolint:gochecknoglobals // Intentional: static lookup table, avoiding allocation per call
+var actionTypeLabels = map[pbc.RecommendationActionType]string{
+	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_UNSPECIFIED:         "Unspecified",
+	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_RIGHTSIZE:           "Rightsize",
+	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_TERMINATE:           "Terminate",
+	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_PURCHASE_COMMITMENT: "Purchase Commitment",
+	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_ADJUST_REQUESTS:     "Adjust Requests",
+	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MODIFY:              "Modify",
+	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_DELETE_UNUSED:       "Delete Unused",
+	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE:             "Migrate",
+	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_CONSOLIDATE:         "Consolidate",
+	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_SCHEDULE:            "Schedule",
+	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_REFACTOR:            "Refactor",
+	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_OTHER:               "Other",
+}
+
+// actionTypeNames maps short names (for filter parsing) to proto enum values.
+// UNSPECIFIED is excluded as it's not a valid filter value.
+//
+//nolint:gochecknoglobals // Intentional: static lookup table, avoiding allocation per call
+var actionTypeNames = map[string]pbc.RecommendationActionType{
+	"RIGHTSIZE":           pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_RIGHTSIZE,
+	"TERMINATE":           pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_TERMINATE,
+	"PURCHASE_COMMITMENT": pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_PURCHASE_COMMITMENT,
+	"ADJUST_REQUESTS":     pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_ADJUST_REQUESTS,
+	"MODIFY":              pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MODIFY,
+	"DELETE_UNUSED":       pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_DELETE_UNUSED,
+	"MIGRATE":             pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE,
+	"CONSOLIDATE":         pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_CONSOLIDATE,
+	"SCHEDULE":            pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_SCHEDULE,
+	"REFACTOR":            pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_REFACTOR,
+	"OTHER":               pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_OTHER,
+}
+
+// stringLabels maps short names to human-readable labels for string-based lookups.
+//
+//nolint:gochecknoglobals // Intentional: static lookup table, avoiding allocation per call
+var stringLabels = map[string]string{
+	"RIGHTSIZE":           "Rightsize",
+	"TERMINATE":           "Terminate",
+	"PURCHASE_COMMITMENT": "Purchase Commitment",
+	"ADJUST_REQUESTS":     "Adjust Requests",
+	"MODIFY":              "Modify",
+	"DELETE_UNUSED":       "Delete Unused",
+	"MIGRATE":             "Migrate",
+	"CONSOLIDATE":         "Consolidate",
+	"SCHEDULE":            "Schedule",
+	"REFACTOR":            "Refactor",
+	"OTHER":               "Other",
+}
+
+// ActionTypeLabel returns the human-readable label for a RecommendationActionType.
+// For unknown/future enum values, it returns "Unknown (N)" where N is the integer value.
+func ActionTypeLabel(at pbc.RecommendationActionType) string {
+	if label, ok := actionTypeLabels[at]; ok {
+		return label
+	}
+	return fmt.Sprintf("Unknown (%d)", int32(at))
+}
+
+// ActionTypeLabelFromString returns the human-readable label for an action type string.
+// For unknown types, it returns the input string unchanged.
+// This is useful for converting stored/serialized action type strings to display labels.
+func ActionTypeLabelFromString(actionType string) string {
+	if actionType == "" {
+		return ""
+	}
+	upperType := strings.ToUpper(strings.TrimSpace(actionType))
+	if label, ok := stringLabels[upperType]; ok {
+		return label
+	}
+	return actionType
+}
+
+// ParseActionType parses a string into a RecommendationActionType enum value.
+// Matching is case-insensitive and whitespace is trimmed.
+// Returns an error for unknown type names, listing all valid options.
+// UNSPECIFIED is not allowed as a filter value.
+func ParseActionType(s string) (pbc.RecommendationActionType, error) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return 0, fmt.Errorf("invalid action type %q: empty string. Valid types: %s",
+			s, strings.Join(ValidActionTypes(), ", "))
+	}
+
+	upperType := strings.ToUpper(trimmed)
+
+	// Check if it's UNSPECIFIED (not allowed in filters)
+	if upperType == "UNSPECIFIED" {
+		return 0, fmt.Errorf("invalid action type %q: UNSPECIFIED is not allowed. Valid types: %s",
+			s, strings.Join(ValidActionTypes(), ", "))
+	}
+
+	if at, ok := actionTypeNames[upperType]; ok {
+		return at, nil
+	}
+
+	return 0, fmt.Errorf("invalid action type %q. Valid types: %s",
+		s, strings.Join(ValidActionTypes(), ", "))
+}
+
+// ParseActionTypeFilter parses a comma-separated list of action types.
+// Each type is validated and converted to a RecommendationActionType enum value.
+// Returns an error if any type is invalid or if the input is empty.
+func ParseActionTypeFilter(filter string) ([]pbc.RecommendationActionType, error) {
+	trimmed := strings.TrimSpace(filter)
+	if trimmed == "" {
+		return nil, errors.New("invalid action type filter: empty string")
+	}
+
+	parts := strings.Split(trimmed, ",")
+	result := make([]pbc.RecommendationActionType, 0, len(parts))
+
+	for _, part := range parts {
+		trimmedPart := strings.TrimSpace(part)
+		if trimmedPart == "" {
+			continue
+		}
+
+		at, err := ParseActionType(trimmedPart)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, at)
+	}
+
+	if len(result) == 0 {
+		return nil, errors.New("invalid action type filter: no valid types found")
+	}
+
+	return result, nil
+}
+
+// ValidActionTypes returns a list of valid action type short names for filter expressions.
+// UNSPECIFIED is excluded as it's not a valid filter value.
+func ValidActionTypes() []string {
+	types := make([]string, 0, len(actionTypeNames))
+	for name := range actionTypeNames {
+		types = append(types, name)
+	}
+	return types
+}
+
+// MatchesActionType checks if a recommendation's action type matches any of the given types.
+// The rec parameter should have a Type field containing the action type string.
+// Matching is case-insensitive.
+func MatchesActionType(recType string, types []pbc.RecommendationActionType) bool {
+	if len(types) == 0 {
+		return true // No filter means match all
+	}
+
+	upperRecType := strings.ToUpper(strings.TrimSpace(recType))
+
+	for _, filterType := range types {
+		// Get the short name for the filter type
+		for name, at := range actionTypeNames {
+			if at == filterType && name == upperRecType {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/proto/action_types_test.go
+++ b/internal/proto/action_types_test.go
@@ -1,0 +1,431 @@
+package proto_test
+
+import (
+	"testing"
+
+	"github.com/rshade/pulumicost-core/internal/proto"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// T011: Table-driven tests for ActionTypeLabel() covering all 11 types.
+func TestActionTypeLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    pbc.RecommendationActionType
+		expected string
+	}{
+		{
+			name:     "UNSPECIFIED",
+			input:    pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_UNSPECIFIED,
+			expected: "Unspecified",
+		},
+		{
+			name:     "RIGHTSIZE",
+			input:    pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_RIGHTSIZE,
+			expected: "Rightsize",
+		},
+		{
+			name:     "TERMINATE",
+			input:    pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_TERMINATE,
+			expected: "Terminate",
+		},
+		{
+			name:     "PURCHASE_COMMITMENT",
+			input:    pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_PURCHASE_COMMITMENT,
+			expected: "Purchase Commitment",
+		},
+		{
+			name:     "ADJUST_REQUESTS",
+			input:    pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_ADJUST_REQUESTS,
+			expected: "Adjust Requests",
+		},
+		{
+			name:     "MODIFY",
+			input:    pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MODIFY,
+			expected: "Modify",
+		},
+		{
+			name:     "DELETE_UNUSED",
+			input:    pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_DELETE_UNUSED,
+			expected: "Delete Unused",
+		},
+		{
+			name:     "MIGRATE",
+			input:    pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE,
+			expected: "Migrate",
+		},
+		{
+			name:     "CONSOLIDATE",
+			input:    pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_CONSOLIDATE,
+			expected: "Consolidate",
+		},
+		{
+			name:     "SCHEDULE",
+			input:    pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_SCHEDULE,
+			expected: "Schedule",
+		},
+		{
+			name:     "REFACTOR",
+			input:    pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_REFACTOR,
+			expected: "Refactor",
+		},
+		{
+			name:     "OTHER",
+			input:    pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_OTHER,
+			expected: "Other",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := proto.ActionTypeLabel(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// T012: Table-driven tests for ParseActionType() with valid/invalid inputs.
+func TestParseActionType(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    pbc.RecommendationActionType
+		expectError bool
+	}{
+		// Valid inputs - uppercase
+		{
+			name:     "RIGHTSIZE uppercase",
+			input:    "RIGHTSIZE",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_RIGHTSIZE,
+		},
+		{
+			name:     "TERMINATE uppercase",
+			input:    "TERMINATE",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_TERMINATE,
+		},
+		{
+			name:     "PURCHASE_COMMITMENT uppercase",
+			input:    "PURCHASE_COMMITMENT",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_PURCHASE_COMMITMENT,
+		},
+		{
+			name:     "ADJUST_REQUESTS uppercase",
+			input:    "ADJUST_REQUESTS",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_ADJUST_REQUESTS,
+		},
+		{
+			name:     "MODIFY uppercase",
+			input:    "MODIFY",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MODIFY,
+		},
+		{
+			name:     "DELETE_UNUSED uppercase",
+			input:    "DELETE_UNUSED",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_DELETE_UNUSED,
+		},
+		{
+			name:     "MIGRATE uppercase",
+			input:    "MIGRATE",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE,
+		},
+		{
+			name:     "CONSOLIDATE uppercase",
+			input:    "CONSOLIDATE",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_CONSOLIDATE,
+		},
+		{
+			name:     "SCHEDULE uppercase",
+			input:    "SCHEDULE",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_SCHEDULE,
+		},
+		{
+			name:     "REFACTOR uppercase",
+			input:    "REFACTOR",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_REFACTOR,
+		},
+		{
+			name:     "OTHER uppercase",
+			input:    "OTHER",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_OTHER,
+		},
+		// Valid inputs - lowercase (case-insensitive)
+		{
+			name:     "rightsize lowercase",
+			input:    "rightsize",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_RIGHTSIZE,
+		},
+		{
+			name:     "migrate lowercase",
+			input:    "migrate",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE,
+		},
+		{
+			name:     "purchase_commitment lowercase",
+			input:    "purchase_commitment",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_PURCHASE_COMMITMENT,
+		},
+		// Valid inputs - mixed case
+		{
+			name:     "Migrate mixed case",
+			input:    "Migrate",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE,
+		},
+		{
+			name:     "Delete_Unused mixed case",
+			input:    "Delete_Unused",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_DELETE_UNUSED,
+		},
+		// Valid with whitespace
+		{
+			name:     "with leading/trailing spaces",
+			input:    "  RIGHTSIZE  ",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_RIGHTSIZE,
+		},
+		// Invalid inputs
+		{
+			name:        "empty string",
+			input:       "",
+			expectError: true,
+		},
+		{
+			name:        "unknown type",
+			input:       "UNKNOWN",
+			expectError: true,
+		},
+		{
+			name:        "invalid random string",
+			input:       "not-a-valid-type",
+			expectError: true,
+		},
+		{
+			name:        "UNSPECIFIED not allowed in filter",
+			input:       "UNSPECIFIED",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := proto.ParseActionType(tt.input)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid action type")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+// T013: Table-driven tests for ParseActionTypeFilter() with comma-separated values.
+func TestParseActionTypeFilter(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    []pbc.RecommendationActionType
+		expectError bool
+	}{
+		{
+			name:  "single type",
+			input: "MIGRATE",
+			expected: []pbc.RecommendationActionType{
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE,
+			},
+		},
+		{
+			name:  "two types",
+			input: "MIGRATE,RIGHTSIZE",
+			expected: []pbc.RecommendationActionType{
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE,
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_RIGHTSIZE,
+			},
+		},
+		{
+			name:  "three types",
+			input: "CONSOLIDATE,SCHEDULE,REFACTOR",
+			expected: []pbc.RecommendationActionType{
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_CONSOLIDATE,
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_SCHEDULE,
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_REFACTOR,
+			},
+		},
+		{
+			name:  "with spaces",
+			input: "MIGRATE , RIGHTSIZE , TERMINATE",
+			expected: []pbc.RecommendationActionType{
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE,
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_RIGHTSIZE,
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_TERMINATE,
+			},
+		},
+		{
+			name:  "lowercase mixed",
+			input: "migrate,Consolidate,SCHEDULE",
+			expected: []pbc.RecommendationActionType{
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE,
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_CONSOLIDATE,
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_SCHEDULE,
+			},
+		},
+		{
+			name:        "empty string",
+			input:       "",
+			expectError: true,
+		},
+		{
+			name:        "contains invalid type",
+			input:       "MIGRATE,INVALID,RIGHTSIZE",
+			expectError: true,
+		},
+		{
+			name:        "only commas",
+			input:       ",,,",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := proto.ParseActionTypeFilter(tt.input)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+// T014: Tests for ValidActionTypes() excluding UNSPECIFIED.
+func TestValidActionTypes(t *testing.T) {
+	types := proto.ValidActionTypes()
+
+	// Should have exactly 11 types (excluding UNSPECIFIED)
+	assert.Len(t, types, 11)
+
+	// Should not contain UNSPECIFIED
+	for _, at := range types {
+		assert.NotEqual(t, "UNSPECIFIED", at)
+	}
+
+	// Should contain all the valid types
+	expectedTypes := []string{
+		"RIGHTSIZE",
+		"TERMINATE",
+		"PURCHASE_COMMITMENT",
+		"ADJUST_REQUESTS",
+		"MODIFY",
+		"DELETE_UNUSED",
+		"MIGRATE",
+		"CONSOLIDATE",
+		"SCHEDULE",
+		"REFACTOR",
+		"OTHER",
+	}
+	for _, expected := range expectedTypes {
+		assert.Contains(t, types, expected)
+	}
+}
+
+// T015: Tests for unknown/future enum value handling (display as "Unknown (N)").
+func TestActionTypeLabel_UnknownValue(t *testing.T) {
+	// Test with a hypothetical future value (high integer)
+	unknownType := pbc.RecommendationActionType(999)
+	result := proto.ActionTypeLabel(unknownType)
+
+	assert.Contains(t, result, "Unknown")
+	assert.Contains(t, result, "999")
+}
+
+// Test ActionTypeLabelFromString for string-based lookups.
+func TestActionTypeLabelFromString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"RIGHTSIZE", "RIGHTSIZE", "Rightsize"},
+		{"MIGRATE", "MIGRATE", "Migrate"},
+		{"PURCHASE_COMMITMENT", "PURCHASE_COMMITMENT", "Purchase Commitment"},
+		{"lowercase", "migrate", "Migrate"},
+		{"unknown", "UNKNOWN", "UNKNOWN"},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := proto.ActionTypeLabelFromString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Test MatchesActionType for recommendation filtering.
+func TestMatchesActionType(t *testing.T) {
+	tests := []struct {
+		name     string
+		recType  string
+		types    []pbc.RecommendationActionType
+		expected bool
+	}{
+		{
+			name:     "empty filter matches all",
+			recType:  "MIGRATE",
+			types:    []pbc.RecommendationActionType{},
+			expected: true,
+		},
+		{
+			name:    "matches single type",
+			recType: "MIGRATE",
+			types: []pbc.RecommendationActionType{
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE,
+			},
+			expected: true,
+		},
+		{
+			name:    "matches in multiple types",
+			recType: "RIGHTSIZE",
+			types: []pbc.RecommendationActionType{
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE,
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_RIGHTSIZE,
+			},
+			expected: true,
+		},
+		{
+			name:    "no match in multiple types",
+			recType: "TERMINATE",
+			types: []pbc.RecommendationActionType{
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE,
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_RIGHTSIZE,
+			},
+			expected: false,
+		},
+		{
+			name:    "case insensitive match",
+			recType: "migrate",
+			types: []pbc.RecommendationActionType{
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE,
+			},
+			expected: true,
+		},
+		{
+			name:    "with whitespace",
+			recType: "  MIGRATE  ",
+			types: []pbc.RecommendationActionType{
+				pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE,
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := proto.MatchesActionType(tt.recType, tt.types)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/rshade/pulumicost-core/internal/proto"
 )
 
 // Status text constants.
@@ -143,4 +144,14 @@ func RenderPriority(priority string) string {
 
 	style := lipgloss.NewStyle().Foreground(color).Bold(true)
 	return style.Render(fmt.Sprintf("%s %s", icon, text))
+}
+
+// FormatActionType returns a human-readable label for a recommendation action type.
+// This function is used in TUI displays to show friendly labels like "Purchase Commitment"
+// instead of "PURCHASE_COMMITMENT".
+//
+// Known action types are converted to their human-readable labels. Unknown types
+// are returned as-is for forward compatibility with future action types.
+func FormatActionType(actionType string) string {
+	return proto.ActionTypeLabelFromString(actionType)
 }

--- a/internal/tui/components_test.go
+++ b/internal/tui/components_test.go
@@ -106,6 +106,68 @@ func TestRenderPriority(t *testing.T) {
 	}
 }
 
+// T027: Test FormatActionType for TUI action type label rendering.
+func TestFormatActionType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// Valid action types
+		{"RIGHTSIZE", "RIGHTSIZE", "Rightsize"},
+		{"TERMINATE", "TERMINATE", "Terminate"},
+		{"PURCHASE_COMMITMENT", "PURCHASE_COMMITMENT", "Purchase Commitment"},
+		{"ADJUST_REQUESTS", "ADJUST_REQUESTS", "Adjust Requests"},
+		{"MODIFY", "MODIFY", "Modify"},
+		{"DELETE_UNUSED", "DELETE_UNUSED", "Delete Unused"},
+		{"MIGRATE", "MIGRATE", "Migrate"},
+		{"CONSOLIDATE", "CONSOLIDATE", "Consolidate"},
+		{"SCHEDULE", "SCHEDULE", "Schedule"},
+		{"REFACTOR", "REFACTOR", "Refactor"},
+		{"OTHER", "OTHER", "Other"},
+		// Case insensitivity
+		{"lowercase migrate", "migrate", "Migrate"},
+		{"mixed case Consolidate", "Consolidate", "Consolidate"},
+		{"lowercase other", "other", "Other"},
+		// Unknown types (returned as-is for forward compatibility)
+		{"unknown type", "UNKNOWN", "UNKNOWN"},
+		{"custom type", "CUSTOM_TYPE", "CUSTOM_TYPE"},
+		// Edge cases
+		{"empty string", "", ""},
+		{"with spaces", "  MIGRATE  ", "Migrate"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatActionType(tt.input)
+			if result != tt.expected {
+				t.Errorf("FormatActionType(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+// T030: Test FormatActionType for unknown action types.
+func TestFormatActionType_UnknownTypes(t *testing.T) {
+	// Unknown types should be returned as-is for forward compatibility
+	unknownTypes := []string{
+		"UNKNOWN",
+		"FUTURE_TYPE",
+		"NOT_A_TYPE",
+		"NEW_ACTION",
+	}
+
+	for _, unknown := range unknownTypes {
+		t.Run(unknown, func(t *testing.T) {
+			result := FormatActionType(unknown)
+			// Unknown types are returned as-is (not transformed)
+			if result != unknown {
+				t.Errorf("FormatActionType(%q) = %q, expected %q (unchanged)", unknown, result, unknown)
+			}
+		})
+	}
+}
+
 func TestRenderFunctions_BasicOutput(t *testing.T) {
 	// Test that the functions produce expected output (styling may be disabled in test env)
 	tests := []struct {

--- a/specs/108-action-type-enum/checklists/requirements.md
+++ b/specs/108-action-type-enum/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Extended RecommendationActionType Enum Support
+
+**Purpose**: Validate specification completeness and quality before planning
+**Created**: 2025-12-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Dependency on `cost recommendations` CLI command is documented in Assumptions section
+- This feature extends existing proto enum support (already in pulumicost-spec v0.4.11)
+- No clarifications needed - the upstream spec clearly defines all 11 action types
+- Feature is well-bounded: filter parsing + TUI display + JSON output + CLI help

--- a/specs/108-action-type-enum/data-model.md
+++ b/specs/108-action-type-enum/data-model.md
@@ -1,0 +1,143 @@
+# Data Model: Extended RecommendationActionType Enum Support
+
+**Feature**: 108-action-type-enum
+**Date**: 2025-12-29
+
+## Overview
+
+This feature adds utility functions for working with the
+`RecommendationActionType` enum from pulumicost-spec. No new entities are
+created - the proto enum already exists in the dependency.
+
+## Entities
+
+### RecommendationActionType (from pulumicost-spec)
+
+**Source**: `github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1`
+
+**Type**: Proto3 enum
+
+**Values**:
+
+<!-- markdownlint-disable MD013 MD060 -->
+
+| Enum Value | Int | Short Name | Label |
+| ---------- | --- | ---------- | ----- |
+| `RECOMMENDATION_ACTION_TYPE_UNSPECIFIED` | 0 | UNSPECIFIED | Unspecified |
+| `RECOMMENDATION_ACTION_TYPE_RIGHTSIZE` | 1 | RIGHTSIZE | Rightsize |
+| `RECOMMENDATION_ACTION_TYPE_TERMINATE` | 2 | TERMINATE | Terminate |
+| `RECOMMENDATION_ACTION_TYPE_PURCHASE_COMMITMENT` | 3 | PURCHASE_COMMITMENT | Purchase Commitment |
+| `RECOMMENDATION_ACTION_TYPE_ADJUST_REQUESTS` | 4 | ADJUST_REQUESTS | Adjust Requests |
+| `RECOMMENDATION_ACTION_TYPE_MODIFY` | 5 | MODIFY | Modify |
+| `RECOMMENDATION_ACTION_TYPE_DELETE_UNUSED` | 6 | DELETE_UNUSED | Delete Unused |
+| `RECOMMENDATION_ACTION_TYPE_MIGRATE` | 7 | MIGRATE | Migrate |
+| `RECOMMENDATION_ACTION_TYPE_CONSOLIDATE` | 8 | CONSOLIDATE | Consolidate |
+| `RECOMMENDATION_ACTION_TYPE_SCHEDULE` | 9 | SCHEDULE | Schedule |
+| `RECOMMENDATION_ACTION_TYPE_REFACTOR` | 10 | REFACTOR | Refactor |
+| `RECOMMENDATION_ACTION_TYPE_OTHER` | 11 | OTHER | Other |
+
+<!-- markdownlint-enable MD013 MD060 -->
+
+### ActionTypeInfo (new utility type)
+
+**Location**: `internal/proto/action_types.go`
+
+**Purpose**: Provides Core-side utilities for action type handling
+
+```go
+// ActionTypeInfo holds display and filtering metadata for an action type.
+type ActionTypeInfo struct {
+    // ProtoValue is the proto enum value.
+    ProtoValue pbc.RecommendationActionType
+
+    // ShortName is the filter-friendly name (e.g., "RIGHTSIZE", "MIGRATE").
+    ShortName string
+
+    // DisplayLabel is the human-readable label for TUI display.
+    DisplayLabel string
+}
+```
+
+**Relationships**:
+
+- Maps 1:1 with `pbc.RecommendationActionType` enum values
+- Used by filter parser for validation
+- Used by TUI renderer for display labels
+
+## Functions
+
+### ActionTypeLabel
+
+**Purpose**: Get human-readable label for a proto enum value
+
+**Signature**:
+
+```go
+func ActionTypeLabel(at pbc.RecommendationActionType) string
+```
+
+**Behavior**:
+
+- Returns display label (e.g., "Migrate" for `MIGRATE`)
+- Returns "Unknown (N)" for unrecognized values where N is the integer value
+
+### ParseActionType
+
+**Purpose**: Parse a filter string into proto enum value(s)
+
+**Signature**:
+
+```go
+func ParseActionType(s string) (pbc.RecommendationActionType, error)
+```
+
+**Behavior**:
+
+- Case-insensitive matching
+- Returns error for unknown type names listing valid options
+- Accepts both short names ("MIGRATE") and full names
+  ("RECOMMENDATION_ACTION_TYPE_MIGRATE")
+
+### ParseActionTypeFilter
+
+**Purpose**: Parse comma-separated action types for filter expressions
+
+**Signature**:
+
+```go
+func ParseActionTypeFilter(filter string) ([]pbc.RecommendationActionType, error)
+```
+
+**Behavior**:
+
+- Splits on comma
+- Trims whitespace
+- Validates each value
+- Returns slice of parsed types
+- Returns error if any type is invalid
+
+### ValidActionTypes
+
+**Purpose**: Get list of valid action type names for help text
+
+**Signature**:
+
+```go
+func ValidActionTypes() []string
+```
+
+**Behavior**:
+
+- Returns short names suitable for filter expressions
+- Excludes UNSPECIFIED (not user-selectable)
+
+## Validation Rules
+
+1. **Filter Value**: Must match a known action type short name
+2. **Case Sensitivity**: Matching is case-insensitive
+3. **Unknown Values**: Log warning but don't error during display
+4. **UNSPECIFIED**: Not valid as a filter value (excluded from validation)
+
+## State Transitions
+
+N/A - Action types are immutable enum values with no state.

--- a/specs/108-action-type-enum/plan.md
+++ b/specs/108-action-type-enum/plan.md
@@ -1,0 +1,92 @@
+# Implementation Plan: Extended RecommendationActionType Enum Support
+
+**Branch**: `108-action-type-enum` | **Date**: 2025-12-29 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/108-action-type-enum/spec.md`
+
+## Summary
+
+Update pulumicost-core to fully support the 5 new `RecommendationActionType`
+enum values (MIGRATE, CONSOLIDATE, SCHEDULE, REFACTOR, OTHER) from
+pulumicost-spec v0.4.9+. The dependency is already in place (v0.4.11); this
+feature adds Core-side handling for filter parsing, TUI display labels, CLI
+help text, and JSON serialization.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.5
+**Primary Dependencies**: pulumicost-spec v0.4.11 (pluginsdk), cobra v1.10.1,
+  bubbletea v1.3.10, lipgloss v1.1.0
+**Storage**: N/A (stateless enum mapping)
+**Testing**: go test (stdlib), testify v1.11.1
+**Target Platform**: Linux (amd64, arm64), macOS (amd64, arm64), Windows (amd64)
+**Project Type**: Single CLI project with internal packages
+**Performance Goals**: N/A (simple enum mapping operations)
+**Constraints**: Backward compatibility required for existing 6 action types
+**Scale/Scope**: 5 new enum values, ~3-4 files modified
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Verify compliance with PulumiCost Core Constitution:
+
+- [x] **Plugin-First Architecture**: This is orchestration logic (enum parsing/
+      display) not a cost data source. Plugins already return these types via
+      proto - Core adds user-facing support.
+- [x] **Test-Driven Development**: Tests planned before implementation;
+      table-driven tests for all 11 action type mappings.
+- [x] **Cross-Platform Compatibility**: Pure Go enum handling - no platform-
+      specific code.
+- [x] **Documentation as Code**: CLI help text updated with all action types.
+- [x] **Protocol Stability**: No proto changes - using existing enum values from
+      pulumicost-spec v0.4.9+.
+- [x] **Implementation Completeness**: Full support for all 11 action types, no
+      stubs or TODOs.
+- [x] **Quality Gates**: Tests, lint, coverage checks apply.
+- [x] **Multi-Repo Coordination**: Depends on pulumicost-spec v0.4.11 which is
+      already integrated.
+
+**Violations Requiring Justification**: None
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/108-action-type-enum/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+internal/
+├── proto/
+│   ├── adapter.go           # Recommendation struct - existing
+│   └── action_types.go      # NEW: Action type utilities
+├── cli/
+│   └── cost_recommendations.go  # NEW: CLI command for recommendations
+└── tui/
+    └── components.go        # TUI label rendering (when recommendations TUI added)
+
+```
+
+**Test Files** (Go convention: tests alongside source):
+
+```text
+internal/proto/action_types_test.go   # Table-driven tests for action type utilities
+internal/cli/cost_recommendations_test.go  # CLI command tests
+```
+
+**Structure Decision**: This feature adds the `cost recommendations` CLI command
+by leveraging existing engine infrastructure (`GetRecommendationsForResources()`,
+`RecommendationsResult`, `Recommendation` types). The new CLI command follows
+patterns established by `cost actual` and `cost projected` commands.
+
+## Complexity Tracking
+
+No violations requiring justification.

--- a/specs/108-action-type-enum/quickstart.md
+++ b/specs/108-action-type-enum/quickstart.md
@@ -1,0 +1,129 @@
+# Quickstart: Extended RecommendationActionType Enum Support
+
+**Feature**: 108-action-type-enum
+**Date**: 2025-12-29
+
+## Overview
+
+This feature adds the `cost recommendations` CLI command and full support for
+all 11 `RecommendationActionType` enum values in the CLI filter parser, TUI
+display, and JSON output.
+
+## Usage Examples
+
+### Basic Recommendations Command
+
+```bash
+# Get all cost optimization recommendations for resources in a Pulumi plan
+pulumicost cost recommendations --pulumi-json plan.json
+
+# Output recommendations as JSON
+pulumicost cost recommendations --pulumi-json plan.json --output json
+
+# Use a specific adapter/plugin
+pulumicost cost recommendations --pulumi-json plan.json --adapter kubecost
+```
+
+### Filtering by Action Type
+
+```bash
+# Filter recommendations by a single action type
+pulumicost cost recommendations --pulumi-json plan.json --filter "action=MIGRATE"
+
+# Filter by multiple action types (comma-separated)
+pulumicost cost recommendations --pulumi-json plan.json --filter "action=RIGHTSIZE,TERMINATE"
+
+# Case-insensitive matching works
+pulumicost cost recommendations --pulumi-json plan.json --filter "action=migrate,consolidate"
+```
+
+### Available Action Types for Filtering
+
+<!-- markdownlint-disable MD060 -->
+
+| Type | Description |
+| ---- | ----------- |
+| RIGHTSIZE | Resize resources to match actual usage |
+| TERMINATE | Stop or delete idle resources |
+| PURCHASE_COMMITMENT | Reserved instances/savings plans |
+| ADJUST_REQUESTS | Kubernetes request/limit tuning |
+| MODIFY | General configuration changes |
+| DELETE_UNUSED | Remove orphaned/unused resources |
+| MIGRATE | Move workloads to different regions/zones/SKUs |
+| CONSOLIDATE | Combine multiple resources into fewer, larger ones |
+| SCHEDULE | Start/stop resources on schedule (dev/test) |
+| REFACTOR | Architectural changes (e.g., move to serverless) |
+| OTHER | Provider-specific recommendations |
+
+<!-- markdownlint-enable MD060 -->
+
+### TUI Display
+
+When viewing recommendations in TUI mode, each action type displays with a
+human-readable label:
+
+- "Migrate" instead of "MIGRATE"
+- "Purchase Commitment" instead of "PURCHASE_COMMITMENT"
+- "Adjust Requests" instead of "ADJUST_REQUESTS"
+
+### JSON Output
+
+JSON output preserves the canonical enum string names:
+
+```json
+{
+  "recommendations": [
+    {
+      "action_type": "MIGRATE",
+      "description": "Move EC2 instance to us-west-2 region",
+      "estimated_savings": 45.00
+    },
+    {
+      "action_type": "SCHEDULE",
+      "description": "Stop dev instance outside business hours",
+      "estimated_savings": 120.00
+    }
+  ]
+}
+```
+
+### Error Handling
+
+Invalid action type filter values produce helpful error messages:
+
+```bash
+$ pulumicost cost recommendations --pulumi-json plan.json --filter "action=INVALID"
+Error: invalid action type "INVALID". Valid types: RIGHTSIZE, TERMINATE,
+PURCHASE_COMMITMENT, ADJUST_REQUESTS, MODIFY, DELETE_UNUSED, MIGRATE,
+CONSOLIDATE, SCHEDULE, REFACTOR, OTHER
+```
+
+## Developer Integration
+
+### Using Action Type Utilities
+
+```go
+import "github.com/rshade/pulumicost-core/internal/proto"
+
+// Get display label for TUI
+label := proto.ActionTypeLabel(pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE)
+// Returns: "Migrate"
+
+// Parse filter string
+actionType, err := proto.ParseActionType("migrate")
+// Returns: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE, nil
+
+// Parse multiple action types from filter
+types, err := proto.ParseActionTypeFilter("migrate,consolidate,schedule")
+// Returns: []pbc.RecommendationActionType{MIGRATE, CONSOLIDATE, SCHEDULE}, nil
+
+// Get valid types for help text
+validTypes := proto.ValidActionTypes()
+// Returns: []string{"RIGHTSIZE", "TERMINATE", ..., "OTHER"}
+```
+
+## Backward Compatibility
+
+- Existing filters using original 6 action types continue to work
+- No changes to JSON output format
+- Proto enum values maintain their integer mappings

--- a/specs/108-action-type-enum/research.md
+++ b/specs/108-action-type-enum/research.md
@@ -1,0 +1,214 @@
+# Research: Extended RecommendationActionType Enum Support
+
+**Feature**: 108-action-type-enum
+**Date**: 2025-12-29
+
+## Research Questions
+
+### RQ-1: Upstream Enum Values Availability
+
+**Question**: Are all 11 action types available in the current pulumicost-spec
+dependency?
+
+**Finding**: Yes. pulumicost-spec v0.4.11 (current dependency) includes all 11
+`RecommendationActionType` values via the `AllRecommendationActionTypes()`
+helper function in `sdk/go/proto/pulumicost/v1/action_types.go`.
+
+**Evidence**:
+
+```go
+// From pulumicost-spec v0.4.11 action_types.go
+var allRecommendationActionTypes = []RecommendationActionType{
+    RecommendationActionType_RECOMMENDATION_ACTION_TYPE_UNSPECIFIED,
+    RecommendationActionType_RECOMMENDATION_ACTION_TYPE_RIGHTSIZE,
+    RecommendationActionType_RECOMMENDATION_ACTION_TYPE_TERMINATE,
+    RecommendationActionType_RECOMMENDATION_ACTION_TYPE_PURCHASE_COMMITMENT,
+    RecommendationActionType_RECOMMENDATION_ACTION_TYPE_ADJUST_REQUESTS,
+    RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MODIFY,
+    RecommendationActionType_RECOMMENDATION_ACTION_TYPE_DELETE_UNUSED,
+    RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MIGRATE,
+    RecommendationActionType_RECOMMENDATION_ACTION_TYPE_CONSOLIDATE,
+    RecommendationActionType_RECOMMENDATION_ACTION_TYPE_SCHEDULE,
+    RecommendationActionType_RECOMMENDATION_ACTION_TYPE_REFACTOR,
+    RecommendationActionType_RECOMMENDATION_ACTION_TYPE_OTHER,
+}
+```
+
+**Decision**: Use the existing `pbc.AllRecommendationActionTypes()` and
+`pbc.IsValidRecommendationActionType()` functions from pluginsdk for validation.
+
+### RQ-2: Current Recommendation Struct in Core
+
+**Question**: How does pulumicost-core currently represent recommendations?
+
+**Finding**: The `internal/proto/adapter.go` defines a `Recommendation` struct
+with an `ActionType string` field. This is a string representation, not a typed
+enum.
+
+**Evidence**:
+
+```go
+// From internal/proto/adapter.go:374-398
+type Recommendation struct {
+    ID          string
+    Category    string
+    ActionType  string  // String, e.g., "RIGHTSIZE", "TERMINATE"
+    Description string
+    ResourceID  string
+    Source      string
+    Impact      *RecommendationImpact
+    Metadata    map[string]string
+}
+```
+
+**Decision**: Create an action type mapping utility that:
+
+1. Converts proto enum values to human-readable labels for TUI
+2. Validates string values in filter expressions against valid enum names
+3. Provides case-insensitive matching for filter parsing
+
+### RQ-3: Filter Expression Pattern
+
+**Question**: What filter parsing patterns exist in the codebase?
+
+**Finding**: The `cost actual` command uses `--filter` flag with `key=value`
+syntax. Filter values are parsed with `strings.Split` and validated against
+known types.
+
+**Evidence**:
+
+```go
+// From internal/cli/cost_actual.go:17
+const (
+    filterKeyValueParts = 2   // For "key=value" pairs
+)
+```
+
+**Decision**: Follow the same pattern for action type filtering:
+
+- Filter syntax: `action=MIGRATE,RIGHTSIZE` (comma-separated)
+- Case-insensitive matching: `action=migrate` matches `MIGRATE`
+- Validation: reject unknown types with error listing valid options
+
+### RQ-4: TUI Label Display Pattern
+
+**Question**: How does the TUI currently display typed values?
+
+**Finding**: The `internal/tui/` package uses Lip Gloss for styling. Labels are
+typically title-cased for display.
+
+**Evidence**: TUI components use `text/transform` or direct title-casing for
+human-readable labels.
+
+**Decision**: Create a mapping function:
+
+<!-- markdownlint-disable MD060 -->
+
+| Proto Enum Value | Display Label |
+| ---------------- | ------------- |
+| `RECOMMENDATION_ACTION_TYPE_RIGHTSIZE` | Rightsize |
+| `RECOMMENDATION_ACTION_TYPE_TERMINATE` | Terminate |
+| `RECOMMENDATION_ACTION_TYPE_PURCHASE_COMMITMENT` | Purchase Commitment |
+| `RECOMMENDATION_ACTION_TYPE_ADJUST_REQUESTS` | Adjust Requests |
+| `RECOMMENDATION_ACTION_TYPE_MODIFY` | Modify |
+| `RECOMMENDATION_ACTION_TYPE_DELETE_UNUSED` | Delete Unused |
+| `RECOMMENDATION_ACTION_TYPE_MIGRATE` | Migrate |
+| `RECOMMENDATION_ACTION_TYPE_CONSOLIDATE` | Consolidate |
+| `RECOMMENDATION_ACTION_TYPE_SCHEDULE` | Schedule |
+| `RECOMMENDATION_ACTION_TYPE_REFACTOR` | Refactor |
+| `RECOMMENDATION_ACTION_TYPE_OTHER` | Other |
+
+<!-- markdownlint-enable MD060 -->
+
+### RQ-5: Unknown Enum Value Handling
+
+**Question**: How should unknown/future enum values be handled?
+
+**Finding**: Proto3 enums are forward-compatible. Unrecognized numeric values
+deserialize as the raw integer. The `pbc.IsValidRecommendationActionType()`
+function returns `false` for unknown values.
+
+**Decision**:
+
+1. For display: Show "Unknown (N)" where N is the raw integer value
+2. For filtering: Only known string names are valid in filter expressions
+3. Log warning when encountering unknown values
+4. Never error on unknown values - allow operation to continue
+
+### RQ-6: Existing Recommendations Infrastructure
+
+**Question**: What recommendation infrastructure already exists in pulumicost-core?
+
+**Finding**: Substantial infrastructure exists for fetching and processing
+recommendations from plugins. The CLI command just needs to wire this together.
+
+**Evidence**:
+
+```go
+// From internal/proto/adapter.go - CostSourceClient interface
+GetRecommendations(
+    ctx context.Context,
+    in *GetRecommendationsRequest,
+    opts ...grpc.CallOption,
+) (*GetRecommendationsResponse, error)
+
+// From internal/engine/engine.go - Engine method
+func (e *Engine) GetRecommendationsForResources(
+    ctx context.Context,
+    resources []ResourceDescriptor,
+) (*RecommendationsResult, error)
+
+// From internal/engine/types.go - Result types
+type RecommendationsResult struct {
+    Recommendations []Recommendation
+    Errors          []RecommendationError
+}
+```
+
+**Decision**: Implement `cost recommendations` CLI command following patterns from
+`cost actual`:
+
+1. Load Pulumi plan and map resources (reuse `loadAndMapResources()`)
+2. Open plugin connections (reuse `openPlugins()`)
+3. Call `engine.GetRecommendationsForResources()`
+4. Render output (table/JSON/NDJSON)
+5. Apply action type filter using new `ParseActionTypeFilter()` utility
+
+## Alternatives Considered
+
+### Alternative 1: Hardcode All 11 Types in Core
+
+**Rejected because**: Creates maintenance burden - must update Core every time
+spec adds new types.
+
+**Chosen approach**: Use `pbc.AllRecommendationActionTypes()` from pluginsdk to
+dynamically get valid types.
+
+### Alternative 2: Use Proto Enum String Names Directly for Display
+
+**Rejected because**: `RECOMMENDATION_ACTION_TYPE_RIGHTSIZE` is not user-
+friendly.
+
+**Chosen approach**: Create human-readable label mapping with title-cased,
+space-separated words.
+
+### Alternative 3: Case-Sensitive Filter Matching
+
+**Rejected because**: Forces users to remember exact casing (`RIGHTSIZE` not
+`rightsize`).
+
+**Chosen approach**: Case-insensitive matching with `strings.EqualFold()`.
+
+## Summary
+
+<!-- markdownlint-disable MD060 -->
+
+| Decision | Rationale |
+| -------- | --------- |
+| Use `pbc.AllRecommendationActionTypes()` | Dynamic enum list from spec SDK |
+| String-to-label mapping table | Human-readable TUI display |
+| Case-insensitive filter matching | Better UX for CLI |
+| Log + display "Unknown" for unrecognized | Forward compatibility |
+| Add `cost recommendations` command | Leverage existing engine infrastructure |
+
+<!-- markdownlint-enable MD060 -->

--- a/specs/108-action-type-enum/spec.md
+++ b/specs/108-action-type-enum/spec.md
@@ -1,0 +1,241 @@
+# Feature Specification: Extended RecommendationActionType Enum Support
+
+**Feature Branch**: `108-action-type-enum`
+**Created**: 2025-12-29
+**Status**: Draft
+**Input**: "Support extended RecommendationActionType enum from pulumicost-spec"
+**GitHub Issue**: #298
+
+## Overview
+
+Update pulumicost-core components to recognize and properly handle the 5 new
+`RecommendationActionType` enum values (MIGRATE, CONSOLIDATE, SCHEDULE,
+REFACTOR, OTHER) that were added to pulumicost-spec v0.4.9.
+
+## Context
+
+The pulumicost-spec v0.4.9 release (2025-12-18) extended the
+`RecommendationActionType` enum from 6 to 11 values via PR #173. The current
+pulumicost-core (v0.4.11) already has this dependency but internal components
+(filter parser, TUI display, CLI help text) only recognize the original 6 types:
+
+**Original Types (already supported)**:
+
+- RIGHTSIZE - Resize resources to match actual usage
+- TERMINATE - Stop or delete idle resources
+- PURCHASE_COMMITMENT - Reserved instances/savings plans
+- ADJUST_REQUESTS - Kubernetes request/limit tuning
+- MODIFY - General configuration changes
+- DELETE_UNUSED - Remove orphaned/unused resources
+
+**New Types (to be supported)**:
+
+- MIGRATE - Move workloads to different regions/zones/SKUs
+- CONSOLIDATE - Combine multiple resources into fewer, larger ones
+- SCHEDULE - Start/stop resources on schedule (dev/test)
+- REFACTOR - Architectural changes (e.g., move to serverless)
+- OTHER - Catch-all for provider-specific recommendations
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Filter Recommendations by New Action Types (Priority: P1)
+
+As a cloud infrastructure operator, I want to filter cost recommendations by the
+new action types (MIGRATE, CONSOLIDATE, SCHEDULE, REFACTOR, OTHER), so that I
+can focus on specific categories of optimization opportunities.
+
+**Why this priority**: Filtering is the primary way users narrow down large sets
+of recommendations. Without parser support for new types, users cannot filter by
+these categories at all.
+
+**Independent Test**: Can be fully tested by using the filter flag with new
+action type values and verifying only matching recommendations are displayed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a set of recommendations including MIGRATE and RIGHTSIZE types,
+   **When** I run `pulumicost cost recommendations --filter "action=MIGRATE"`,
+   **Then** only MIGRATE recommendations are shown.
+
+2. **Given** a set of recommendations with various action types,
+   **When** I run `pulumicost cost recommendations --filter "action=SCHEDULE,REFACTOR"`,
+   **Then** only SCHEDULE and REFACTOR recommendations are shown.
+
+3. **Given** a filter with the value "action=INVALID_TYPE",
+   **When** I run the command,
+   **Then** an error message lists all valid action types including the 5 new ones.
+
+---
+
+### User Story 2 - Display New Action Types in TUI (Priority: P2)
+
+As a cloud infrastructure operator viewing recommendations in the TUI, I want
+new action types to display with appropriate labels and visual indicators, so
+that I can quickly identify the type of optimization without referring to
+documentation.
+
+**Why this priority**: Users who enable TUI mode expect consistent visual
+treatment of all data. Displaying "UNKNOWN" or raw enum values for new types
+would be confusing.
+
+**Independent Test**: Can be fully tested by returning recommendations with new
+action types from a mock plugin and verifying the TUI renders them with proper
+labels.
+
+**Acceptance Scenarios**:
+
+1. **Given** a recommendation with action type MIGRATE,
+   **When** I view it in TUI mode,
+   **Then** I see a "Migrate" label (not "MIGRATE" or "Unknown").
+
+2. **Given** recommendations with all 11 action types,
+   **When** I view them in TUI mode,
+   **Then** each type displays with an appropriate human-readable label.
+
+3. **Given** a recommendation with action type OTHER,
+   **When** I view it in TUI mode,
+   **Then** I see "Other" label to indicate provider-specific recommendation.
+
+---
+
+### User Story 3 - JSON Output Includes New Action Types (Priority: P3)
+
+As an automation engineer consuming recommendation output programmatically, I
+want new action types to be correctly serialized in JSON output, so that my
+scripts can process all recommendation types consistently.
+
+**Why this priority**: JSON output is critical for automation but follows the
+same data flow as TUI - if action types are correctly parsed, JSON serialization
+follows naturally.
+
+**Independent Test**: Can be fully tested by requesting JSON output for
+recommendations with new action types and validating the structure.
+
+**Acceptance Scenarios**:
+
+1. **Given** recommendations with CONSOLIDATE and SCHEDULE types,
+   **When** I request output as `--output json`,
+   **Then** the `action_type` field contains the correct string values.
+
+2. **Given** recommendations with all 11 action types,
+   **When** I request output as `--output json`,
+   **Then** all action types serialize to their expected string representation.
+
+---
+
+### User Story 4 - CLI Command for Recommendations (Priority: P0)
+
+As a cloud infrastructure operator, I want a `cost recommendations` CLI command
+that fetches and displays cost optimization recommendations from plugins, so that
+I can review optimization opportunities independently of `pulumi preview`.
+
+**Why this priority**: This is a prerequisite for all other user stories. Without
+the CLI command, there's no way to filter, display, or serialize recommendations.
+The engine infrastructure (`GetRecommendationsForResources()`) already exists.
+
+**Independent Test**: Can be fully tested by running the command with a Pulumi
+plan JSON and verifying recommendations are fetched from plugins and displayed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Pulumi plan JSON and an installed cost plugin,
+   **When** I run `pulumicost cost recommendations --pulumi-json plan.json`,
+   **Then** I see a table of recommendations with ID, ActionType, Description,
+   ResourceID, and EstimatedSavings columns.
+
+2. **Given** a Pulumi plan JSON with resources that have recommendations,
+   **When** I run `pulumicost cost recommendations --output json`,
+   **Then** I receive valid JSON with all recommendation fields.
+
+3. **Given** no installed plugins that support recommendations,
+   **When** I run `pulumicost cost recommendations --pulumi-json plan.json`,
+   **Then** I see an informative message that no recommendations are available.
+
+4. **Given** a plan with multiple resources,
+   **When** I run with `--filter "action=MIGRATE"`,
+   **Then** only MIGRATE recommendations are shown.
+
+---
+
+### Edge Cases
+
+- What happens when a plugin returns an unrecognized action type value?
+  Display as "Unknown (value)" and log a warning; do not error.
+- What happens when the protobuf enum has additional future values?
+  Handle gracefully as "Unknown" - forward compatibility for enum extension.
+- What happens when filtering by a mix of valid and invalid action types?
+  Reject the entire filter with an error listing valid types.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST recognize all 11 RecommendationActionType values in
+  filter expressions: RIGHTSIZE, TERMINATE, PURCHASE_COMMITMENT, ADJUST_REQUESTS,
+  MODIFY, DELETE_UNUSED, MIGRATE, CONSOLIDATE, SCHEDULE, REFACTOR, OTHER.
+
+- **FR-002**: System MUST provide human-readable labels for new action types in
+  TUI display: "Migrate", "Consolidate", "Schedule", "Refactor", "Other".
+
+- **FR-003**: System MUST include all 11 action types in CLI help text for the
+  `--filter` flag.
+
+- **FR-004**: System MUST serialize new action types correctly in JSON output
+  using their string representation (e.g., "MIGRATE", "CONSOLIDATE").
+
+- **FR-005**: System MUST handle unknown/future action type values gracefully by
+  displaying "Unknown" and logging a warning (not erroring).
+
+- **FR-006**: System MUST maintain backward compatibility - existing action types
+  (RIGHTSIZE, TERMINATE, etc.) continue to work unchanged.
+
+- **FR-007**: Filter parser MUST support case-insensitive matching for action
+  types (e.g., "migrate" matches MIGRATE).
+
+- **FR-008**: System MUST provide a `cost recommendations` CLI command that
+  fetches recommendations from plugins via `Engine.GetRecommendationsForResources()`
+  and displays them in table, JSON, or NDJSON format.
+
+### Key Entities
+
+- **RecommendationActionType**: Extended enum with 11 values representing
+  different cost optimization action categories. Used for filtering, display,
+  and serialization.
+
+- **ActionTypeLabel**: Human-readable mapping from enum values to display
+  labels for TUI rendering (e.g., MIGRATE -> "Migrate").
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can filter recommendations by all 11 action types without
+  errors or unexpected behavior.
+
+- **SC-002**: TUI displays appropriate labels for all 11 action types with no
+  "Unknown" labels for valid types.
+
+- **SC-003**: JSON output correctly serializes all 11 action types.
+
+- **SC-004**: CLI help text includes all 11 action types as valid filter values.
+
+- **SC-005**: Backward compatibility: existing filters using original 6 action
+  types continue to work without modification.
+
+- **SC-006**: Unit test coverage for new action type handling reaches 80%+.
+
+- **SC-007**: `cost recommendations` command successfully fetches and displays
+  recommendations from plugins using existing engine infrastructure.
+
+## Assumptions
+
+- Engine infrastructure for recommendations already exists:
+  `Engine.GetRecommendationsForResources()`, `RecommendationsResult`,
+  `Recommendation` types, and `CostSourceClient.GetRecommendations()`.
+
+- Filter expression parsing follows patterns established in `cost actual` command.
+
+- TUI components follow existing label/styling patterns in `internal/tui/`.
+
+- The pulumicost-spec v0.4.9+ dependency (already at v0.4.11) includes the
+  extended enum values in generated Go code.

--- a/specs/108-action-type-enum/tasks.md
+++ b/specs/108-action-type-enum/tasks.md
@@ -1,0 +1,302 @@
+# Tasks: Extended RecommendationActionType Enum Support
+
+**Input**: Design documents from `/specs/108-action-type-enum/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Per Constitution Principle II (Test-Driven Development), tests are
+MANDATORY and must be written BEFORE implementation. All code changes must
+maintain minimum 80% test coverage.
+
+**Completeness**: Per Constitution Principle VI (Implementation Completeness),
+all tasks MUST be fully implemented. Stub functions, placeholders, and TODO
+comments are strictly forbidden.
+
+**Organization**: Tasks are grouped by user story to enable independent
+implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+This is a Go CLI project with existing packages:
+
+- `internal/proto/` - Protocol adapter and recommendation types
+- `internal/cli/` - CLI commands
+- `internal/tui/` - Terminal UI components
+- `test/unit/` - Unit tests
+
+---
+
+## Phase 0: CLI Command (Priority: P0)
+
+**Purpose**: Add `cost recommendations` CLI command using existing engine
+infrastructure. This is a prerequisite for all filtering/display features.
+
+### Tests for CLI Command (TDD Required)
+
+- [x] T001 [P] [US4] Write tests for NewCostRecommendationsCmd() in
+      internal/cli/cost_recommendations_test.go
+- [x] T002 [P] [US4] Write tests for recommendations output rendering (table,
+      JSON, NDJSON) in internal/cli/cost_recommendations_test.go
+- [x] T003 [P] [US4] Write tests for --filter flag parsing with action types in
+      internal/cli/cost_recommendations_test.go
+
+### Implementation for CLI Command
+
+- [x] T004 [US4] Create internal/cli/cost_recommendations.go with
+      NewCostRecommendationsCmd() following cost_actual.go patterns
+- [x] T005 [US4] Add --pulumi-json, --adapter, --output, --filter flags to
+      command
+- [x] T006 [US4] Implement executeCostRecommendations() calling
+      Engine.GetRecommendationsForResources()
+- [x] T007 [US4] Implement RenderRecommendationsOutput() for table/JSON/NDJSON
+      formats in internal/cli/cost_recommendations.go (follows cost_actual.go pattern)
+- [x] T008 [US4] Wire command into cost command group in internal/cli/root.go
+
+**Checkpoint**: `cost recommendations` command works with table/JSON output
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify dependencies and create new files
+
+- [x] T009 [Setup] Verify pulumicost-spec v0.4.11 is present with extended
+      action types in go.mod
+- [x] T010 [Setup] Create new file internal/proto/action_types.go for action
+      type utilities
+
+---
+
+## Phase 2: Foundational (Core Utilities)
+
+**Purpose**: Create shared action type utilities used by ALL user stories
+
+**CRITICAL**: User stories depend on these utilities being complete first
+
+### Tests for Foundational Phase (TDD Required)
+
+- [x] T011 [P] [Core] Write table-driven tests for ActionTypeLabel() covering
+      all 11 types in internal/proto/action_types_test.go
+- [x] T012 [P] [Core] Write table-driven tests for ParseActionType() with
+      valid/invalid inputs in internal/proto/action_types_test.go
+- [x] T013 [P] [Core] Write table-driven tests for ParseActionTypeFilter() with
+      comma-separated values in internal/proto/action_types_test.go
+- [x] T014 [P] [Core] Write tests for ValidActionTypes() excluding UNSPECIFIED
+      in internal/proto/action_types_test.go
+- [x] T015 [P] [Core] Write tests for unknown/future enum value handling
+      (display as "Unknown (N)") in internal/proto/action_types_test.go
+
+### Implementation for Foundational Phase
+
+- [x] T016 [Core] Implement actionTypeLabels map with all 11 human-readable
+      labels in internal/proto/action_types.go
+- [x] T017 [Core] Implement ActionTypeLabel(at pbc.RecommendationActionType)
+      string in internal/proto/action_types.go
+- [x] T018 [Core] Implement ParseActionType(s string)
+      (pbc.RecommendationActionType, error) with case-insensitive matching in
+      internal/proto/action_types.go
+- [x] T019 [Core] Implement ParseActionTypeFilter(filter string)
+      ([]pbc.RecommendationActionType, error) in internal/proto/action_types.go
+- [x] T020 [Core] Implement ValidActionTypes() []string excluding UNSPECIFIED in
+      internal/proto/action_types.go
+- [x] T021 [Core] Run tests and verify all pass with 80%+ coverage: go test
+      -cover ./internal/proto/...
+
+**Checkpoint**: Foundation ready - utilities for all user stories are complete
+
+---
+
+## Phase 3: User Story 1 - Filter Recommendations (Priority: P1)
+
+**Goal**: Enable filtering recommendations by the new action types (MIGRATE,
+CONSOLIDATE, SCHEDULE, REFACTOR, OTHER)
+
+**Independent Test**: Filter flag accepts new action types and returns only
+matching recommendations
+
+### Tests for User Story 1 (TDD Required)
+
+- [x] T022 [P] [US1] Write tests for action type filter parsing in CLI command
+      in internal/cli/cost_recommendations_test.go
+- [x] T023 [P] [US1] Write tests for invalid action type filter error message
+      listing all 11 valid types in internal/cli/cost_recommendations_test.go
+
+### Implementation for User Story 1
+
+- [x] T024 [US1] Add MatchesActionType(rec Recommendation, types
+      []pbc.RecommendationActionType) bool helper in internal/proto/action_types.go
+- [x] T025 [US1] Integrate action type filter into cost recommendations command
+      using ParseActionTypeFilter() from action_types.go
+- [x] T026 [US1] Update CLI help text to list all 11 valid action types in
+      internal/cli/cost_recommendations.go
+
+**Checkpoint**: User Story 1 complete - users can filter by all action types
+
+---
+
+## Phase 4: User Story 2 - TUI Display Labels (Priority: P2)
+
+**Goal**: Display human-readable labels for all action types in TUI mode
+
+**Note**: The TUI package (`internal/tui/`) exists with shared components. This
+phase adds action type formatting utilities that will be used by CLI table output
+and any future recommendations TUI view.
+
+**Independent Test**: Mock recommendations with new action types display proper
+labels in TUI
+
+### Tests for User Story 2 (TDD Required)
+
+- [x] T027 [P] [US2] Write tests for TUI action type label rendering in
+      internal/tui/components_test.go
+
+### Implementation for User Story 2
+
+- [x] T028 [US2] Add FormatActionType(actionType string) string function using
+      ActionTypeLabel() in internal/tui/components.go
+- [x] T029 [US2] Use FormatActionType() in CLI table output for recommendations
+      in internal/cli/cost_recommendations.go
+- [x] T030 [US2] Verify unknown action types display as "Unknown (N)" with
+      warning log in internal/tui/components.go
+
+**Checkpoint**: User Story 2 complete - TUI shows human-readable labels
+
+---
+
+## Phase 5: User Story 3 - JSON Output (Priority: P3)
+
+**Goal**: JSON output correctly serializes all action types
+
+**Independent Test**: JSON output contains correct action_type string values
+
+### Tests for User Story 3 (TDD Required)
+
+- [x] T031 [P] [US3] Write tests for JSON serialization of all 11 action types
+      in internal/proto/adapter_test.go
+
+### Implementation for User Story 3
+
+- [x] T032 [US3] Verify Recommendation struct's ActionType string field is
+      populated correctly from proto in internal/proto/adapter.go
+- [x] T033 [US3] Add integration test validating JSON output format with new
+      action types in internal/cli/cost_recommendations_test.go
+
+**Checkpoint**: User Story 3 complete - JSON output includes all action types
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and documentation
+
+- [x] T034 [P] Run full test suite: make test
+- [x] T035 [P] Run linting: make lint
+- [x] T036 [P] Verify 80% test coverage for new code: go test -cover
+      ./internal/proto/... ./internal/cli/...
+- [x] T037 Update CLAUDE.md with any new patterns or utilities discovered
+- [x] T038 Validate quickstart.md examples work correctly with cost
+      recommendations command
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 0 (CLI Command)**: No dependencies - can start immediately
+- **Phase 1 (Setup)**: No dependencies - can run in parallel with Phase 0
+- **Phase 2 (Foundational)**: Depends on Phase 1 - BLOCKS all user stories
+- **Phase 3-5 (User Stories)**: Depend on Phase 0 (CLI) and Phase 2 (Foundational)
+  - User stories can proceed in priority order (P1 → P2 → P3)
+  - Or in parallel if team capacity allows
+- **Phase 6 (Polish)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US4 (CLI Command)**: Core command needed for all other stories
+- **US1 (Filter)**: Needs US4 + ActionTypeLabel, ParseActionType, ValidActionTypes
+- **US2 (TUI)**: Needs ActionTypeLabel for display
+- **US3 (JSON)**: No additional utilities needed - uses existing struct
+
+### Within Each Phase
+
+- Tests MUST be written and FAIL before implementation (TDD)
+- Tests can run in parallel (marked [P])
+- Implementation follows test completion
+- Verify tests pass before moving to next phase
+
+### Parallel Opportunities
+
+```text
+Phase 0 - All tests (T001-T003) can run in parallel
+Phase 0 - Implementation (T004-T008) is sequential (shared files)
+Phase 2 - All tests (T011-T015) can run in parallel
+Phase 2 - Implementation (T016-T020) is sequential (shared file)
+Phase 3 - Tests (T022-T023) can run in parallel
+Phase 4 - Tests (T027) independent
+Phase 5 - Tests (T031) independent
+Phase 6 - Validation tasks (T034-T036) can run in parallel
+```
+
+---
+
+## Parallel Example: Phase 0 and Phase 2 Tests
+
+```bash
+# Launch Phase 0 CLI command tests:
+Task: "Write tests for NewCostRecommendationsCmd() in cost_recommendations_test.go"
+Task: "Write tests for recommendations output rendering in cost_recommendations_test.go"
+Task: "Write tests for --filter flag parsing in cost_recommendations_test.go"
+
+# Launch Phase 2 foundational tests:
+Task: "Write table-driven tests for ActionTypeLabel() in action_types_test.go"
+Task: "Write table-driven tests for ParseActionType() in action_types_test.go"
+Task: "Write table-driven tests for ParseActionTypeFilter() in action_types_test.go"
+Task: "Write tests for ValidActionTypes() in action_types_test.go"
+Task: "Write tests for unknown enum value handling in action_types_test.go"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (CLI Command + Filtering)
+
+1. Complete Phase 0: CLI Command (the command itself)
+2. Complete Phase 1: Setup (verify dependencies)
+3. Complete Phase 2: Foundational (core utilities with TDD)
+4. Complete Phase 3: User Story 1 (filter support)
+5. **STOP and VALIDATE**: Test `cost recommendations --filter "action=MIGRATE"`
+6. Ship/demo MVP
+
+### Incremental Delivery
+
+1. Phase 0 (CLI Command) → Basic command works
+2. Phase 1+2 (Setup + Foundational) → Action type utilities ready
+3. Add User Story 1 (Filter) → Test independently → Deploy (MVP!)
+4. Add User Story 2 (TUI Labels) → Test independently → Deploy
+5. Add User Story 3 (JSON Output) → Test independently → Deploy
+6. Each story adds value without breaking previous stories
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story (US1, US2, US3, US4)
+- [Setup] = Phase 1 setup tasks
+- [Core] = Phase 2 foundational utilities used by multiple stories
+- US4 = CLI Command (P0 prerequisite for all other stories)
+- All 11 action types must be covered: RIGHTSIZE, TERMINATE,
+  PURCHASE_COMMITMENT, ADJUST_REQUESTS, MODIFY, DELETE_UNUSED, MIGRATE,
+  CONSOLIDATE, SCHEDULE, REFACTOR, OTHER
+- Use pbc.AllRecommendationActionTypes() from pluginsdk for dynamic validation
+- Case-insensitive matching with strings.EqualFold() for filter parsing
+- Display "Unknown (N)" for unrecognized values (forward compatibility)
+- Commit after each task or logical group
+- Total: 38 tasks across 7 phases (Phase 0-6)


### PR DESCRIPTION
## Summary

Implements the `cost recommendations` CLI command that fetches FinOps optimization recommendations from plugins and displays them in table, JSON, or NDJSON format. Adds comprehensive support for all 11 `RecommendationActionType` enum values with human-readable labels, case-insensitive filter parsing, and forward-compatible handling of unknown enum values.

## Test plan

- [x] `make test` passes - all unit tests pass
- [x] `make lint` passes - zero issues
- [x] Test coverage: 100% on action_types.go functions
- [x] CLI help shows all 11 valid action types
- [x] `cost recommendations --help` displays proper usage examples

## Changes

### New files

- `internal/proto/action_types.go` - Action type utilities (label mapping, parsing, validation)
- `internal/proto/action_types_test.go` - Table-driven tests with 100% coverage
- `internal/cli/cost_recommendations.go` - CLI command implementation following cost_actual.go patterns
- `internal/cli/cost_recommendations_test.go` - CLI command tests

### Modified files

- `internal/cli/root.go` - Wire recommendations command into cost group
- `internal/tui/components.go` - Add FormatActionType() for TUI display
- `internal/tui/components_test.go` - Tests for action type formatting
- `internal/proto/adapter_test.go` - JSON serialization tests for all 11 action types
- `CLAUDE.md` - Document action type utilities and patterns

Closes #298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cost recommendations CLI command to analyze Pulumi deployments and suggest optimizations
  * Added action-type filtering to refine recommendation results
  * Added multiple output formats (table, JSON, NDJSON)

* **Documentation**
  * Updated documentation for the new cost recommendations feature
  * Added roadmap items for project branding exploration and automated cost-change reporting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->