### PR TITLE
fix(registry): resolve Windows test failures and add plugin robustnes…

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,6 +47,9 @@ guardrails in `CONTEXT.md`.
 
 ## Immediate Priority (Bug Fixes)
 
+- [ ] **Active Nightly Failure**
+  - [ ] Nightly test failure - 2026-01-18
+        ([#427](https://github.com/rshade/finfocus/issues/427))
 - [x] **Test Reliability & CI Stability** *(Completed 2026-01-17)*
   - [x] Nightly test failures resolved (#417, #414, #424)
 
@@ -68,12 +71,25 @@ guardrails in `CONTEXT.md`.
         ([#236](https://github.com/rshade/finfocus/issues/236))
   - [ ] Multi-Plugin Routing: Intelligent Feature-Based Plugin Selection
         ([#410](https://github.com/rshade/finfocus/issues/410))
-  - [x] Parallel plugin metadata fetching in plugin list command
-        ([#408](https://github.com/rshade/finfocus/issues/408)) *(Completed 2026-01-17)*
+  - [ ] Parallel plugin metadata fetching in plugin list command
+        ([#408](https://github.com/rshade/finfocus/issues/408))
 - [x] **Enhanced Visualization**
   - [x] Upgrade cost commands to enhanced TUI (#218) *(Completed)*
 - [x] **Code Quality**
   - [x] Fix CodeRabbit issues from #398 (#412) *(Completed 2026-01-17)*
+- [ ] **Plugin Robustness** *(New - 2026-01-18)*
+  - [ ] Respect strict mode for spec version parse errors
+        ([#435](https://github.com/rshade/finfocus/issues/435))
+  - [ ] Add Set/Get handlers for plugin_host config section
+        ([#434](https://github.com/rshade/finfocus/issues/434))
+  - [ ] Show installed plugins even when metadata fetch fails
+        ([#432](https://github.com/rshade/finfocus/issues/432))
+  - [ ] Add lock acquisition to RemoveOtherVersions
+        ([#431](https://github.com/rshade/finfocus/issues/431))
+  - [ ] Fallback to latest stable version when asset missing
+        ([#430](https://github.com/rshade/finfocus/issues/430))
+  - [ ] Replace manual assertions with testify in registry tests
+        ([#429](https://github.com/rshade/finfocus/issues/429))
 - [ ] **Deferred from v0.1.x**
   - [ ] Pagination for large datasets
         ([#225](https://github.com/rshade/finfocus/issues/225))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -346,6 +346,8 @@ func (c *Config) Set(key, value string) error {
 		return c.setPluginValue(parts[1:], value)
 	case "logging":
 		return c.setLoggingValue(parts[1:], value)
+	case "plugin_host":
+		return c.setPluginHostValue(parts[1:], value)
 	default:
 		return fmt.Errorf("unknown configuration section: %s", parts[0])
 	}
@@ -365,6 +367,8 @@ func (c *Config) Get(key string) (interface{}, error) {
 		return c.getPluginValue(parts[1:])
 	case "logging":
 		return c.getLoggingValue(parts[1:])
+	case "plugin_host":
+		return c.getPluginHostValue(parts[1:])
 	default:
 		return nil, fmt.Errorf("unknown configuration section: %s", parts[0])
 	}
@@ -867,6 +871,39 @@ func (c *Config) getLoggingValue(parts []string) (interface{}, error) {
 		return c.Logging.File, nil
 	default:
 		return nil, fmt.Errorf("unknown logging setting: %s", parts[0])
+	}
+}
+
+// Helper methods for plugin_host values.
+func (c *Config) setPluginHostValue(parts []string, value string) error {
+	if len(parts) != 1 {
+		return errors.New("invalid plugin_host key")
+	}
+
+	switch parts[0] {
+	case "strict_compatibility":
+		boolVal, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("strict_compatibility must be a boolean: %w", err)
+		}
+		c.PluginHostConfig.StrictCompatibility = boolVal
+	default:
+		return fmt.Errorf("unknown plugin_host setting: %s", parts[0])
+	}
+
+	return nil
+}
+
+func (c *Config) getPluginHostValue(parts []string) (interface{}, error) {
+	if len(parts) != 1 {
+		return nil, errors.New("invalid plugin_host key")
+	}
+
+	switch parts[0] {
+	case "strict_compatibility":
+		return c.PluginHostConfig.StrictCompatibility, nil
+	default:
+		return nil, fmt.Errorf("unknown plugin_host setting: %s", parts[0])
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -156,6 +156,22 @@ func TestConfig_SetGetValues(t *testing.T) {
 	value, err = cfg.Get("logging.level")
 	require.NoError(t, err)
 	assert.Equal(t, "debug", value)
+
+	// Test plugin_host values
+	err = cfg.Set("plugin_host.strict_compatibility", "true")
+	require.NoError(t, err)
+
+	value, err = cfg.Get("plugin_host.strict_compatibility")
+	require.NoError(t, err)
+	assert.Equal(t, true, value)
+
+	// Test setting to false
+	err = cfg.Set("plugin_host.strict_compatibility", "false")
+	require.NoError(t, err)
+
+	value, err = cfg.Get("plugin_host.strict_compatibility")
+	require.NoError(t, err)
+	assert.Equal(t, false, value)
 }
 
 func TestConfig_SetErrors(t *testing.T) {
@@ -181,6 +197,16 @@ func TestConfig_SetErrors(t *testing.T) {
 	err = cfg.Set("plugins.aws", "value")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "plugin key must be in format")
+
+	// Invalid plugin_host key
+	err = cfg.Set("plugin_host.invalid", "true")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown plugin_host setting")
+
+	// Invalid plugin_host strict_compatibility value
+	err = cfg.Set("plugin_host.strict_compatibility", "not-a-bool")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "strict_compatibility must be a boolean")
 }
 
 func TestConfig_GetErrors(t *testing.T) {
@@ -201,6 +227,11 @@ func TestConfig_GetErrors(t *testing.T) {
 	_, err = cfg.Get("plugins.nonexistent.key")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "plugin not found")
+
+	// Unknown plugin_host key
+	_, err = cfg.Get("plugin_host.invalid")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown plugin_host setting")
 }
 
 func TestConfig_Validation(t *testing.T) {

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -117,7 +117,14 @@ func checkVersionCompatibility(ctx context.Context, pluginName, pluginSpecVersio
 	result, verErr := CompareSpecVersions(pluginsdk.SpecVersion, pluginSpecVersion)
 	if verErr != nil {
 		log.Warn().Err(verErr).Str("plugin", pluginName).Msg("Failed to parse plugin spec version")
-		return nil // Parse errors are not blocking
+		// In strict mode, parse errors also block plugin initialization
+		if config.GetStrictPluginCompatibility() {
+			return fmt.Errorf(
+				"%w: failed to parse spec version %q for plugin %s: %s",
+				ErrPluginIncompatible, pluginSpecVersion, pluginName, verErr.Error(),
+			)
+		}
+		return nil // Parse errors are not blocking in permissive mode
 	}
 
 	if result == MajorMismatch {

--- a/internal/registry/github_api_test.go
+++ b/internal/registry/github_api_test.go
@@ -136,3 +136,264 @@ func TestFetchRelease_RateLimit(t *testing.T) {
 		t.Error("Expected error for 403, got nil")
 	}
 }
+
+func TestListStableReleases(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/owner/repo/releases" {
+			http.NotFound(w, r)
+			return
+		}
+
+		releases := []GitHubRelease{
+			{TagName: "v2.0.0", Name: "Release 2.0.0", Draft: false, Prerelease: false},
+			{TagName: "v2.0.0-beta", Name: "Beta", Draft: false, Prerelease: true},
+			{TagName: "v1.5.0", Name: "Release 1.5.0", Draft: false, Prerelease: false},
+			{TagName: "v1.4.0-draft", Name: "Draft", Draft: true, Prerelease: false},
+			{TagName: "v1.0.0", Name: "Release 1.0.0", Draft: false, Prerelease: false},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(releases); err != nil {
+			t.Errorf("Failed to encode releases: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient()
+	client.BaseURL = server.URL
+	client.HTTPClient = server.Client()
+
+	releases, err := client.ListStableReleases("owner", "repo", 10)
+	if err != nil {
+		t.Fatalf("ListStableReleases failed: %v", err)
+	}
+
+	// Should only return stable releases (not draft, not prerelease)
+	if len(releases) != 3 {
+		t.Errorf("Expected 3 stable releases, got %d", len(releases))
+	}
+
+	expectedTags := []string{"v2.0.0", "v1.5.0", "v1.0.0"}
+	for i, expected := range expectedTags {
+		if releases[i].TagName != expected {
+			t.Errorf("Expected release[%d].TagName = %s, got %s", i, expected, releases[i].TagName)
+		}
+	}
+}
+
+func TestListStableReleases_WithLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		releases := []GitHubRelease{
+			{TagName: "v3.0.0", Draft: false, Prerelease: false},
+			{TagName: "v2.0.0", Draft: false, Prerelease: false},
+			{TagName: "v1.0.0", Draft: false, Prerelease: false},
+		}
+		if err := json.NewEncoder(w).Encode(releases); err != nil {
+			t.Errorf("Failed to encode releases: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient()
+	client.BaseURL = server.URL
+	client.HTTPClient = server.Client()
+
+	releases, err := client.ListStableReleases("owner", "repo", 2)
+	if err != nil {
+		t.Fatalf("ListStableReleases failed: %v", err)
+	}
+
+	// Should respect the limit
+	if len(releases) != 2 {
+		t.Errorf("Expected 2 releases (limit), got %d", len(releases))
+	}
+}
+
+func TestListStableReleases_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient()
+	client.BaseURL = server.URL
+	client.HTTPClient = server.Client()
+
+	_, err := client.ListStableReleases("owner", "repo", 10)
+	if err == nil {
+		t.Error("Expected error for 404, got nil")
+	}
+}
+
+func TestFindReleaseWithAsset_ExactVersionFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/releases/tags/v1.0.0":
+			release := GitHubRelease{
+				TagName: "v1.0.0",
+				Assets: []ReleaseAsset{
+					{Name: "plugin_v1.0.0_linux_amd64.tar.gz", BrowserDownloadURL: "http://dl/1"},
+				},
+			}
+			if err := json.NewEncoder(w).Encode(release); err != nil {
+				t.Errorf("Failed to encode release: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient()
+	client.BaseURL = server.URL
+	client.HTTPClient = server.Client()
+
+	release, asset, err := client.FindReleaseWithAsset("owner", "repo", "v1.0.0", "plugin", nil)
+	if err != nil {
+		t.Fatalf("FindReleaseWithAsset failed: %v", err)
+	}
+
+	if release.TagName != "v1.0.0" {
+		t.Errorf("Expected release v1.0.0, got %s", release.TagName)
+	}
+	if asset == nil {
+		t.Fatal("Expected asset, got nil")
+	}
+}
+
+func TestFindReleaseWithAsset_FallbackToStable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/releases/tags/v2.0.0":
+			// Version exists but has no matching asset
+			release := GitHubRelease{
+				TagName: "v2.0.0",
+				Assets: []ReleaseAsset{
+					{Name: "plugin_v2.0.0_windows_amd64.zip", BrowserDownloadURL: "http://dl/win"},
+				},
+			}
+			if err := json.NewEncoder(w).Encode(release); err != nil {
+				t.Errorf("Failed to encode release: %v", err)
+			}
+		case "/repos/owner/repo/releases":
+			// Fallback releases - v1.0.0 has Linux asset
+			releases := []GitHubRelease{
+				{
+					TagName: "v2.0.0",
+					Assets: []ReleaseAsset{
+						{Name: "plugin_v2.0.0_windows_amd64.zip", BrowserDownloadURL: "http://dl/win"},
+					},
+				},
+				{
+					TagName: "v1.0.0",
+					Assets: []ReleaseAsset{
+						{Name: "plugin_v1.0.0_linux_amd64.tar.gz", BrowserDownloadURL: "http://dl/linux"},
+					},
+				},
+			}
+			if err := json.NewEncoder(w).Encode(releases); err != nil {
+				t.Errorf("Failed to encode releases: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient()
+	client.BaseURL = server.URL
+	client.HTTPClient = server.Client()
+
+	// Request v2.0.0 which doesn't have Linux asset, should fallback to v1.0.0
+	release, asset, err := client.FindReleaseWithAsset("owner", "repo", "v2.0.0", "plugin", nil)
+	if err != nil {
+		t.Fatalf("FindReleaseWithAsset failed: %v", err)
+	}
+
+	// Should have fallen back to v1.0.0 which has the Linux asset
+	if release.TagName != "v1.0.0" {
+		t.Errorf("Expected fallback to v1.0.0, got %s", release.TagName)
+	}
+	if asset == nil || asset.Name != "plugin_v1.0.0_linux_amd64.tar.gz" {
+		t.Errorf("Expected Linux asset, got %v", asset)
+	}
+}
+
+func TestFindReleaseWithAsset_NoVersionSpecified(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/releases" {
+			releases := []GitHubRelease{
+				{
+					TagName: "v1.0.0",
+					Assets: []ReleaseAsset{
+						{Name: "plugin_v1.0.0_linux_amd64.tar.gz", BrowserDownloadURL: "http://dl/1"},
+					},
+				},
+			}
+			if err := json.NewEncoder(w).Encode(releases); err != nil {
+				t.Errorf("Failed to encode releases: %v", err)
+			}
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient()
+	client.BaseURL = server.URL
+	client.HTTPClient = server.Client()
+
+	// Empty version should search stable releases
+	release, asset, err := client.FindReleaseWithAsset("owner", "repo", "", "plugin", nil)
+	if err != nil {
+		t.Fatalf("FindReleaseWithAsset failed: %v", err)
+	}
+
+	if release.TagName != "v1.0.0" {
+		t.Errorf("Expected v1.0.0, got %s", release.TagName)
+	}
+	if asset == nil {
+		t.Fatal("Expected asset, got nil")
+	}
+}
+
+func TestFindReleaseWithAsset_NoCompatibleAsset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/releases/tags/v1.0.0":
+			release := GitHubRelease{
+				TagName: "v1.0.0",
+				Assets: []ReleaseAsset{
+					{Name: "plugin_v1.0.0_freebsd_amd64.tar.gz", BrowserDownloadURL: "http://dl/1"},
+				},
+			}
+			if err := json.NewEncoder(w).Encode(release); err != nil {
+				t.Errorf("Failed to encode release: %v", err)
+			}
+		case "/repos/owner/repo/releases":
+			// All releases have incompatible assets
+			releases := []GitHubRelease{
+				{
+					TagName: "v1.0.0",
+					Assets: []ReleaseAsset{
+						{Name: "plugin_v1.0.0_freebsd_amd64.tar.gz", BrowserDownloadURL: "http://dl/1"},
+					},
+				},
+			}
+			if err := json.NewEncoder(w).Encode(releases); err != nil {
+				t.Errorf("Failed to encode releases: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient()
+	client.BaseURL = server.URL
+	client.HTTPClient = server.Client()
+
+	_, _, err := client.FindReleaseWithAsset("owner", "repo", "v1.0.0", "plugin", nil)
+	if err == nil {
+		t.Error("Expected error for no compatible asset, got nil")
+	}
+}

--- a/internal/registry/installer.go
+++ b/internal/registry/installer.go
@@ -712,6 +712,13 @@ func (i *Installer) RemoveOtherVersions(
 	pluginDir string,
 	progress func(msg string),
 ) (*RemoveOtherVersionsResult, error) {
+	// Acquire lock for concurrent safety during version removal
+	unlock, err := i.acquireLock(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire lock for %s: %w", name, err)
+	}
+	defer unlock()
+
 	if pluginDir == "" {
 		pluginDir = i.pluginDir
 	}
@@ -719,7 +726,7 @@ func (i *Installer) RemoveOtherVersions(
 	pluginPath := filepath.Join(pluginDir, name)
 
 	// Check if plugin directory exists
-	if _, err := os.Stat(pluginPath); os.IsNotExist(err) {
+	if _, statErr := os.Stat(pluginPath); os.IsNotExist(statErr) {
 		return &RemoveOtherVersionsResult{
 			PluginName:  name,
 			KeptVersion: keepVersion,

--- a/internal/registry/installer_test.go
+++ b/internal/registry/installer_test.go
@@ -4,10 +4,13 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewInstaller(t *testing.T) {
@@ -31,17 +34,13 @@ func TestNewInstaller(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			installer := NewInstaller(tt.pluginDir)
-			if installer == nil {
-				t.Fatal("NewInstaller returned nil")
+			require.NotNil(t, installer, "NewInstaller returned nil")
+			assert.NotNil(t, installer.client, "installer.client is nil")
+			if tt.wantDir {
+				assert.NotEmpty(t, installer.pluginDir, "installer.pluginDir is empty")
 			}
-			if installer.client == nil {
-				t.Error("installer.client is nil")
-			}
-			if tt.wantDir && installer.pluginDir == "" {
-				t.Error("installer.pluginDir is empty")
-			}
-			if tt.pluginDir != "" && installer.pluginDir != tt.pluginDir {
-				t.Errorf("pluginDir = %v, want %v", installer.pluginDir, tt.pluginDir)
+			if tt.pluginDir != "" {
+				assert.Equal(t, tt.pluginDir, installer.pluginDir)
 			}
 		})
 	}
@@ -54,15 +53,9 @@ func TestInstallOptions(t *testing.T) {
 		PluginDir: "/custom/dir",
 	}
 
-	if !opts.Force {
-		t.Error("Force should be true")
-	}
-	if !opts.NoSave {
-		t.Error("NoSave should be true")
-	}
-	if opts.PluginDir != "/custom/dir" {
-		t.Errorf("PluginDir = %v, want /custom/dir", opts.PluginDir)
-	}
+	assert.True(t, opts.Force, "Force should be true")
+	assert.True(t, opts.NoSave, "NoSave should be true")
+	assert.Equal(t, "/custom/dir", opts.PluginDir)
 }
 
 func TestInstallResult(t *testing.T) {
@@ -74,15 +67,9 @@ func TestInstallResult(t *testing.T) {
 		Repository: "owner/repo",
 	}
 
-	if result.Name != "test-plugin" {
-		t.Errorf("Name = %v, want test-plugin", result.Name)
-	}
-	if result.Version != "v1.0.0" {
-		t.Errorf("Version = %v, want v1.0.0", result.Version)
-	}
-	if !result.FromURL {
-		t.Error("FromURL should be true")
-	}
+	assert.Equal(t, "test-plugin", result.Name)
+	assert.Equal(t, "v1.0.0", result.Version)
+	assert.True(t, result.FromURL, "FromURL should be true")
 }
 
 func TestParseOwnerRepo(t *testing.T) {
@@ -115,19 +102,13 @@ func TestParseOwnerRepo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			owner, repo, err := parseOwnerRepo(tt.input)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("parseOwnerRepo() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
 			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if owner != tt.wantOwner {
-				t.Errorf("owner = %v, want %v", owner, tt.wantOwner)
-			}
-			if repo != tt.wantRepo {
-				t.Errorf("repo = %v, want %v", repo, tt.wantRepo)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOwner, owner)
+			assert.Equal(t, tt.wantRepo, repo)
 		})
 	}
 }
@@ -197,11 +178,10 @@ func TestFindPluginBinary(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := tt.setupDir(t)
 			result := findPluginBinary(dir, tt.pluginName)
-			if tt.wantFound && result == "" {
-				t.Error("expected to find binary but got empty string")
-			}
-			if !tt.wantFound && result != "" {
-				t.Errorf("expected no binary but found: %s", result)
+			if tt.wantFound {
+				assert.NotEmpty(t, result, "expected to find binary")
+			} else {
+				assert.Empty(t, result, "expected no binary")
 			}
 		})
 	}
@@ -211,9 +191,7 @@ func TestInstallAlreadyExists(t *testing.T) {
 	// Create temp plugin directory with existing installation
 	tmpDir := t.TempDir()
 	pluginDir := filepath.Join(tmpDir, "test-plugin", "v1.0.0")
-	if err := os.MkdirAll(pluginDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(pluginDir, 0755))
 
 	installer := NewInstaller(tmpDir)
 	opts := InstallOptions{Force: false}
@@ -221,9 +199,7 @@ func TestInstallAlreadyExists(t *testing.T) {
 	// This should fail because we can't actually contact GitHub
 	// but if it gets past the "already installed" check, the test structure is correct
 	_, err := installer.Install("test-plugin@v1.0.0", opts, nil)
-	if err == nil {
-		t.Error("expected error for non-existent registry plugin")
-	}
+	assert.Error(t, err, "expected error for non-existent registry plugin")
 }
 
 func TestUpdateOptions(t *testing.T) {
@@ -233,15 +209,9 @@ func TestUpdateOptions(t *testing.T) {
 		PluginDir: "/test/dir",
 	}
 
-	if !opts.DryRun {
-		t.Error("UpdateOptions.DryRun should be true")
-	}
-	if opts.Version != "v2.0.0" {
-		t.Errorf("UpdateOptions.Version = %v, want v2.0.0", opts.Version)
-	}
-	if opts.PluginDir != "/test/dir" {
-		t.Errorf("UpdateOptions.PluginDir = %v, want /test/dir", opts.PluginDir)
-	}
+	assert.True(t, opts.DryRun, "DryRun should be true")
+	assert.Equal(t, "v2.0.0", opts.Version)
+	assert.Equal(t, "/test/dir", opts.PluginDir)
 }
 
 func TestRemoveOptions(t *testing.T) {
@@ -250,12 +220,8 @@ func TestRemoveOptions(t *testing.T) {
 		PluginDir:  "/test/dir",
 	}
 
-	if !opts.KeepConfig {
-		t.Error("RemoveOptions.KeepConfig should be true")
-	}
-	if opts.PluginDir != "/test/dir" {
-		t.Errorf("RemoveOptions.PluginDir = %v, want /test/dir", opts.PluginDir)
-	}
+	assert.True(t, opts.KeepConfig, "KeepConfig should be true")
+	assert.Equal(t, "/test/dir", opts.PluginDir)
 }
 
 func TestUpdateResult(t *testing.T) {
@@ -267,18 +233,10 @@ func TestUpdateResult(t *testing.T) {
 		WasUpToDate: false,
 	}
 
-	if result.Name != "test-plugin" {
-		t.Errorf("Name = %v, want test-plugin", result.Name)
-	}
-	if result.OldVersion != "v1.0.0" {
-		t.Errorf("OldVersion = %v, want v1.0.0", result.OldVersion)
-	}
-	if result.NewVersion != "v2.0.0" {
-		t.Errorf("NewVersion = %v, want v2.0.0", result.NewVersion)
-	}
-	if result.WasUpToDate {
-		t.Error("WasUpToDate should be false")
-	}
+	assert.Equal(t, "test-plugin", result.Name)
+	assert.Equal(t, "v1.0.0", result.OldVersion)
+	assert.Equal(t, "v2.0.0", result.NewVersion)
+	assert.False(t, result.WasUpToDate, "WasUpToDate should be false")
 }
 
 func TestInstallEmptySpecifier(t *testing.T) {
@@ -287,9 +245,7 @@ func TestInstallEmptySpecifier(t *testing.T) {
 	opts := InstallOptions{}
 
 	_, err := installer.Install("", opts, nil)
-	if err == nil {
-		t.Error("expected error for empty specifier")
-	}
+	assert.Error(t, err, "expected error for empty specifier")
 }
 
 func TestInstallInvalidURLFormat(t *testing.T) {
@@ -298,30 +254,22 @@ func TestInstallInvalidURLFormat(t *testing.T) {
 	opts := InstallOptions{}
 
 	_, err := installer.Install("github.com/invalid", opts, nil)
-	if err == nil {
-		t.Error("expected error for invalid URL format")
-	}
+	assert.Error(t, err, "expected error for invalid URL format")
 }
 
 func TestFindPluginBinaryNonExistentDir(t *testing.T) {
 	result := findPluginBinary("/nonexistent/path", "test")
-	if result != "" {
-		t.Errorf("expected empty string for non-existent dir, got: %s", result)
-	}
+	assert.Empty(t, result, "expected empty string for non-existent dir")
 }
 
 func TestParseOwnerRepoEmptyInput(t *testing.T) {
 	_, _, err := parseOwnerRepo("")
-	if err == nil {
-		t.Error("expected error for empty input")
-	}
+	assert.Error(t, err, "expected error for empty input")
 }
 
 func TestParseOwnerRepoOnlySlash(t *testing.T) {
 	_, _, err := parseOwnerRepo("/")
-	if err == nil {
-		t.Error("expected error for empty owner/repo segments")
-	}
+	assert.Error(t, err, "expected error for empty owner/repo segments")
 }
 
 func TestInstallerLock(t *testing.T) {
@@ -331,20 +279,14 @@ func TestInstallerLock(t *testing.T) {
 
 	// Acquire lock first time
 	unlock1, err := installer.acquireLock(name)
-	if err != nil {
-		t.Fatalf("Failed to acquire lock: %v", err)
-	}
-	if unlock1 == nil {
-		t.Fatal("Unlock function is nil")
-	}
+	require.NoError(t, err, "Failed to acquire lock")
+	require.NotNil(t, unlock1, "Unlock function is nil")
 
 	// Try to acquire lock second time - should fail
 	unlock2, err := installer.acquireLock(name)
-	if err == nil {
-		t.Error("Expected error when acquiring already held lock")
-		if unlock2 != nil {
-			unlock2()
-		}
+	assert.Error(t, err, "Expected error when acquiring already held lock")
+	if unlock2 != nil {
+		unlock2()
 	}
 
 	// Release first lock
@@ -352,12 +294,8 @@ func TestInstallerLock(t *testing.T) {
 
 	// Try to acquire lock again - should succeed now
 	unlock3, err := installer.acquireLock(name)
-	if err != nil {
-		t.Fatalf("Failed to acquire lock after release: %v", err)
-	}
-	if unlock3 == nil {
-		t.Fatal("Unlock function is nil")
-	}
+	require.NoError(t, err, "Failed to acquire lock after release")
+	require.NotNil(t, unlock3, "Unlock function is nil")
 	unlock3()
 }
 
@@ -367,25 +305,16 @@ func TestInstallerLockStaleDetection(t *testing.T) {
 	name := "test-plugin"
 
 	// Ensure plugin directory exists
-	if err := os.MkdirAll(tmpDir, 0750); err != nil {
-		t.Fatalf("Failed to create plugin directory: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(tmpDir, 0750), "Failed to create plugin directory")
 
 	// Create a stale lock file with an invalid PID
 	lockPath := filepath.Join(tmpDir, name+".lock")
-	if err := os.WriteFile(lockPath, []byte("99999999"), 0600); err != nil {
-		t.Fatalf("Failed to create stale lock file: %v", err)
-	}
+	require.NoError(t, os.WriteFile(lockPath, []byte("99999999"), 0600), "Failed to create stale lock file")
 
 	// Acquiring lock should succeed because the PID is invalid (stale)
 	unlock, err := installer.acquireLock(name)
-	if err != nil {
-		t.Errorf("Expected to acquire lock with stale lock file, got error: %v", err)
-		return
-	}
-	if unlock == nil {
-		t.Fatal("Unlock function is nil")
-	}
+	require.NoError(t, err, "Expected to acquire lock with stale lock file")
+	require.NotNil(t, unlock, "Unlock function is nil")
 	unlock()
 }
 
@@ -395,25 +324,16 @@ func TestInstallerLockEmptyFile(t *testing.T) {
 	name := "test-plugin"
 
 	// Ensure plugin directory exists
-	if err := os.MkdirAll(tmpDir, 0750); err != nil {
-		t.Fatalf("Failed to create plugin directory: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(tmpDir, 0750), "Failed to create plugin directory")
 
 	// Create an empty lock file (legacy or corrupt)
 	lockPath := filepath.Join(tmpDir, name+".lock")
-	if err := os.WriteFile(lockPath, []byte(""), 0600); err != nil {
-		t.Fatalf("Failed to create empty lock file: %v", err)
-	}
+	require.NoError(t, os.WriteFile(lockPath, []byte(""), 0600), "Failed to create empty lock file")
 
 	// Acquiring lock should succeed because empty file is treated as stale
 	unlock, err := installer.acquireLock(name)
-	if err != nil {
-		t.Errorf("Expected to acquire lock with empty lock file, got error: %v", err)
-		return
-	}
-	if unlock == nil {
-		t.Fatal("Unlock function is nil")
-	}
+	require.NoError(t, err, "Expected to acquire lock with empty lock file")
+	require.NotNil(t, unlock, "Unlock function is nil")
 	unlock()
 }
 
@@ -423,39 +343,26 @@ func TestInstallerLockInvalidPID(t *testing.T) {
 	name := "test-plugin"
 
 	// Ensure plugin directory exists
-	if err := os.MkdirAll(tmpDir, 0750); err != nil {
-		t.Fatalf("Failed to create plugin directory: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(tmpDir, 0750), "Failed to create plugin directory")
 
 	// Create a lock file with invalid content
 	lockPath := filepath.Join(tmpDir, name+".lock")
-	if err := os.WriteFile(lockPath, []byte("not-a-pid"), 0600); err != nil {
-		t.Fatalf("Failed to create invalid lock file: %v", err)
-	}
+	require.NoError(t, os.WriteFile(lockPath, []byte("not-a-pid"), 0600), "Failed to create invalid lock file")
 
 	// Acquiring lock should succeed because invalid PID is treated as stale
 	unlock, err := installer.acquireLock(name)
-	if err != nil {
-		t.Errorf("Expected to acquire lock with invalid PID, got error: %v", err)
-		return
-	}
-	if unlock == nil {
-		t.Fatal("Unlock function is nil")
-	}
+	require.NoError(t, err, "Expected to acquire lock with invalid PID")
+	require.NotNil(t, unlock, "Unlock function is nil")
 	unlock()
 }
 
 func TestIsProcessRunning(t *testing.T) {
 	// Test with current process - should be running
 	currentPID := os.Getpid()
-	if !isProcessRunning(currentPID) {
-		t.Error("Expected current process to be running")
-	}
+	assert.True(t, isProcessRunning(currentPID), "Expected current process to be running")
 
 	// Test with invalid PID - should not be running
-	if isProcessRunning(99999999) {
-		t.Error("Expected invalid PID to not be running")
-	}
+	assert.False(t, isProcessRunning(99999999), "Expected invalid PID to not be running")
 
 	// Test with PID 0 - typically kernel, but behavior varies
 	// Just ensure it doesn't panic
@@ -495,21 +402,19 @@ func TestIsLockStale(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lockPath := filepath.Join(tmpDir, "test-"+tt.name+".lock")
-			if err := os.WriteFile(lockPath, []byte(tt.content), 0600); err != nil {
-				t.Fatalf("Failed to create lock file: %v", err)
-			}
+			require.NoError(t, os.WriteFile(lockPath, []byte(tt.content), 0600), "Failed to create lock file")
 
 			result := isLockStale(lockPath)
-			if result != tt.expected {
-				t.Errorf("isLockStale() = %v, expected %v", result, tt.expected)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 
 	// Test with non-existent file - should not be stale (safe default)
-	if isLockStale(filepath.Join(tmpDir, "nonexistent.lock")) {
-		t.Error("Non-existent lock file should not be considered stale")
-	}
+	assert.False(
+		t,
+		isLockStale(filepath.Join(tmpDir, "nonexistent.lock")),
+		"Non-existent lock file should not be considered stale",
+	)
 }
 
 func TestRemoveOtherVersions(t *testing.T) {
@@ -612,35 +517,20 @@ func TestRemoveOtherVersions(t *testing.T) {
 			)
 
 			if tt.wantErrContains != "" {
-				if err == nil {
-					t.Errorf("expected error containing %q, got nil", tt.wantErrContains)
-					return
-				}
-				if !strings.Contains(err.Error(), tt.wantErrContains) {
-					t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrContains)
-				}
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
 				return
 			}
 
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+			require.NoError(t, err)
+			assert.Len(t, result.RemovedVersions, tt.wantRemoved)
+
+			if tt.wantBytesFreed {
+				assert.Greater(t, result.BytesFreed, int64(0), "expected bytes freed to be > 0")
 			}
 
-			if len(result.RemovedVersions) != tt.wantRemoved {
-				t.Errorf("removed %d versions, want %d", len(result.RemovedVersions), tt.wantRemoved)
-			}
-
-			if tt.wantBytesFreed && result.BytesFreed == 0 {
-				t.Error("expected bytes freed to be > 0")
-			}
-
-			if result.PluginName != tt.pluginName {
-				t.Errorf("PluginName = %s, want %s", result.PluginName, tt.pluginName)
-			}
-
-			if result.KeptVersion != tt.keepVersion {
-				t.Errorf("KeptVersion = %s, want %s", result.KeptVersion, tt.keepVersion)
-			}
+			assert.Equal(t, tt.pluginName, result.PluginName)
+			assert.Equal(t, tt.keepVersion, result.KeptVersion)
 		})
 	}
 }
@@ -653,18 +543,41 @@ func TestRemoveOtherVersionsResult(t *testing.T) {
 		BytesFreed:      1024,
 	}
 
-	if result.PluginName != "test-plugin" {
-		t.Errorf("PluginName = %v, want test-plugin", result.PluginName)
+	assert.Equal(t, "test-plugin", result.PluginName)
+	assert.Equal(t, "v2.0.0", result.KeptVersion)
+	assert.Len(t, result.RemovedVersions, 2)
+	assert.Equal(t, int64(1024), result.BytesFreed)
+}
+
+func TestRemoveOtherVersionsAcquiresLock(t *testing.T) {
+	tmpDir := t.TempDir()
+	installer := NewInstaller(tmpDir)
+	name := "lock-test-plugin"
+
+	// Create a plugin with versions
+	for _, v := range []string{"v1.0.0", "v2.0.0"} {
+		vPath := filepath.Join(tmpDir, name, v)
+		require.NoError(t, os.MkdirAll(vPath, 0755))
+		binPath := filepath.Join(vPath, "binary")
+		require.NoError(t, os.WriteFile(binPath, []byte("test"), 0755))
 	}
-	if result.KeptVersion != "v2.0.0" {
-		t.Errorf("KeptVersion = %v, want v2.0.0", result.KeptVersion)
-	}
-	if len(result.RemovedVersions) != 2 {
-		t.Errorf("RemovedVersions length = %d, want 2", len(result.RemovedVersions))
-	}
-	if result.BytesFreed != 1024 {
-		t.Errorf("BytesFreed = %d, want 1024", result.BytesFreed)
-	}
+
+	// Acquire lock first to simulate contention
+	unlock, err := installer.acquireLock(name)
+	require.NoError(t, err, "Failed to acquire initial lock")
+
+	// Try to call RemoveOtherVersions while lock is held - should fail
+	_, removeErr := installer.RemoveOtherVersions(name, "v2.0.0", tmpDir, nil)
+	require.Error(t, removeErr, "Expected error when lock is already held")
+	assert.Contains(t, removeErr.Error(), "failed to acquire lock")
+
+	// Release the lock
+	unlock()
+
+	// Now RemoveOtherVersions should succeed
+	result, err := installer.RemoveOtherVersions(name, "v2.0.0", tmpDir, nil)
+	require.NoError(t, err, "RemoveOtherVersions failed after lock release")
+	assert.Len(t, result.RemovedVersions, 1)
 }
 
 func TestGetDirSize(t *testing.T) {
@@ -674,33 +587,21 @@ func TestGetDirSize(t *testing.T) {
 	file1 := filepath.Join(dir, "file1.txt")
 	file2 := filepath.Join(dir, "subdir", "file2.txt")
 
-	if err := os.MkdirAll(filepath.Join(dir, "subdir"), 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(file1, []byte("hello"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(file2, []byte("world!"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "subdir"), 0755))
+	require.NoError(t, os.WriteFile(file1, []byte("hello"), 0644))
+	require.NoError(t, os.WriteFile(file2, []byte("world!"), 0644))
 
 	size, err := getDirSize(dir)
-	if err != nil {
-		t.Fatalf("getDirSize() error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// "hello" = 5 bytes, "world!" = 6 bytes = 11 bytes total
 	expectedSize := int64(11)
-	if size != expectedSize {
-		t.Errorf("getDirSize() = %d, want %d", size, expectedSize)
-	}
+	assert.Equal(t, expectedSize, size)
 }
 
 func TestGetDirSizeNonExistent(t *testing.T) {
 	_, err := getDirSize("/nonexistent/path")
-	if err == nil {
-		t.Error("expected error for non-existent path")
-	}
+	assert.Error(t, err, "expected error for non-existent path")
 }
 
 // TestInstallerLockConcurrent verifies that multiple concurrent acquisition
@@ -749,20 +650,27 @@ func TestInstallerLockConcurrent(t *testing.T) {
 	wg.Wait()
 
 	// At least one goroutine should have acquired the lock
-	if successCount.Load() == 0 {
-		t.Error("Expected at least one goroutine to acquire the lock")
-	}
+	assert.Greater(t, successCount.Load(), int32(0), "Expected at least one goroutine to acquire the lock")
 
 	// All goroutines should have either succeeded or failed
 	total := successCount.Load() + errorCount.Load()
-	if total != numGoroutines {
-		t.Errorf("Expected %d total results, got %d", numGoroutines, total)
+	assert.Equal(t, int32(numGoroutines), total)
+
+	// On Windows, lock file release may be delayed due to file handle timing.
+	// Wait for the lock file to be cleaned up before attempting final acquisition.
+	if runtime.GOOS == "windows" {
+		lockPath := filepath.Join(tmpDir, name+".lock")
+		for i := 0; i < 20; i++ {
+			if _, err := os.Stat(lockPath); os.IsNotExist(err) {
+				break
+			}
+			// Small delay to allow Windows file handles to fully close
+			time.Sleep(10 * time.Millisecond)
+		}
 	}
 
 	// After all goroutines complete, we should be able to acquire the lock again
 	unlock, err := installer.acquireLock(name)
-	if err != nil {
-		t.Fatalf("Failed to acquire lock after concurrent test: %v", err)
-	}
+	require.NoError(t, err, "Failed to acquire lock after concurrent test")
 	unlock()
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -397,6 +397,10 @@ func TestFindBinary_Legacy(t *testing.T) {
 
 		legacyBin := filepath.Join(pluginDir, "pulumicost-plugin-myplugin")
 		newBin := filepath.Join(pluginDir, "finfocus-plugin-myplugin")
+		if runtime.GOOS == "windows" {
+			legacyBin += ".exe"
+			newBin += ".exe"
+		}
 		require.NoError(t, os.WriteFile(legacyBin, []byte("old"), 0755))
 		require.NoError(t, os.WriteFile(newBin, []byte("new"), 0755))
 


### PR DESCRIPTION
…s improvements

## Summary

This batch implements 8 fixes spanning Windows test compatibility, concurrent safety improvements, and plugin ecosystem resilience. The changes ensure CI passes on Windows runners by handling `.exe` extensions and file handle timing, while also adding new capabilities for graceful fallback when plugin releases lack platform-specific assets.

Key improvements:

- Plugins that fail to launch now appear in `finfocus plugin list` with informative error notes instead of being silently omitted
- New `FindReleaseWithAsset()` method automatically falls back to previous stable releases when the requested version lacks a compatible asset
- Configuration system extended to support `plugin_host.strict_compatibility` for controlling version parse error behavior

## Test plan

- [x] `make lint` passes with zero issues
- [x] `make test` passes (all unit tests)
- [x] New tests added for `ListStableReleases` and `FindReleaseWithAsset`
- [x] Testify assertion patterns used for new and converted tests

## Changes

### Modified files

- `internal/registry/registry_test.go` - Add Windows `.exe` extension handling in TestFindBinary_Legacy
- `internal/registry/installer_test.go` - Add Windows lock cleanup retry loop, convert tests to testify, add TestRemoveOtherVersionsAcquiresLock
- `internal/registry/installer.go` - Add lock acquisition in RemoveOtherVersions
- `internal/registry/github.go` - Add ListStableReleases and FindReleaseWithAsset methods for fallback support
- `internal/registry/github_api_test.go` - Add tests for new GitHub API methods
- `internal/pluginhost/host.go` - Add strict mode handling for version parse errors
- `internal/pluginhost/version_test.go` - Add strict mode tests
- `internal/config/config.go` - Add plugin_host.strict_compatibility Set/Get
- `internal/config/config_test.go` - Add tests for plugin_host config
- `internal/cli/plugin_list.go` - Show failed plugins with error notes in list

Closes #427, #429, #430, #431, #432, #434, #435