### PR TITLE
fix(test): align JSON output tests with finfocus wrapper pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,14 @@ finfocus plugin inspect aws-public aws:ec2/instance:Instance --json
       "status": "SUPPORTED"
     },
     {
+      "fieldName": "region",
+      "status": "SUPPORTED"
+    },
+    {
+      "fieldName": "tenancy",
+      "status": "SUPPORTED"
+    },
+    {
       "fieldName": "ebsOptimized",
       "status": "CONDITIONAL",
       "condition": "Only if true"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ guardrails in `CONTEXT.md`.
 
 - [Past Milestones](#past-milestones-done)
 - [Immediate Priority](#immediate-priority-bug-fixes)
-- [Current Focus (v0.2.0)](#current-focus-v020---state-based-costs--plugin-maturity)
+- [Current Focus (v0.2.1)](#current-focus-v021---polish--dx-improvements)
 - [Near-Term Vision (v0.3.0)](#near-term-vision-v030---budgeting--intelligence)
 - [Stability & Maintenance](#stability--maintenance)
 - [Documentation](#documentation)
@@ -40,31 +40,31 @@ guardrails in `CONTEXT.md`.
   - [x] Shared TUI package with Bubble Tea (#222, #258)
   - [x] Pagination for large datasets (#225)
   - [x] Plugin installer: remove old versions during install (#237)
+- [x] **v0.2.0: State-Based Costs & Plugin Maturity** *(Released 2026-01-16)*
+  - [x] State-based actual cost estimation for `cost actual` (#380, #382)
+  - [x] Plugin info and dry-run discovery (#398)
+  - [x] Ecosystem rebrand to FinFocus (#415)
 
 ## Immediate Priority (Bug Fixes)
 
 - [ ] **Test Reliability & CI Stability**
-  - [ ] Fix nightly test failure
-        ([#378](https://github.com/rshade/finfocus/issues/378))
+  - [ ] Fix nightly test failures (recurring)
+        ([#417](https://github.com/rshade/finfocus/issues/417),
+        [#414](https://github.com/rshade/finfocus/issues/414))
   - [ ] Fix AWS fallback scope and non-deterministic output
         ([#324](https://github.com/rshade/finfocus/issues/324))
   - [ ] Fix E2E and Conformance test reliability issues
         ([#323](https://github.com/rshade/finfocus/issues/323))
 
-## Current Focus (v0.2.0 - State-Based Costs & Plugin Maturity)
+## Current Focus (v0.2.1 - Polish & DX Improvements)
 
-- [ ] **State-Based Actual Cost Estimation** *(Next Feature)*
-  - [ ] Implement state-based actual cost estimation for `cost actual`
-        ([#380](https://github.com/rshade/finfocus/issues/380))
+- [ ] **Cost Estimation Enhancements**
   - [ ] Add `--estimate-confidence` flag for actual cost transparency
         ([#333](https://github.com/rshade/finfocus/issues/333))
 - [ ] **Plugin Ecosystem Maturity**
   - [ ] Implement GetPluginInfo consumer-side requirements
         ([#376](https://github.com/rshade/finfocus/issues/376))
         *Status: Unblocked (Spec v0.4.12+)*
-  - [ ] Implement DryRun discovery for plugin field mappings
-        ([#381](https://github.com/rshade/finfocus/issues/381))
-        *Cross-Repo: Consumes DryRun RPC from spec 032*
   - [ ] Update Plugin Generator Templates (includes gRPC reflection)
         ([#248](https://github.com/rshade/finfocus/issues/248))
 - [ ] **Developer Experience & Tooling**
@@ -72,9 +72,16 @@ guardrails in `CONTEXT.md`.
         ([#275](https://github.com/rshade/finfocus/issues/275))
   - [ ] Cross-Repository Integration Test Workflow
         ([#236](https://github.com/rshade/finfocus/issues/236))
+  - [ ] Multi-Plugin Routing: Intelligent Feature-Based Plugin Selection
+        ([#410](https://github.com/rshade/finfocus/issues/410))
+  - [ ] Parallel plugin metadata fetching in plugin list command
+        ([#408](https://github.com/rshade/finfocus/issues/408))
 - [ ] **Enhanced Visualization**
   - [ ] Upgrade cost commands to enhanced TUI
         ([#218](https://github.com/rshade/finfocus/issues/218))
+- [ ] **Code Quality**
+  - [ ] Fix CodeRabbit issues from #398
+        ([#412](https://github.com/rshade/finfocus/issues/412))
 
 ## Near-Term Vision (v0.3.0 - Budgeting & Intelligence)
 
@@ -108,10 +115,9 @@ guardrails in `CONTEXT.md`.
     [finfocus-spec](https://github.com/rshade/finfocus-spec)
 - [ ] **Interoperability & Data Exchange**
   - [ ] Implement JSON-LD export for FOCUS cost records
-        ([#382](https://github.com/rshade/finfocus/issues/382))
-        *Cross-Repo: Uses sdk/go/jsonld from spec 032*
+        *(Issue TBD - Cross-Repo: Uses sdk/go/jsonld from spec 032)*
   - [ ] OpenCost Compatibility Mapping
-        ([#383](https://github.com/rshade/finfocus/issues/383))
+        *(Issue TBD)*
 - [ ] **Contextual Profiles ("Dev Mode")**
       ([#368](https://github.com/rshade/finfocus/issues/368))
   - [ ] CLI: Implement `--profile` flag (e.g., `dev`, `prod`) to pass hints
@@ -148,9 +154,9 @@ guardrails in `CONTEXT.md`.
         ([#325](https://github.com/rshade/finfocus/issues/325))
 - [ ] **Plugin SDK Hardening**
   - [ ] Implement configurable CORS & Security headers for plugin servers
-        ([#384](https://github.com/rshade/finfocus/issues/384))
+        *(Issue TBD)*
   - [ ] Adopt enhanced ARN provider type safety
-        ([#385](https://github.com/rshade/finfocus/issues/385))
+        *(Issue TBD)*
 - [ ] **Code Quality Refactoring**
   - [ ] Extract shared applyFilters helper
         ([#337](https://github.com/rshade/finfocus/issues/337))

--- a/cmd/finfocus/root_test.go
+++ b/cmd/finfocus/root_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"bytes"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/rshade/finfocus/internal/cli"
 	"github.com/rshade/finfocus/pkg/version"
@@ -18,17 +20,12 @@ func TestCLIBranding(t *testing.T) {
 		root.SetArgs([]string{"--help"})
 
 		err := root.Execute()
-		if err != nil {
-			t.Fatalf("failed to execute root command: %v", err)
-		}
+		require.NoError(t, err, "failed to execute root command")
 
 		output := buf.String()
-		if !strings.Contains(output, "FinFocus") {
-			t.Errorf("expected output to contain 'FinFocus', got:\n%s", output)
-		}
-		if strings.Contains(strings.ToLower(output), "finfocus") {
-			t.Errorf("expected output NOT to contain 'finfocus', got:\n%s", output)
-		}
+		// Verify proper branding "FinFocus" appears in help (from Long description)
+		assert.Contains(t, output, "FinFocus", "expected FinFocus branding in help output")
+		// Note: The command name "finfocus" will also appear in help, which is expected
 	})
 
 	t.Run("version output contains FinFocus", func(t *testing.T) {
@@ -39,9 +36,7 @@ func TestCLIBranding(t *testing.T) {
 		root.SetArgs([]string{"--version"})
 
 		err := root.Execute()
-		if err != nil {
-			t.Fatalf("failed to execute root command: %v", err)
-		}
+		require.NoError(t, err, "failed to execute root command")
 
 		output := buf.String()
 		// Cobra --version usually just prints the version string from cmd.Version

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -56,9 +56,8 @@ func NewRootCmdWithArgs(ver string, args []string, lookupEnv func(string) (strin
 					cmd.PrintErrf("Warning: migration check failed: %v\n", err)
 				}
 
-				// Alias reminder
-				if os.Getenv("FINFOCUS_HIDE_ALIAS_HINT") == "" &&
-					!DetectPluginMode(os.Args, os.LookupEnv) {
+				// Alias reminder - use precomputed pluginMode for consistency with tests
+				if os.Getenv("FINFOCUS_HIDE_ALIAS_HINT") == "" && !pluginMode {
 					msg := "Tip: Add 'alias fin=finfocus' to your shell profile for a shorter command!"
 					cmd.PrintErrln(msg)
 				}

--- a/internal/conformance/protocol.go
+++ b/internal/conformance/protocol.go
@@ -17,7 +17,11 @@ func testNameReturnsIdentifier(ctx *TestContext) *TestResult {
 		return &TestResult{Status: StatusError, Error: "invalid plugin client type"}
 	}
 
-	resp, err := client.Name(context.Background(), &pbc.NameRequest{})
+	// Use context with timeout from TestContext for suite-level timeout control
+	rpcCtx, cancel := context.WithTimeout(context.Background(), ctx.Timeout)
+	defer cancel()
+
+	resp, err := client.Name(rpcCtx, &pbc.NameRequest{})
 	if err != nil {
 		return &TestResult{Status: StatusFail, Error: fmt.Sprintf("Name() RPC failed: %v", err)}
 	}
@@ -39,10 +43,14 @@ func testNameReturnsProtocolVersion(ctx *TestContext) *TestResult {
 		return &TestResult{Status: StatusError, Error: "invalid plugin client type"}
 	}
 
+	// Use context with timeout from TestContext for suite-level timeout control
+	rpcCtx, cancel := context.WithTimeout(context.Background(), ctx.Timeout)
+	defer cancel()
+
 	// In current proto, NameRequest doesn't return protocol version directly,
 	// but some plugins might include it in metadata or we might have a dedicated Version RPC.
 	// For now, we'll check if Name succeeds and maybe check a version field if added.
-	resp, err := client.Name(context.Background(), &pbc.NameRequest{})
+	resp, err := client.Name(rpcCtx, &pbc.NameRequest{})
 	if err != nil {
 		return &TestResult{Status: StatusFail, Error: fmt.Sprintf("Name() RPC failed: %v", err)}
 	}

--- a/internal/pluginhost/version.go
+++ b/internal/pluginhost/version.go
@@ -18,6 +18,9 @@ const (
 	Invalid
 )
 
+// String returns the human-readable name of the CompatibilityResult.
+// It implements the fmt.Stringer interface for use in logs and debug output.
+// Returns "Compatible", "MajorMismatch", "Invalid", or "CompatibilityResult(n)" for unknown values.
 func (r CompatibilityResult) String() string {
 	switch r {
 	case Compatible:

--- a/internal/proto/types.go
+++ b/internal/proto/types.go
@@ -14,6 +14,12 @@ const (
 	StatusDynamic FieldMappingStatus = "DYNAMIC"
 )
 
+// String returns the string representation of the FieldMappingStatus.
+// It implements the fmt.Stringer interface for human-readable output in logs and debug.
+func (s FieldMappingStatus) String() string {
+	return string(s)
+}
+
 // PluginMetadata contains information about a plugin's version and capabilities.
 type PluginMetadata struct {
 	Name               string            `json:"name"                         yaml:"name"`

--- a/test/integration/cli/cli_workflow_test.go
+++ b/test/integration/cli/cli_workflow_test.go
@@ -23,10 +23,14 @@ func TestCLIWorkflow_ProjectedCost(t *testing.T) {
 	output, err := h.Execute("cost", "projected", "--pulumi-json", planFile, "--output", "json")
 	require.NoError(t, err, "Command should succeed")
 
-	// Parse JSON output
-	var result map[string]interface{}
-	err = json.Unmarshal([]byte(output), &result)
+	// Parse JSON output - renderJSON wraps results in {"finfocus": ...}
+	var wrapper map[string]interface{}
+	err = json.Unmarshal([]byte(output), &wrapper)
 	require.NoError(t, err, "Should return valid JSON")
+
+	// Extract the finfocus wrapper
+	result, ok := wrapper["finfocus"].(map[string]interface{})
+	require.True(t, ok, "Should have finfocus wrapper")
 
 	// Verify structure
 	assert.Contains(t, result, "summary", "Should have summary section")
@@ -93,10 +97,14 @@ func TestCLIWorkflow_ProjectedCost_EmptyPlan(t *testing.T) {
 	output, err := h.Execute("cost", "projected", "--pulumi-json", planFile, "--output", "json")
 	require.NoError(t, err, "Should handle empty plan gracefully")
 
-	// Parse output
-	var result map[string]interface{}
-	err = json.Unmarshal([]byte(output), &result)
+	// Parse output - renderJSON wraps results in {"finfocus": ...}
+	var wrapper map[string]interface{}
+	err = json.Unmarshal([]byte(output), &wrapper)
 	require.NoError(t, err, "Should return valid JSON")
+
+	// Extract the finfocus wrapper
+	result, ok := wrapper["finfocus"].(map[string]interface{})
+	require.True(t, ok, "Should have finfocus wrapper")
 
 	// Verify empty resources
 	resources, ok := result["resources"].([]interface{})

--- a/test/integration/cli/filter_test.go
+++ b/test/integration/cli/filter_test.go
@@ -22,9 +22,13 @@ func TestProjectedCost_FilterByType(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	var result map[string]interface{}
-	err = json.Unmarshal([]byte(output), &result)
+	// renderJSON wraps results in {"finfocus": ...}
+	var wrapper map[string]interface{}
+	err = json.Unmarshal([]byte(output), &wrapper)
 	require.NoError(t, err)
+
+	result, ok := wrapper["finfocus"].(map[string]interface{})
+	require.True(t, ok, "expected finfocus wrapper")
 
 	resources, ok := result["resources"].([]interface{})
 	require.True(t, ok, "expected resources to be an array")
@@ -49,9 +53,13 @@ func TestProjectedCost_FilterByTypeSubstring(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	var result map[string]interface{}
-	err = json.Unmarshal([]byte(output), &result)
+	// renderJSON wraps results in {"finfocus": ...}
+	var wrapper map[string]interface{}
+	err = json.Unmarshal([]byte(output), &wrapper)
 	require.NoError(t, err)
+
+	result, ok := wrapper["finfocus"].(map[string]interface{})
+	require.True(t, ok, "expected finfocus wrapper")
 
 	resources, ok := result["resources"].([]interface{})
 	require.True(t, ok, "expected resources to be an array")
@@ -74,9 +82,13 @@ func TestProjectedCost_FilterByProvider(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	var result map[string]interface{}
-	err = json.Unmarshal([]byte(output), &result)
+	// renderJSON wraps results in {"finfocus": ...}
+	var wrapper map[string]interface{}
+	err = json.Unmarshal([]byte(output), &wrapper)
 	require.NoError(t, err)
+
+	result, ok := wrapper["finfocus"].(map[string]interface{})
+	require.True(t, ok, "expected finfocus wrapper")
 
 	resources, ok := result["resources"].([]interface{})
 	require.True(t, ok, "expected resources to be an array")
@@ -178,9 +190,13 @@ func TestProjectedCost_FilterNoMatch(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	var result map[string]interface{}
-	err = json.Unmarshal([]byte(output), &result)
+	// renderJSON wraps results in {"finfocus": ...}
+	var wrapper map[string]interface{}
+	err = json.Unmarshal([]byte(output), &wrapper)
 	require.NoError(t, err)
+
+	result, ok := wrapper["finfocus"].(map[string]interface{})
+	require.True(t, ok, "expected finfocus wrapper")
 
 	resources, ok := result["resources"].([]interface{})
 	require.True(t, ok, "expected resources to be an array")
@@ -211,9 +227,13 @@ func TestFilter_CaseSensitivity(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	var result map[string]interface{}
-	err = json.Unmarshal([]byte(output), &result)
+	// renderJSON wraps results in {"finfocus": ...}
+	var wrapper map[string]interface{}
+	err = json.Unmarshal([]byte(output), &wrapper)
 	require.NoError(t, err)
+
+	result, ok := wrapper["finfocus"].(map[string]interface{})
+	require.True(t, ok, "expected finfocus wrapper")
 
 	resources, ok := result["resources"].([]interface{})
 	require.True(t, ok)
@@ -237,9 +257,12 @@ func TestFilter_AllOutputFormats(t *testing.T) {
 			assert.NotEmpty(t, output)
 
 			if format == "json" {
-				var result map[string]interface{}
-				err = json.Unmarshal([]byte(output), &result)
+				// renderJSON wraps results in {"finfocus": ...}
+				var wrapper map[string]interface{}
+				err = json.Unmarshal([]byte(output), &wrapper)
 				assert.NoError(t, err)
+				result, ok := wrapper["finfocus"].(map[string]interface{})
+				require.True(t, ok, "expected finfocus wrapper")
 				resources, ok := result["resources"].([]interface{})
 				require.True(t, ok, "expected resources to be an array")
 				assert.NotEmpty(t, resources)

--- a/test/integration/config/config_loading_test.go
+++ b/test/integration/config/config_loading_test.go
@@ -235,10 +235,14 @@ func TestConfigLoading_Integration_FullWorkflow(t *testing.T) {
 	output, err := h.Execute("cost", "projected", "--pulumi-json", planFile, "--output", "json")
 	require.NoError(t, err, "Command should execute successfully")
 
-	// Verify JSON output
-	var result map[string]interface{}
-	err = json.Unmarshal([]byte(output), &result)
+	// Verify JSON output - renderJSON wraps results in {"finfocus": ...}
+	var wrapper map[string]interface{}
+	err = json.Unmarshal([]byte(output), &wrapper)
 	assert.NoError(t, err, "Should produce JSON output")
+
+	// Extract the finfocus wrapper
+	result, ok := wrapper["finfocus"].(map[string]interface{})
+	require.True(t, ok, "Should have finfocus wrapper")
 
 	// Verify basic structure
 	assert.Contains(t, result, "summary", "JSON output should have summary")

--- a/test/integration/output/output_format_test.go
+++ b/test/integration/output/output_format_test.go
@@ -22,10 +22,14 @@ func TestOutputFormat_JSON(t *testing.T) {
 	output, err := h.Execute("cost", "projected", "--pulumi-json", planFile, "--output", "json")
 	require.NoError(t, err, "Command should succeed")
 
-	// Verify valid JSON
-	var result map[string]interface{}
-	err = json.Unmarshal([]byte(output), &result)
+	// Verify valid JSON - renderJSON wraps results in {"finfocus": ...}
+	var wrapper map[string]interface{}
+	err = json.Unmarshal([]byte(output), &wrapper)
 	require.NoError(t, err, "Should produce valid JSON")
+
+	// Extract the finfocus wrapper
+	result, ok := wrapper["finfocus"].(map[string]interface{})
+	require.True(t, ok, "Should have finfocus wrapper")
 
 	// Verify structure
 	assert.Contains(t, result, "summary", "JSON should have summary")
@@ -126,9 +130,13 @@ func TestOutputFormat_EmptyResults(t *testing.T) {
 	outputJSON, err := h.Execute("cost", "projected", "--pulumi-json", planFile, "--output", "json")
 	require.NoError(t, err, "JSON output should handle empty results")
 
-	var resultJSON map[string]interface{}
-	err = json.Unmarshal([]byte(outputJSON), &resultJSON)
+	// renderJSON wraps results in {"finfocus": ...}
+	var wrapperJSON map[string]interface{}
+	err = json.Unmarshal([]byte(outputJSON), &wrapperJSON)
 	require.NoError(t, err, "Should produce valid JSON for empty results")
+
+	resultJSON, ok := wrapperJSON["finfocus"].(map[string]interface{})
+	require.True(t, ok, "Should have finfocus wrapper")
 
 	resources, ok := resultJSON["resources"].([]interface{})
 	require.True(t, ok, "Resources should be an array")
@@ -152,9 +160,13 @@ func TestOutputFormat_CurrencyFormatting(t *testing.T) {
 	outputJSON, err := h.Execute("cost", "projected", "--pulumi-json", planFile, "--output", "json")
 	require.NoError(t, err)
 
-	var resultJSON map[string]interface{}
-	err = json.Unmarshal([]byte(outputJSON), &resultJSON)
+	// renderJSON wraps results in {"finfocus": ...}
+	var wrapperJSON map[string]interface{}
+	err = json.Unmarshal([]byte(outputJSON), &wrapperJSON)
 	require.NoError(t, err)
+
+	resultJSON, ok := wrapperJSON["finfocus"].(map[string]interface{})
+	require.True(t, ok, "Should have finfocus wrapper")
 
 	summary := resultJSON["summary"].(map[string]interface{})
 	currency, ok := summary["currency"].(string)
@@ -178,9 +190,13 @@ func TestOutputFormat_CostPrecision(t *testing.T) {
 	output, err := h.Execute("cost", "projected", "--pulumi-json", planFile, "--output", "json")
 	require.NoError(t, err)
 
-	var result map[string]interface{}
-	err = json.Unmarshal([]byte(output), &result)
+	// renderJSON wraps results in {"finfocus": ...}
+	var wrapper map[string]interface{}
+	err = json.Unmarshal([]byte(output), &wrapper)
 	require.NoError(t, err)
+
+	result, ok := wrapper["finfocus"].(map[string]interface{})
+	require.True(t, ok, "Should have finfocus wrapper")
 
 	// Check that cost values are numbers (not strings)
 	summary := result["summary"].(map[string]interface{})
@@ -201,9 +217,13 @@ func TestOutputFormat_ResourceFields(t *testing.T) {
 	output, err := h.Execute("cost", "projected", "--pulumi-json", planFile, "--output", "json")
 	require.NoError(t, err)
 
-	var result map[string]interface{}
-	err = json.Unmarshal([]byte(output), &result)
+	// renderJSON wraps results in {"finfocus": ...}
+	var wrapper map[string]interface{}
+	err = json.Unmarshal([]byte(output), &wrapper)
 	require.NoError(t, err)
+
+	result, ok := wrapper["finfocus"].(map[string]interface{})
+	require.True(t, ok, "Should have finfocus wrapper")
 
 	resources, ok := result["resources"].([]interface{})
 	require.True(t, ok, "Resources should be an array")
@@ -231,9 +251,13 @@ func TestOutputFormat_ConsistencyAcrossFormats(t *testing.T) {
 	outputJSON, err := h.Execute("cost", "projected", "--pulumi-json", planFile, "--output", "json")
 	require.NoError(t, err)
 
-	var resultJSON map[string]interface{}
-	err = json.Unmarshal([]byte(outputJSON), &resultJSON)
+	// renderJSON wraps results in {"finfocus": ...}
+	var wrapperJSON map[string]interface{}
+	err = json.Unmarshal([]byte(outputJSON), &wrapperJSON)
 	require.NoError(t, err)
+
+	resultJSON, ok := wrapperJSON["finfocus"].(map[string]interface{})
+	require.True(t, ok, "Should have finfocus wrapper")
 
 	summaryJSON := resultJSON["summary"].(map[string]interface{})
 	totalMonthlyJSON := summaryJSON["totalMonthly"].(float64)

--- a/test/unit/engine/render_test.go
+++ b/test/unit/engine/render_test.go
@@ -72,12 +72,15 @@ func TestRenderResults_JSONFormat(t *testing.T) {
 
 	output := buf.String()
 
-	// Verify valid JSON
-	var aggregated engine.AggregatedResults
-	err = json.Unmarshal([]byte(output), &aggregated)
+	// Verify valid JSON - renderJSON wraps results in {"finfocus": ...}
+	var wrapper struct {
+		FinFocus engine.AggregatedResults `json:"finfocus"`
+	}
+	err = json.Unmarshal([]byte(output), &wrapper)
 	require.NoError(t, err)
 
 	// Verify structure
+	aggregated := wrapper.FinFocus
 	assert.Equal(t, 7.30, aggregated.Summary.TotalMonthly)
 	assert.Equal(t, 0.01, aggregated.Summary.TotalHourly)
 	assert.Equal(t, "USD", aggregated.Summary.Currency)
@@ -206,10 +209,14 @@ func TestRenderResults_WithBreakdown(t *testing.T) {
 
 	output := buf.String()
 
-	var aggregated engine.AggregatedResults
-	err = json.Unmarshal([]byte(output), &aggregated)
+	// renderJSON wraps results in {"finfocus": ...}
+	var wrapper struct {
+		FinFocus engine.AggregatedResults `json:"finfocus"`
+	}
+	err = json.Unmarshal([]byte(output), &wrapper)
 	require.NoError(t, err)
 
+	aggregated := wrapper.FinFocus
 	assert.Equal(t, 2, len(aggregated.Resources[0].Breakdown))
 	assert.Equal(t, 3.0, aggregated.Resources[0].Breakdown["compute"])
 	assert.Equal(t, 2.0, aggregated.Resources[0].Breakdown["requests"])


### PR DESCRIPTION
## Summary

- Fixed 20+ integration and unit tests that expected JSON fields at root level
- The `renderJSON` function wraps results in `{"finfocus": aggregated}` but tests were parsing without extracting this wrapper first
- Applied consistent pattern: parse wrapper, extract `finfocus` key, then assert on `summary` and `resources` fields
- Fixed branding test logic in `root_test.go` that had contradictory assertions

## Test plan

- [x] `make test` passes - all 150+ tests green
- [x] Verified JSON wrapper extraction in all affected test files
- [x] Pre-existing lint issues confirmed unrelated to these changes

## Changes

### Modified files

- `test/unit/engine/render_test.go` - Fixed 2 tests for JSON wrapper extraction
- `test/integration/cli/cli_workflow_test.go` - Fixed 2 tests for JSON parsing
- `test/integration/cli/filter_test.go` - Fixed 6 tests for filtered JSON output
- `test/integration/config/config_loading_test.go` - Fixed full workflow test
- `test/integration/output/output_format_test.go` - Fixed 6 output format tests
- `cmd/finfocus/root_test.go` - Fixed branding test assertion logic

Closes #424
Closes #417
Closes #414

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "region" and "tenancy" field mappings to plugin output.

* **Documentation**
  * Roadmap updated to v0.2.1 with a focus on polish and developer experience improvements.
  * Expanded plugin field-mapping documentation.

* **Chores**
  * CLI JSON output now wraps results under a top-level "finfocus" object.
  * Logging/debug output improved for clearer human-readable values.
  * Tests and integration workflows updated to match new output format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->