### PR TITLE
ci(nightly): harden nightly analysis workflow with pinning and timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,15 +189,17 @@ jobs:
 
       - name: Run JSON fuzz test (30s smoke)
         run: |
-          # Use -timeout=60s to give cleanup headroom beyond the 30s fuzz duration
-          go test -fuzz=FuzzJSON -fuzztime=30s -timeout=60s ./internal/ingest
-          go test -fuzz=FuzzPulumiPlanParse -fuzztime=30s -timeout=60s ./internal/ingest
+          # Use -timeout=90s to give adequate cleanup headroom beyond the 30s fuzz duration
+          # Fuzzing framework needs extra time for corpus cache writes, especially with many new inputs
+          go test -fuzz=FuzzJSON -fuzztime=30s -timeout=90s ./internal/ingest
+          go test -fuzz=FuzzPulumiPlanParse -fuzztime=30s -timeout=90s ./internal/ingest
 
       - name: Run YAML fuzz test (30s smoke)
         run: |
-          # Use -timeout=60s to give cleanup headroom beyond the 30s fuzz duration
-          go test -fuzz=FuzzYAML -fuzztime=30s -timeout=60s ./internal/spec
-          go test -fuzz=FuzzSpecFilename -fuzztime=30s -timeout=60s ./internal/spec
+          # Use -timeout=90s to give adequate cleanup headroom beyond the 30s fuzz duration
+          # Fuzzing framework needs extra time for corpus cache writes, especially with many new inputs
+          go test -fuzz=FuzzYAML -fuzztime=30s -timeout=90s ./internal/spec
+          go test -fuzz=FuzzSpecFilename -fuzztime=30s -timeout=90s ./internal/spec
 
       - name: Save fuzz corpus cache
         uses: actions/cache/save@v5

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -99,7 +99,7 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE || 'e2e-test-passphrase' }}
           E2E_TIMEOUT_MINS: '60'
           FINFOCUS_LOG_LEVEL: debug
-          FINFOCUS_LOG_FORMAT: console
+          FINFOCUS_LOG_FORMAT: text
         run: |
           echo "Running integration tests (including nightly-only tests)..."
           go test -v -timeout 50m -tags nightly ./test/integration/...
@@ -151,7 +151,7 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE || 'e2e-test-passphrase' }}
           E2E_TIMEOUT_MINS: '60'
           FINFOCUS_LOG_LEVEL: debug
-          FINFOCUS_LOG_FORMAT: console
+          FINFOCUS_LOG_FORMAT: text
           FINFOCUS_BINARY: ${{ github.workspace }}/bin/finfocus
         run: |
           cd test/e2e
@@ -203,7 +203,7 @@ jobs:
           E2E_REGION: us-east-1
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE || 'e2e-test-passphrase' }}
           FINFOCUS_LOG_LEVEL: debug
-          FINFOCUS_LOG_FORMAT: console
+          FINFOCUS_LOG_FORMAT: text
           FINFOCUS_BINARY: ${{ github.workspace }}/bin/finfocus
         run: |
           cd test/e2e

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ Shared utilities for recommendation action type handling:
 - `MatchesActionType(recType string, types []pbc.RecommendationActionType) bool` - Filter matching
 
 Valid action types: RIGHTSIZE, TERMINATE, PURCHASE_COMMITMENT, ADJUST_REQUESTS, MODIFY,
-DELETE_UNUSED, MIGRATE, CONSOLIDATE, SCHEDULE, REFACTOR, OTHER
+DELETE_UNUSED, MIGRATE, CONSOLIDATE, SCHEDULE, REFACTOR, INVESTIGATE, OTHER
 
 ## Documentation
 
@@ -1019,6 +1019,8 @@ CodeRabbit now:
 5. **Integrates with existing CI/CD** tools and workflows
 
 ## Active Technologies
+
+- Go 1.25.5 + github.com/stretchr/testify v1.11.1, Pulumi Automation API (v3.210.0+), E2E test framework (`test/e2e/`), local filesystem for Pulumi state files and fixtures (`test/e2e/fixtures/`) (001-multi-region-e2e)
 
 - Go 1.25.5 + finfocus-spec v0.5.2 (pluginsdk), cobra v1.10.1, (108-action-type-enum)
 - N/A (stateless enum mapping) (108-action-type-enum)

--- a/docs/testing/multi-region-e2e.md
+++ b/docs/testing/multi-region-e2e.md
@@ -1,0 +1,608 @@
+---
+title: Multi-Region E2E Testing Guide
+description: Comprehensive guide for running and maintaining multi-region E2E tests that validate cost calculations across AWS regions
+layout: default
+---
+
+## Overview
+
+This guide provides comprehensive documentation for running and maintaining
+multi-region E2E tests in FinFocus. These tests validate cost calculations
+across different AWS regions (us-east-1, eu-west-1, ap-northeast-1).
+They ensure regional pricing differences are correctly reflected in both
+projected and actual cost calculations.
+
+## Table of Contents
+
+1. [Quick Start](#quick-start)
+2. [Test Architecture](#test-architecture)
+3. [Configuration](#configuration)
+4. [Test Fixtures](#test-fixtures)
+5. [Running Tests](#running-tests)
+6. [Validation Strategy](#validation-strategy)
+7. [Failure Handling](#failure-handling)
+8. [Troubleshooting](#troubleshooting)
+9. [Extending Tests](#extending-tests)
+10. [CI/CD Integration](#cicd-integration)
+
+## Quick Start
+
+```bash
+# Build the FinFocus binary
+make build
+
+# Run multi-region tests (default: us-east-1 only)
+make test-e2e
+
+# Test all three regions
+export FINFOCUS_E2E_REGIONS="us-east-1,eu-west-1,ap-northeast-1"
+go test -v -tags e2e ./test/e2e -run TestMultiRegion
+```
+
+**Expected Duration**: ~5 minutes per region (projected + actual costs)
+
+## Test Architecture
+
+### Components
+
+Multi-region E2E tests consist of several key components:
+
+1. **Test Fixtures** (`test/e2e/fixtures/multi-region/`)
+   - Pulumi programs for each region
+   - Expected cost data with tolerance ranges
+   - Region-specific configurations
+
+2. **Test Implementations** (`test/e2e/multi_region_*_test.go`)
+   - `multi_region_projected_test.go`: Projected cost validation
+   - `multi_region_actual_test.go`: Actual cost validation with deployed resources
+   - `multi_region_fallback_test.go`: Plugin fallback and error handling
+
+3. **Helper Functions** (`test/e2e/multi_region_helpers.go`)
+   - Configuration management
+   - Cost validation logic
+   - Retry mechanisms
+   - Plugin version tracking
+
+### Test Flow
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│ 1. Setup & Configuration                                     │
+│    - Load RegionTestConfig                                   │
+│    - Validate region, tolerance, timeout                     │
+│    - Log plugin versions                                     │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────────────────┐
+│ 2. Fixture Preparation                                       │
+│    - Load expected costs from JSON                           │
+│    - Generate/use Pulumi plan                                │
+│    - Validate fixture structure                              │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────────────────┐
+│ 3. Cost Calculation                                          │
+│    - Projected: Run finfocus cost projected                  │
+│    - Actual: Deploy resources + Run finfocus cost actual     │
+│    - Parse JSON output                                       │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────────────────┐
+│ 4. Validation                                                │
+│    - Compare actual vs expected costs                        │
+│    - Check tolerance (±5% default)                           │
+│    - Validate plugin loading                                 │
+│    - Record results                                          │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────────────────┐
+│ 5. Assertion & Reporting                                     │
+│    - Assert all validations passed                           │
+│    - Log execution time                                      │
+│    - Report failures with context                            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable                             | Default     | Description                             | Example                              |
+| ------------------------------------ | ----------- | --------------------------------------- | ------------------------------------ |
+| `FINFOCUS_E2E_REGIONS`               | `us-east-1` | Comma-separated list of regions to test | `us-east-1,eu-west-1,ap-northeast-1` |
+| `FINFOCUS_E2E_TOLERANCE`             | `0.05`      | Cost variance tolerance (±5%)           | `0.10` for ±10%                      |
+| `FINFOCUS_E2E_TIMEOUT`               | `10m`       | Maximum test execution time per region  | `15m`                                |
+| `FINFOCUS_E2E_SKIP_ACTUAL_COSTS`     | `false`     | Skip actual cost tests                  | `true`                               |
+| `FINFOCUS_E2E_SKIP_DEPENDENCY_CHECK` | `false`     | Skip dependency validation              | `true`                               |
+| `AWS_PROFILE`                        | (none)      | AWS credentials profile to use          | `finfocus-testing`                   |
+| `AWS_REGION`                         | (none)      | Default AWS region for credentials      | `us-east-1`                          |
+
+### RegionTestConfig Structure
+
+```go
+type RegionTestConfig struct {
+    Region            string        // AWS region code
+    FixturePath       string        // Path to Pulumi program
+    ExpectedCostsPath string        // Path to expected-costs.json
+    Tolerance         float64       // Cost variance tolerance
+    Timeout           time.Duration // Maximum execution time
+    PluginVersion     string        // Expected plugin version
+}
+```
+
+## Test Fixtures
+
+### Directory Structure
+
+```text
+test/e2e/fixtures/multi-region/
+├── us-east-1/
+│   ├── Pulumi.yaml          # YAML runtime with inline resources (8 resources)
+│   └── expected-costs.json  # Expected cost ranges
+├── eu-west-1/
+│   ├── Pulumi.yaml          # YAML runtime (region: eu-west-1)
+│   └── expected-costs.json
+├── ap-northeast-1/
+│   ├── Pulumi.yaml          # YAML runtime (region: ap-northeast-1)
+│   └── expected-costs.json
+└── unified/                  # User Story 4 - Multi-region in single fixture
+    ├── Pulumi.yaml          # YAML runtime with explicit provider aliases
+    └── expected-costs.json  # Per-resource + aggregate cost expectations
+```
+
+### Resource Distribution
+
+Each region fixture includes:
+
+- **2x EC2 Instances** (t3.micro, t3.small) - Compute
+  - Different instance types to test pricing variations
+- **2x EBS Volumes** (gp3 100GB, io2 50GB) - Storage
+  - Different volume types and IOPS configurations
+- **2x Network Resources** (NAT Gateway, VPC Endpoint) - Network
+  - Regional network pricing differences
+- **2x RDS Instances** (db.t3.micro PostgreSQL, MySQL) - Database
+  - Database engine pricing variations
+
+**Total**: 8 resources per region × 3 regions = 24 resources validated
+
+### Expected Costs Format
+
+`expected-costs.json` structure:
+
+```json
+{
+  "region": "us-east-1",
+  "cost_type": "projected",
+  "resources": [
+    {
+      "resource_type": "aws:ec2:Instance",
+      "resource_name": "web-server-t3-micro",
+      "min_cost": 6.5,
+      "max_cost": 7.5,
+      "region": "us-east-1",
+      "cost_type": "projected"
+    },
+    ...
+  ]
+}
+```
+
+## Running Tests
+
+### Basic Usage
+
+```bash
+# Run all E2E tests (includes multi-region)
+make test-e2e
+
+# Run only multi-region tests
+go test -v -tags e2e ./test/e2e -run TestMultiRegion
+
+# Run specific region test
+go test -v -tags e2e ./test/e2e -run TestMultiRegion_Projected_USEast1
+```
+
+### Advanced Usage
+
+```bash
+# Test all three regions with custom tolerance
+export FINFOCUS_E2E_REGIONS="us-east-1,eu-west-1,ap-northeast-1"
+export FINFOCUS_E2E_TOLERANCE=0.10
+go test -v -tags e2e ./test/e2e -run TestMultiRegion
+
+# Skip actual cost tests (for development)
+export FINFOCUS_E2E_SKIP_ACTUAL_COSTS=true
+go test -v -tags e2e ./test/e2e -run TestMultiRegion_Projected
+
+# Run with increased timeout
+export FINFOCUS_E2E_TIMEOUT=15m
+go test -timeout 20m -v -tags e2e ./test/e2e -run TestMultiRegion
+
+# Run specific test suite
+go test -v -tags e2e ./test/e2e -run TestMultiRegion_Fallback
+```
+
+### Parallel Execution
+
+Tests are designed to run in parallel for faster execution:
+
+```bash
+# Run with parallelism (default behavior)
+go test -v -tags e2e -parallel 3 ./test/e2e -run TestMultiRegion_Projected
+```
+
+## Validation Strategy
+
+### Tolerance-Based Validation
+
+Multi-region tests use **tolerance-based validation** to handle pricing variability:
+
+1. **Expected Cost Range**: Each resource has `min_cost` and `max_cost` values
+2. **Default Tolerance**: ±5% to accommodate minor pricing fluctuations
+3. **Validation Logic**: Actual cost must fall within [min_cost, max_cost]
+4. **Variance Calculation**: Percentage difference from midpoint
+
+```go
+midpoint := (expected.MinCost + expected.MaxCost) / 2
+withinTolerance := actual.MonthlyCost >= expected.MinCost &&
+                   actual.MonthlyCost <= expected.MaxCost
+variance := (actual.MonthlyCost - midpoint) / midpoint * 100
+```
+
+### Plugin Validation
+
+Tests validate plugin loading and versioning:
+
+1. **Plugin Availability**: Verify AWS plugin is loaded
+2. **Version Check**: Validate plugin version matches expected
+3. **Binary Path**: Confirm plugin binary exists at reported path
+4. **Region-Specific**: Check correct plugin is used for each region
+
+## Failure Handling
+
+### Error Classification
+
+Multi-region tests implement strict failure semantics:
+
+| Error Type                | Detection                                            | Action                   | Retry |
+| ------------------------- | ---------------------------------------------------- | ------------------------ | ----- |
+| **Missing Pricing Data**  | "no pricing data" in error                           | Fail immediately         | No    |
+| **Network Failure**       | "connection refused", "timeout"                      | Retry 3x with backoff    | Yes   |
+| **Invalid Region**        | Region not in [us-east-1, eu-west-1, ap-northeast-1] | Fail immediately         | No    |
+| **Cost Out of Tolerance** | Actual cost outside expected range                   | Record failure, continue | No    |
+
+### Retry Logic
+
+Network failures use exponential backoff:
+
+```go
+attempt 1: 100ms delay
+attempt 2: 200ms delay
+attempt 3: 400ms delay
+final: fail with error
+```
+
+### Fallback Behavior
+
+When region-specific plugins are unavailable:
+
+1. **Detection**: Plugin not found or fails to load
+2. **Fallback**: Use public pricing data (issue #24)
+3. **Warning**: Log fallback occurrence
+4. **Validation**: Use looser tolerance (±10% instead of ±5%)
+
+## Troubleshooting
+
+### Common Issues
+
+#### 1. Test Fails: "No pricing data available"
+
+**Symptom**:
+
+```text
+FAIL: No pricing data available for eu-west-1/aws:ec2:Instance
+```
+
+**Cause**: Plugin doesn't have pricing data for the region
+
+**Solution**:
+
+```bash
+# Verify plugin installation
+./bin/finfocus plugin list
+
+# Install region-specific plugin if missing
+./bin/finfocus plugin install aws-public --version <version>
+```
+
+#### 2. Test Fails: "Network failure after 3 retries"
+
+**Symptom**:
+
+```text
+FAIL: Network failure after 3 retries: connection refused
+```
+
+**Cause**: Plugin gRPC communication failed
+
+**Solution**:
+
+1. Check plugin process: `ps aux | grep finfocus-plugin`
+2. Verify no firewall blocking localhost
+3. Retry test (may be transient)
+4. Check plugin logs: `~/.finfocus/logs/`
+
+#### 3. Cost Variance Exceeds Tolerance
+
+**Symptom**:
+
+```text
+FAIL: Resource web-server cost $58.50 outside expected range [$50.00, $55.00]
+```
+
+**Cause**: AWS pricing changed or resource configuration differs
+
+**Solution**:
+
+1. Verify pricing change on AWS pricing page
+2. Update `expected-costs.json` with new ranges
+3. Temporarily increase tolerance: `export FINFOCUS_E2E_TOLERANCE=0.10`
+
+#### 4. Test Timeout
+
+**Symptom**:
+
+```text
+panic: test timed out after 10m0s
+```
+
+**Cause**: Test execution exceeded timeout (likely actual cost tests)
+
+**Solution**:
+
+```bash
+# Increase timeout
+export FINFOCUS_E2E_TIMEOUT=15m
+go test -timeout 20m -tags e2e ./test/e2e -run TestMultiRegion
+
+# Or skip actual cost tests
+export FINFOCUS_E2E_SKIP_ACTUAL_COSTS=true
+```
+
+#### 5. Missing Dependencies (Issue #177 or #24)
+
+**Symptom**:
+
+```text
+FAIL: Pulumi Automation API support required (issue #177)
+```
+
+**Cause**: Test depends on incomplete feature
+
+**Solution**:
+
+1. Check issue status: `gh issue view 177`
+2. Skip actual cost tests: `export FINFOCUS_E2E_SKIP_ACTUAL_COSTS=true`
+3. Wait for dependency to merge
+
+## Extending Tests
+
+### Adding a New Region
+
+1. **Create Fixture Directory**:
+
+   ```bash
+   mkdir -p test/e2e/fixtures/multi-region/us-west-2
+   ```
+
+2. **Create Pulumi YAML Program** (`Pulumi.yaml`):
+
+   ```yaml
+   name: multi-region-test-us-west-2
+   runtime: yaml
+   description: Multi-region E2E test fixture for us-west-2
+
+   config:
+     aws:region:
+       value: us-west-2
+     pulumi:tags:
+       value:
+         Environment: e2e-test
+         ManagedBy: finfocus
+         TestSuite: multi-region
+
+   resources:
+     # EC2 Instance example
+     web-server-t3-micro:
+       type: aws:ec2:Instance
+       properties:
+         ami: ami-placeholder-us-west-2
+         instanceType: t3.micro
+         tags:
+           Name: web-server-t3-micro
+
+     # Add additional resources as needed (2 EC2, 2 EBS, 2 Network, 2 RDS)
+   ```
+
+3. **Create Expected Costs** (`expected-costs.json`):
+
+   ```json
+   {
+     "region": "us-west-2",
+     "cost_type": "projected",
+     "resources": [...]
+   }
+   ```
+
+4. **Add Test Function** (in `multi_region_projected_test.go`):
+
+   ```go
+   func TestMultiRegion_Projected_USWest2(t *testing.T) {
+       if shouldSkipRegion(t, "us-west-2") {
+           t.Skip("Skipping us-west-2 test")
+       }
+       testMultiRegionProjected(t, "us-west-2")
+   }
+   ```
+
+5. **Update Configuration Validation** (in `multi_region_helpers.go`):
+
+   ```go
+   validRegions := []string{"us-east-1", "eu-west-1", "ap-northeast-1", "us-west-2"}
+   ```
+
+### Adding New Resource Types
+
+1. **Update Fixture** (`test/e2e/fixtures/multi-region/<region>/Pulumi.yaml`):
+
+   ```yaml
+   # Add new resource (e.g., Lambda function)
+   test-function:
+     type: aws:lambda:Function
+     properties:
+       runtime: nodejs18.x
+       handler: index.handler
+       role: ${test-role.arn}
+       # ... other properties
+   ```
+
+2. **Update Expected Costs** (`expected-costs.json`):
+
+   ```json
+   {
+     "resource_type": "aws:lambda:Function",
+     "resource_name": "test-function",
+     "min_cost": 0.2,
+     "max_cost": 0.3,
+     "region": "us-east-1",
+     "cost_type": "projected"
+   }
+   ```
+
+3. **Verify All Regions**: Add the same resource to all region fixtures
+
+## Unified Multi-Region Fixtures (User Story 4)
+
+### Overview
+
+In addition to per-region fixtures, the unified fixture tests a **single Pulumi program**
+that deploys resources across multiple regions - a common real-world pattern.
+
+### Structure
+
+```yaml
+# test/e2e/fixtures/multi-region/unified/Pulumi.yaml
+name: multi-region-test-unified
+runtime: yaml
+
+resources:
+  # Explicit provider per region
+  aws-us-east-1:
+    type: pulumi:providers:aws
+    properties:
+      region: us-east-1
+
+  aws-eu-west-1:
+    type: pulumi:providers:aws
+    properties:
+      region: eu-west-1
+
+  # Resources reference specific providers
+  web-us-east-1:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-placeholder
+      instanceType: t3.micro
+    options:
+      provider: ${aws-us-east-1}
+
+  web-eu-west-1:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-placeholder
+      instanceType: t3.micro
+    options:
+      provider: ${aws-eu-west-1}
+```
+
+### Validation
+
+Unified fixtures validate:
+
+1. **Per-resource costs** reflect region-specific pricing
+2. **Aggregate total** equals sum of individual region costs within ±5% tolerance
+3. **Region attribution** from provider configuration in plan JSON
+
+### Running Unified Tests
+
+```bash
+go test -v -tags e2e ./test/e2e -run TestMultiRegion_Unified_Projected
+```
+
+### Troubleshooting Unified Fixtures
+
+**Issue: "Region not detected for resource"**
+
+- Ensure provider is explicitly declared with `region` property
+- Verify resource uses `options.provider` to reference the provider
+- Check plan JSON contains provider URN with region
+
+**Issue: "Aggregate total outside tolerance"**
+
+- Tolerance compounds: 3 resources at +5% each = ~+15% total
+- Update `aggregate_validation` bounds in `expected-costs.json` if needed
+
+## CI/CD Integration
+
+### GitHub Actions
+
+Multi-region tests run automatically via `make test-e2e`:
+
+```yaml
+- name: Run E2E Tests
+  run: make test-e2e
+  env:
+    FINFOCUS_E2E_REGIONS: us-east-1
+    FINFOCUS_E2E_SKIP_ACTUAL_COSTS: true
+    AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+```
+
+### Performance Considerations
+
+- **Projected tests**: ~2-3 minutes per region
+- **Actual tests**: ~4-5 minutes per region (includes deployment)
+- **Parallel execution**: Reduces total time by ~50%
+- **CI optimization**: Run us-east-1 only by default, full multi-region on schedule
+
+### Failure Notification
+
+Tests report failures with detailed context:
+
+```text
+Cost validation failed for web-server-t3-micro:
+  Actual: $58.50
+  Expected: [$50.00, $55.00]
+  Variance: +15.00%
+  Region: eu-west-1
+  Cost Type: projected
+```
+
+## Best Practices
+
+1. **Regular Updates**: Update `expected-costs.json` when AWS pricing changes
+2. **Tolerance Adjustment**: Use ±5% for normal tests, ±10% for fallback scenarios
+3. **Fixture Maintenance**: Keep fixtures synchronized across regions
+4. **Dependency Tracking**: Monitor issues #177 and #24 for test prerequisites
+5. **Log Review**: Check plugin version logs to verify correct plugin usage
+6. **Performance Monitoring**: Watch for tests exceeding 5-minute target
+7. **Error Classification**: Ensure errors are properly classified for correct retry behavior
+
+## References
+
+- [Feature Specification](../../specs/001-multi-region-e2e/spec.md)
+- [Implementation Plan](../../specs/001-multi-region-e2e/plan.md)
+- [Quickstart Guide](../../specs/001-multi-region-e2e/quickstart.md)
+- [Test Fixtures](../../test/e2e/fixtures/multi-region/)
+- [E2E Test README](../../test/e2e/README.md)
+- [CLAUDE.md - Testing Section](../../CLAUDE.md#testing)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -16,6 +16,7 @@ func setupTestConfig(t *testing.T) (string, func()) {
 	t.Helper()
 	testHome := t.TempDir()
 	t.Setenv("HOME", testHome)
+	t.Setenv("USERPROFILE", testHome) // Windows compatibility
 	// If a reset helper exists, call it here; otherwise noop.
 	cleanup := func() {}
 	return testHome, cleanup

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -451,13 +451,13 @@ func TestConfig_FINFOCUS_LOG_FORMAT_EnvVar(t *testing.T) {
 	stubHome(t)
 
 	// Test various log formats via environment variable
+	// Note: Only "json" and "text" are valid formats per isValidFormat()
 	tests := []struct {
 		envValue       string
 		expectedFormat string
 	}{
 		{"json", "json"},
 		{"text", "text"},
-		{"console", "console"},
 	}
 
 	for _, tt := range tests {

--- a/internal/logging/file_test.go
+++ b/internal/logging/file_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,6 +41,10 @@ func TestCreateWriter_CreatesFile(t *testing.T) {
 
 // T059: Unit test for createWriter fallback to stderr on permission error.
 func TestCreateWriter_FallbackOnPermissionError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping permission test on Windows - POSIX permissions not enforced")
+	}
+
 	// Create a directory and make it read-only to force permission error
 	tmpDir := t.TempDir()
 	readOnlyDir := filepath.Join(tmpDir, "readonly")
@@ -108,6 +113,10 @@ func TestNewLoggerWithPath_CreatesFile(t *testing.T) {
 
 // T061: Unit test for NewLoggerWithPath fallback.
 func TestNewLoggerWithPath_Fallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping permission test on Windows - POSIX permissions not enforced")
+	}
+
 	tmpDir := t.TempDir()
 	readOnlyDir := filepath.Join(tmpDir, "readonly")
 	err := os.Mkdir(readOnlyDir, 0500)

--- a/internal/migration/migrator_test.go
+++ b/internal/migration/migrator_test.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,5 +35,10 @@ func TestSafeCopy(t *testing.T) {
 
 	info, err := os.Stat(filepath.Join(dst, "plugins", "aws", "plugin.exe"))
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0700), info.Mode().Perm())
+	// On Windows, file permissions work differently - just ensure it's a regular file
+	if runtime.GOOS == "windows" {
+		assert.True(t, info.Mode().IsRegular(), "should be a regular file")
+	} else {
+		assert.Equal(t, os.FileMode(0700), info.Mode().Perm())
+	}
 }

--- a/internal/proto/action_types.go
+++ b/internal/proto/action_types.go
@@ -24,6 +24,7 @@ var actionTypeLabels = map[pbc.RecommendationActionType]string{
 	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_CONSOLIDATE:         "Consolidate",
 	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_SCHEDULE:            "Schedule",
 	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_REFACTOR:            "Refactor",
+	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_INVESTIGATE:         "Investigate",
 	pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_OTHER:               "Other",
 }
 
@@ -42,6 +43,7 @@ var actionTypeNames = map[string]pbc.RecommendationActionType{
 	"CONSOLIDATE":         pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_CONSOLIDATE,
 	"SCHEDULE":            pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_SCHEDULE,
 	"REFACTOR":            pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_REFACTOR,
+	"INVESTIGATE":         pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_INVESTIGATE,
 	"OTHER":               pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_OTHER,
 }
 
@@ -59,6 +61,7 @@ var stringLabels = map[string]string{
 	"CONSOLIDATE":         "Consolidate",
 	"SCHEDULE":            "Schedule",
 	"REFACTOR":            "Refactor",
+	"INVESTIGATE":         "Investigate",
 	"OTHER":               "Other",
 }
 

--- a/internal/proto/action_types_test.go
+++ b/internal/proto/action_types_test.go
@@ -72,6 +72,11 @@ func TestActionTypeLabel(t *testing.T) {
 			expected: "Refactor",
 		},
 		{
+			name:     "INVESTIGATE",
+			input:    pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_INVESTIGATE,
+			expected: "Investigate",
+		},
+		{
 			name:     "OTHER",
 			input:    pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_OTHER,
 			expected: "Other",
@@ -144,6 +149,11 @@ func TestParseActionType(t *testing.T) {
 			name:     "REFACTOR uppercase",
 			input:    "REFACTOR",
 			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_REFACTOR,
+		},
+		{
+			name:     "INVESTIGATE uppercase",
+			input:    "INVESTIGATE",
+			expected: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_INVESTIGATE,
 		},
 		{
 			name:     "OTHER uppercase",
@@ -304,8 +314,8 @@ func TestParseActionTypeFilter(t *testing.T) {
 func TestValidActionTypes(t *testing.T) {
 	types := proto.ValidActionTypes()
 
-	// Should have exactly 11 types (excluding UNSPECIFIED)
-	assert.Len(t, types, 11)
+	// Should have exactly 12 types (excluding UNSPECIFIED)
+	assert.Len(t, types, 12)
 
 	// Should not contain UNSPECIFIED
 	for _, at := range types {
@@ -324,6 +334,7 @@ func TestValidActionTypes(t *testing.T) {
 		"CONSOLIDATE",
 		"SCHEDULE",
 		"REFACTOR",
+		"INVESTIGATE",
 		"OTHER",
 	}
 	for _, expected := range expectedTypes {

--- a/specs/001-multi-region-e2e/checklists/requirements.md
+++ b/specs/001-multi-region-e2e/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Add multi-region E2E testing support
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-21
+**Feature**: specs/001-multi-region-e2e/spec.md
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All quality checks passed. Specification is ready for planning phase.

--- a/specs/001-multi-region-e2e/contracts/test-interfaces.go
+++ b/specs/001-multi-region-e2e/contracts/test-interfaces.go
@@ -1,0 +1,226 @@
+// Package contracts defines the interfaces and contracts for multi-region E2E testing.
+// This is a design-time artifact documenting expected test infrastructure behavior.
+package contracts
+
+import (
+	"context"
+	"time"
+)
+
+// RegionTestRunner executes E2E tests for a single AWS region.
+type RegionTestRunner interface {
+	// RunProjectedCostTest executes projected cost validation for the region.
+	// Returns validation results or error if test setup/execution fails.
+	RunProjectedCostTest(
+		ctx context.Context,
+		config RegionTestConfig,
+	) (*MultiRegionTestResult, error)
+
+	// RunActualCostTest executes actual cost validation for deployed resources in the region.
+	// Requires Pulumi Automation API support (issue #177) and GetActualCost implementation (issue #24).
+	// Returns validation results or error if test setup/execution fails.
+	RunActualCostTest(ctx context.Context, config RegionTestConfig) (*MultiRegionTestResult, error)
+
+	// RunFallbackTest validates fallback behavior when region-specific plugins are unavailable.
+	// Returns validation results or error if fallback logic fails.
+	RunFallbackTest(ctx context.Context, config RegionTestConfig) (*MultiRegionTestResult, error)
+}
+
+// CostValidator validates actual costs against expected ranges with tolerance.
+type CostValidator interface {
+	// ValidateCost checks if actual cost is within expected range.
+	// Returns CostValidationResult with tolerance check outcome.
+	ValidateCost(actual CostResult, expected ExpectedCost, tolerance float64) CostValidationResult
+
+	// ValidateMultiRegionCosts validates costs across multiple regions and aggregates results.
+	// Returns MultiRegionTestResult summarizing all validations.
+	ValidateMultiRegionCosts(
+		results []CostResult,
+		expectations []ExpectedCost,
+		tolerance float64,
+	) (*MultiRegionTestResult, error)
+}
+
+// FixtureLoader loads Pulumi programs and expected cost data for test fixtures.
+type FixtureLoader interface {
+	// LoadExpectedCosts reads and parses expected-costs.json for a region.
+	// Returns slice of ExpectedCost or error if file is missing/invalid.
+	LoadExpectedCosts(fixturePath string) ([]ExpectedCost, error)
+
+	// GetPulumiProgramPath returns absolute path to Pulumi program for a region.
+	// Returns error if fixture directory doesn't exist.
+	GetPulumiProgramPath(region string) (string, error)
+
+	// ValidateFixture checks that a fixture directory contains required files.
+	// Required files: main.go, Pulumi.yaml, expected-costs.json
+	// Returns error if any required file is missing.
+	ValidateFixture(fixturePath string) error
+}
+
+// RetryPolicy defines retry behavior for transient failures.
+type RetryPolicy interface {
+	// ShouldRetry determines if an error is transient and should be retried.
+	// Returns true for network errors, false for validation errors.
+	ShouldRetry(err error) bool
+
+	// GetBackoff returns backoff duration for a given attempt number.
+	// Implements exponential backoff: 100ms, 200ms, 400ms for attempts 0, 1, 2.
+	GetBackoff(attempt int) time.Duration
+
+	// MaxAttempts returns maximum retry attempts (3 per clarification).
+	MaxAttempts() int
+}
+
+// RegionTestConfig holds configuration for a single region's E2E test execution.
+type RegionTestConfig struct {
+	Region            string        // AWS region (us-east-1, eu-west-1, ap-northeast-1)
+	FixturePath       string        // Path to Pulumi program fixture directory
+	ExpectedCostsPath string        // Path to expected-costs.json file
+	Tolerance         float64       // Cost variance tolerance (0.05 for ±5%)
+	Timeout           time.Duration // Maximum test execution time (5 minutes default)
+	PluginVersion     string        // Expected AWS plugin version (e.g., "0.1.0")
+}
+
+// ExpectedCost defines expected cost range for a specific resource type in a region.
+type ExpectedCost struct {
+	ResourceType string  // Pulumi resource type (e.g., "aws:ec2:Instance")
+	ResourceName string  // Logical resource name in Pulumi program
+	MinCost      float64 // Minimum acceptable monthly cost (USD)
+	MaxCost      float64 // Maximum acceptable monthly cost (USD)
+	Region       string  // AWS region this expectation applies to
+	CostType     string  // "projected" or "actual"
+}
+
+// CostResult represents actual cost calculation result from FinFocus CLI.
+type CostResult struct {
+	ResourceName string  // Resource identifier
+	ResourceType string  // Pulumi resource type
+	Region       string  // AWS region
+	MonthlyCost  float64 // Calculated monthly cost (USD)
+	Currency     string  // Currency code (should always be "USD")
+	CostType     string  // "projected" or "actual"
+	Timestamp    time.Time
+}
+
+// CostValidationResult captures the result of cost validation for a single resource.
+type CostValidationResult struct {
+	ResourceName    string    // Resource identifier
+	ResourceType    string    // Pulumi resource type
+	Region          string    // AWS region
+	ActualCost      float64   // Actual calculated cost (USD)
+	ExpectedMin     float64   // Minimum expected cost (USD)
+	ExpectedMax     float64   // Maximum expected cost (USD)
+	WithinTolerance bool      // Whether actual cost is within expected range
+	Variance        float64   // Percentage variance from expected midpoint
+	Timestamp       time.Time // When validation was performed
+	CostType        string    // "projected" or "actual"
+}
+
+// MultiRegionTestResult aggregates validation results across all regions and cost types.
+type MultiRegionTestResult struct {
+	Regions           []string               // List of tested regions
+	Results           []CostValidationResult // Individual validation results
+	TotalResources    int                    // Total number of resources validated
+	PassedValidations int                    // Number of resources within tolerance
+	FailedValidations int                    // Number of resources outside tolerance
+	ExecutionTime     time.Duration          // Total test execution time
+	TestTimestamp     time.Time              // When test suite started
+	Success           bool                   // True if all validations passed
+}
+
+// ErrorClassifier classifies errors for retry and failure handling.
+type ErrorClassifier interface {
+	// IsNetworkError determines if an error is a network-related transient failure.
+	IsNetworkError(err error) bool
+
+	// IsMissingPricingData determines if an error indicates missing pricing data.
+	IsMissingPricingData(err error) bool
+
+	// IsInvalidRegion determines if an error indicates invalid region configuration.
+	IsInvalidRegion(err error) bool
+}
+
+// Contract: Test Execution Flow
+//
+// 1. Test Setup:
+//    - Validate RegionTestConfig (region code, fixture path, tolerance)
+//    - Load ExpectedCost data from expected-costs.json
+//    - Check plugin availability and version
+//
+// 2. Test Execution (per region, per cost type):
+//    - For Projected Costs:
+//      * Generate Pulumi plan JSON from fixture program
+//      * Execute: finfocus cost projected --pulumi-json <plan> --output json
+//      * Parse cost results
+//    - For Actual Costs:
+//      * Deploy Pulumi resources using Automation API (requires issue #177)
+//      * Execute: finfocus cost actual --state-file <state> --output json
+//      * Parse cost results
+//      * Cleanup deployed resources (defer)
+//
+// 3. Validation:
+//    - For each resource:
+//      * Compare actual cost against expected min/max
+//      * Calculate variance percentage
+//      * Record CostValidationResult (pass/fail)
+//
+// 4. Aggregation:
+//    - Collect all CostValidationResult into MultiRegionTestResult
+//    - Calculate pass/fail counts
+//    - Determine overall test success
+//
+// 5. Failure Handling:
+//    - Missing pricing data → Fail immediately (no retry)
+//    - Network errors → Retry 3x with exponential backoff, then fail
+//    - Invalid region config → Fail immediately in setup
+//    - Cost out of tolerance → Record failure, continue test
+//
+// 6. Assertion:
+//    - require.True(t, result.Success, "Multi-region validation failed")
+//    - Log detailed failure information for debugging
+
+// Contract: Fixture Structure
+//
+// test/e2e/fixtures/multi-region/<region>/
+//   ├── main.go              # Pulumi program (5-10 resources, 3-4 types)
+//   ├── Pulumi.yaml          # Stack configuration with region
+//   ├── go.mod               # Go module for Pulumi program
+//   └── expected-costs.json  # Expected cost ranges per resource
+//
+// Example expected-costs.json:
+// {
+//   "region": "us-east-1",
+//   "cost_type": "projected",
+//   "resources": [
+//     {
+//       "resource_type": "aws:ec2:Instance",
+//       "resource_name": "web-server",
+//       "min_cost": 50.0,
+//       "max_cost": 55.0,
+//       "region": "us-east-1",
+//       "cost_type": "projected"
+//     }
+//   ]
+// }
+
+// Contract: Test Naming Convention
+//
+// Test functions follow naming pattern: TestMultiRegion_<CostType>_<Scenario>_<Region>
+//
+// Examples:
+// - TestMultiRegion_Projected_Baseline_USEast1
+// - TestMultiRegion_Actual_PricingDifference_EUWest1
+// - TestMultiRegion_Fallback_MissingPlugin_APNortheast1
+// - TestMultiRegion_ErrorHandling_MissingPricingData
+// - TestMultiRegion_ErrorHandling_NetworkFailure
+
+// Contract: Environment Variables
+//
+// Tests respect existing E2E environment variables:
+// - FINFOCUS_E2E_AWS_REGION: Override default region (default: us-east-1)
+// - FINFOCUS_E2E_TOLERANCE: Override cost tolerance (default: 0.05)
+// - FINFOCUS_E2E_TIMEOUT: Override test timeout (default: 10m)
+//
+// Additional variables for multi-region testing:
+// - FINFOCUS_E2E_REGIONS: Comma-separated list of regions to test (default: "us-east-1,eu-west-1,ap-northeast-1")
+// - FINFOCUS_E2E_SKIP_ACTUAL_COSTS: Skip actual cost tests if "true" (for pre-#177 development)

--- a/specs/001-multi-region-e2e/data-model.md
+++ b/specs/001-multi-region-e2e/data-model.md
@@ -1,0 +1,625 @@
+# Data Model: Multi-Region E2E Testing
+
+**Date**: 2026-01-21
+**Phase**: 1 (Design & Contracts)
+**Status**: Complete
+
+## Overview
+
+This document defines the data structures, validation rules, and state transitions for multi-region E2E testing infrastructure. Since this is a test infrastructure feature, the "data model" primarily consists of test configuration structures, expected cost definitions, and test result representations.
+
+## Core Entities
+
+### 1. RegionTestConfig
+
+Represents configuration for a single region's E2E test execution.
+
+**Fields**:
+
+- `Region` (`string`): AWS region identifier. Must be valid AWS region code (us-east-1, eu-west-1, ap-northeast-1)
+- `FixturePath` (`string`): Path to Pulumi program fixture directory. Must exist on filesystem
+- `ExpectedCostsPath` (`string`): Path to expected-costs.json file. Must exist and be valid JSON
+- `Tolerance` (`float64`): Cost variance tolerance (default: 0.05 for ±5%). Must be > 0 and ≤ 1.0
+- `Timeout` (`time.Duration`): Maximum test execution time (default: 5 minutes). Must be > 0
+- `PluginVersion` (`string`): Expected AWS plugin version (e.g., "0.1.0"). Semantic version format
+
+**Relationships**:
+- One-to-many with `ExpectedCost` (multiple expected costs per region)
+- One-to-one with Pulumi program fixture directory
+
+**Validation Rules**:
+```go
+func (r *RegionTestConfig) Validate() error {
+    validRegions := []string{"us-east-1", "eu-west-1", "ap-northeast-1"}
+    if !contains(validRegions, r.Region) {
+        return fmt.Errorf("invalid region: %s (must be one of %v)", r.Region, validRegions)
+    }
+
+    if !fileExists(r.FixturePath) {
+        return fmt.Errorf("fixture path does not exist: %s", r.FixturePath)
+    }
+
+    if r.Tolerance <= 0 || r.Tolerance > 1.0 {
+        return fmt.Errorf("tolerance must be > 0 and ≤ 1.0, got: %f", r.Tolerance)
+    }
+
+    if r.Timeout <= 0 {
+        return fmt.Errorf("timeout must be positive, got: %v", r.Timeout)
+    }
+
+    return nil
+}
+```
+
+---
+
+### 2. ExpectedCost
+
+Defines expected cost range for a specific resource type in a region.
+
+**Fields**:
+
+- `ResourceType` (`string`): Resource type identifier (e.g., "aws:ec2:Instance"). Must match Pulumi resource type format (provider:module:type)
+- `ResourceName` (`string`): Logical name of resource in Pulumi program. Non-empty
+- `MinCost` (`float64`): Minimum acceptable monthly cost (USD). Must be ≥ 0
+- `MaxCost` (`float64`): Maximum acceptable monthly cost (USD). Must be > MinCost
+- `Region` (`string`): Region this expectation applies to. Must be valid AWS region code
+- `CostType` (`CostType`): Type of cost calculation. Must be "projected" or "actual"
+
+**Relationships**:
+
+- Many-to-one with `RegionTestConfig` (grouped by region)
+- One-to-one with specific resource in Pulumi program
+
+**Validation Rules**:
+```go
+func (e *ExpectedCost) Validate() error {
+    if e.ResourceType == "" {
+        return fmt.Errorf("resource type is required")
+    }
+
+    if e.ResourceName == "" {
+        return fmt.Errorf("resource name is required")
+    }
+
+    if e.MinCost < 0 {
+        return fmt.Errorf("min cost must be non-negative, got: %f", e.MinCost)
+    }
+
+    if e.MaxCost <= e.MinCost {
+        return fmt.Errorf("max cost (%f) must be greater than min cost (%f)", e.MaxCost, e.MinCost)
+    }
+
+    if e.CostType != CostTypeProjected && e.CostType != CostTypeActual {
+        return fmt.Errorf("invalid cost type: %s", e.CostType)
+    }
+
+    return nil
+}
+```
+
+**JSON Schema**:
+```json
+{
+  "type": "object",
+  "required": ["resource_type", "resource_name", "min_cost", "max_cost", "region", "cost_type"],
+  "properties": {
+    "resource_type": {
+      "type": "string",
+      "pattern": "^[a-z]+:[a-z0-9]+:[A-Za-z0-9]+"
+    },
+    "resource_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "min_cost": {
+      "type": "number",
+      "minimum": 0
+    },
+    "max_cost": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "region": {
+      "type": "string",
+      "enum": ["us-east-1", "eu-west-1", "ap-northeast-1"]
+    },
+    "cost_type": {
+      "type": "string",
+      "enum": ["projected", "actual"]
+    }
+  }
+}
+```
+
+---
+
+### 3. CostValidationResult
+
+Captures the result of cost validation for a single resource.
+
+**Fields**:
+
+- `ResourceName` (`string`): Resource identifier. Non-empty
+- `ResourceType` (`string`): Pulumi resource type. Non-empty
+- `Region` (`string`): AWS region. Valid AWS region code
+- `ActualCost` (`float64`): Actual calculated cost (USD). Must be ≥ 0
+- `ExpectedMin` (`float64`): Minimum expected cost (USD). Must be ≥ 0
+- `ExpectedMax` (`float64`): Maximum expected cost (USD). Must be > ExpectedMin
+- `WithinTolerance` (`bool`): Whether actual cost is within expected range
+- `Variance` (`float64`): Percentage variance from expected midpoint
+- `Timestamp` (`time.Time`): When validation was performed
+- `CostType` (`CostType`): Type of cost validated. Must be "projected" or "actual"
+
+**Relationships**:
+
+- Many-to-one with `MultiRegionTestResult` (aggregated test results)
+- One-to-one with `ExpectedCost` (validation source)
+
+**State Transitions**:
+```text
+Initial State: [Validation Pending]
+    ↓
+[Execute Cost Calculation]
+    ↓
+[Compare with Expected Range]
+    ↓
+Decision Point: Within Tolerance?
+    ├─ YES → [Validation Passed] (WithinTolerance = true)
+    └─ NO  → [Validation Failed] (WithinTolerance = false)
+```
+
+---
+
+### 4. MultiRegionTestResult
+
+Aggregates validation results across all regions and cost types.
+
+**Fields**:
+
+- `Regions` (`[]string`): List of tested regions. Must contain 1-3 regions
+- `Results` (`[]CostValidationResult`): Individual validation results. Non-empty
+- `TotalResources` (`int`): Total number of resources validated. Must match len(Results)
+- `PassedValidations` (`int`): Number of resources within tolerance. Must be ≤ TotalResources
+- `FailedValidations` (`int`): Number of resources outside tolerance. Must equal TotalResources - PassedValidations
+- `ExecutionTime` (`time.Duration`): Total test execution time. Must be > 0
+- `TestTimestamp` (`time.Time`): When test suite started
+- `Success` (`bool`): True if all validations passed
+
+**Relationships**:
+
+- One-to-many with `CostValidationResult` (contains all validation results)
+- One-to-many with `RegionTestConfig` (tested multiple regions)
+
+**Validation Rules**:
+```go
+func (m *MultiRegionTestResult) Validate() error {
+    if len(m.Results) == 0 {
+        return fmt.Errorf("results cannot be empty")
+    }
+
+    if m.TotalResources != len(m.Results) {
+        return fmt.Errorf("total resources (%d) must match results length (%d)",
+            m.TotalResources, len(m.Results))
+    }
+
+    if m.PassedValidations + m.FailedValidations != m.TotalResources {
+        return fmt.Errorf("passed (%d) + failed (%d) must equal total (%d)",
+            m.PassedValidations, m.FailedValidations, m.TotalResources)
+    }
+
+    m.Success = (m.FailedValidations == 0)
+    return nil
+}
+```
+
+---
+
+### 5. CostType
+
+Enumeration for cost calculation types.
+
+**Values**:
+- `CostTypeProjected`: Projected costs from Pulumi preview
+- `CostTypeActual`: Actual costs from deployed resources
+
+**Validation**:
+```go
+type CostType string
+
+const (
+    CostTypeProjected CostType = "projected"
+    CostTypeActual    CostType = "actual"
+)
+
+func (c CostType) IsValid() bool {
+    return c == CostTypeProjected || c == CostTypeActual
+}
+
+func (c CostType) String() string {
+    return string(c)
+}
+```
+
+---
+
+## Data Flow
+
+```text
+1. Test Setup:
+   RegionTestConfig → Load ExpectedCost from JSON
+
+2. Test Execution:
+   RegionTestConfig → Deploy/Preview Pulumi → Calculate Costs
+
+3. Validation:
+   Actual Costs + Expected Costs → CostValidationResult
+
+4. Aggregation:
+   Multiple CostValidationResult → MultiRegionTestResult
+
+5. Assertion:
+   MultiRegionTestResult.Success → Test Pass/Fail
+```
+
+## File Formats
+
+### expected-costs.json
+
+```json
+{
+  "region": "us-east-1",
+  "cost_type": "projected",
+  "resources": [
+    {
+      "resource_type": "aws:ec2:Instance",
+      "resource_name": "web-server",
+      "min_cost": 50.0,
+      "max_cost": 55.0,
+      "region": "us-east-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ebs:Volume",
+      "resource_name": "data-volume",
+      "min_cost": 8.0,
+      "max_cost": 10.0,
+      "region": "us-east-1",
+      "cost_type": "projected"
+    }
+  ]
+}
+```
+
+### Pulumi.yaml (fixture configuration - YAML runtime)
+
+```yaml
+name: multi-region-test-us-east-1
+runtime: yaml
+description: Multi-region E2E test fixture for us-east-1
+
+config:
+  aws:region: us-east-1
+
+resources:
+  # EC2 Instances
+  web-server:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-0123456789abcdef0
+      instanceType: t3.micro
+      tags:
+        Environment: e2e-test
+        ManagedBy: finfocus
+        TestSuite: multi-region
+
+  app-server:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-0123456789abcdef0
+      instanceType: t3.small
+      tags:
+        Environment: e2e-test
+```
+
+## Validation Matrix
+
+- **Region code**: Scope: RegionTestConfig, Trigger: Test setup, Failure: Fail immediately
+- **Fixture path exists**: Scope: RegionTestConfig, Trigger: Test setup, Failure: Fail immediately
+- **Expected costs JSON valid**: Scope: ExpectedCost, Trigger: Load time, Failure: Fail immediately
+- **Cost tolerance range**: Scope: CostValidationResult, Trigger: Comparison, Failure: Record failure in result
+- **Plugin availability**: Scope: TestMain, Trigger: Before tests, Failure: Skip/Fail entire suite
+- **Execution timeout**: Scope: Per-region test, Trigger: Timer, Failure: Fail test with timeout error
+- **Network retry exhausted**: Scope: Plugin communication, Trigger: After 3 retries, Failure: Fail test with network error
+
+## Error Handling
+
+### Missing Pricing Data
+- **Detection**: Plugin returns empty cost result
+- **Action**: Fail test immediately with message: "No pricing data available for {region}/{resource_type}"
+- **Rationale**: E2E tests require complete data (clarification Q4)
+
+### Network Failure
+- **Detection**: Plugin gRPC call fails with network error
+- **Action**: Retry 3 times with exponential backoff (100ms, 200ms, 400ms)
+- **Final Action**: Fail test with message: "Network failure after 3 retries: {error}"
+- **Rationale**: Distinguish transient from persistent issues (clarification Q5)
+
+### Invalid Region Configuration
+- **Detection**: Region not in allowed list
+- **Action**: Fail test in setup with message: "Invalid region: {region} (expected one of: us-east-1, eu-west-1, ap-northeast-1)"
+- **Rationale**: Fail fast on configuration errors (edge case resolution)
+
+## Concurrency Considerations
+
+- Region tests can run in parallel (`t.Parallel()`)
+- Projected and actual cost tests can run concurrently
+- Shared fixtures are read-only (safe for parallel access)
+- Plugin communication is stateless (safe for concurrent calls)
+
+---
+
+## User Story 4: Unified Multi-Region Fixtures
+
+**Added**: 2026-01-22
+
+### 6. UnifiedExpectedCosts
+
+Defines expected cost structure for a unified multi-region fixture.
+
+**Fields**:
+
+- `FixtureType` (`string`): Fixture classification. Must be "unified"
+- `TotalRegions` (`int`): Number of regions in fixture. Must be > 0 and ≤ 10
+- `Resources` (`[]ExpectedCost`): Per-resource expected costs. Non-empty
+- `AggregateValidation` (`AggregateExpectation`): Total cost expectations. Required
+
+**Relationships**:
+
+- One-to-many with `ExpectedCost` (contains expectations for all regions)
+- One-to-one with unified Pulumi.yaml fixture
+
+**JSON Schema**:
+```json
+{
+  "type": "object",
+  "required": ["fixture_type", "total_regions", "resources", "aggregate_validation"],
+  "properties": {
+    "fixture_type": {
+      "type": "string",
+      "const": "unified"
+    },
+    "total_regions": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 10
+    },
+    "resources": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/ExpectedCost" }
+    },
+    "aggregate_validation": {
+      "$ref": "#/definitions/AggregateExpectation"
+    }
+  }
+}
+```
+
+---
+
+### 7. AggregateExpectation
+
+Defines aggregate cost validation for unified fixtures.
+
+**Fields**:
+
+- `TotalMinCost` (`float64`): Minimum acceptable total cost (USD). Must be ≥ 0
+- `TotalMaxCost` (`float64`): Maximum acceptable total cost (USD). Must be > TotalMinCost
+- `Tolerance` (`float64`): Cost variance tolerance. Must be > 0 and ≤ 1.0
+
+**Validation Rules**:
+```go
+func (a *AggregateExpectation) Validate() error {
+    if a.TotalMinCost < 0 {
+        return fmt.Errorf("total min cost must be non-negative, got: %f", a.TotalMinCost)
+    }
+
+    if a.TotalMaxCost <= a.TotalMinCost {
+        return fmt.Errorf("total max cost (%f) must be greater than total min cost (%f)",
+            a.TotalMaxCost, a.TotalMinCost)
+    }
+
+    if a.Tolerance <= 0 || a.Tolerance > 1.0 {
+        return fmt.Errorf("tolerance must be > 0 and ≤ 1.0, got: %f", a.Tolerance)
+    }
+
+    return nil
+}
+```
+
+---
+
+### 8. UnifiedValidationResult
+
+Captures validation results for a unified multi-region fixture.
+
+**Fields**:
+
+- `PerResourceResults` (`[]CostValidationResult`): Individual resource validations. Non-empty
+- `TotalCost` (`float64`): Actual total cost (USD). Must be ≥ 0
+- `TotalWithinTolerance` (`bool`): Whether total is within aggregate bounds
+- `RegionBreakdown` (`map[string]float64`): Cost per region for analysis
+- `Success` (`bool`): True if all validations passed
+
+**Relationships**:
+
+- One-to-many with `CostValidationResult` (contains per-resource results)
+- One-to-one with `UnifiedExpectedCosts` (validation source)
+
+**Validation Rules**:
+```go
+func (u *UnifiedValidationResult) Validate() error {
+    if len(u.PerResourceResults) == 0 {
+        return fmt.Errorf("per-resource results cannot be empty")
+    }
+
+    // All per-resource validations must pass
+    for _, r := range u.PerResourceResults {
+        if !r.WithinTolerance {
+            u.Success = false
+            return nil
+        }
+    }
+
+    // Aggregate validation must also pass
+    u.Success = u.TotalWithinTolerance
+    return nil
+}
+```
+
+---
+
+### 9. ProviderRegionMapping
+
+Maps provider URNs to regions for unified fixture processing.
+
+**Fields**:
+
+- `ProviderURN` (`string`): Pulumi provider URN. Must match URN format
+- `Region` (`string`): AWS region for provider. Valid AWS region code
+- `ProviderType` (`string`): Provider type identifier. Must be "pulumi:providers:aws"
+
+**Purpose**:
+- Built during plan JSON parsing
+- Used to resolve resource regions from provider references
+- Enables region-agnostic resource definitions with explicit provider assignment
+
+**Example**:
+```go
+providerMap := map[string]string{
+    "urn:pulumi:dev::project::pulumi:providers:aws::aws-us-east-1": "us-east-1",
+    "urn:pulumi:dev::project::pulumi:providers:aws::aws-eu-west-1": "eu-west-1",
+    "urn:pulumi:dev::project::pulumi:providers:aws::aws-ap-northeast-1": "ap-northeast-1",
+}
+```
+
+---
+
+## Unified Fixture Data Flow
+
+```text
+1. Fixture Load:
+   UnifiedExpectedCosts → Parse from expected-costs.json
+
+2. Plan Generation:
+   Pulumi.yaml → pulumi preview --json → plan.json
+
+3. Provider Mapping:
+   plan.json → Extract provider resources → ProviderRegionMapping
+
+4. Cost Calculation:
+   finfocus cost projected → Plugin per region → Cost Results
+
+5. Validation:
+   Cost Results + UnifiedExpectedCosts → UnifiedValidationResult
+
+6. Assertion:
+   UnifiedValidationResult.Success → Test Pass/Fail
+```
+
+## File Formats (Unified Fixtures)
+
+### expected-costs.json (Unified)
+
+```json
+{
+  "fixture_type": "unified",
+  "total_regions": 3,
+  "resources": [
+    {
+      "resource_type": "aws:ec2:Instance",
+      "resource_name": "web-us-east-1",
+      "min_cost": 6.66,
+      "max_cost": 7.36,
+      "region": "us-east-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ec2:Instance",
+      "resource_name": "web-eu-west-1",
+      "min_cost": 7.13,
+      "max_cost": 8.47,
+      "region": "eu-west-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ec2:Instance",
+      "resource_name": "web-ap-northeast-1",
+      "min_cost": 7.33,
+      "max_cost": 8.83,
+      "region": "ap-northeast-1",
+      "cost_type": "projected"
+    }
+  ],
+  "aggregate_validation": {
+    "total_min_cost": 21.12,
+    "total_max_cost": 24.66,
+    "tolerance": 0.05
+  }
+}
+```
+
+### Pulumi.yaml (Unified YAML Runtime)
+
+```yaml
+name: multi-region-test-unified
+runtime: yaml
+description: Unified multi-region E2E test fixture
+
+resources:
+  aws-us-east-1:
+    type: pulumi:providers:aws
+    properties:
+      region: us-east-1
+
+  aws-eu-west-1:
+    type: pulumi:providers:aws
+    properties:
+      region: eu-west-1
+
+  aws-ap-northeast-1:
+    type: pulumi:providers:aws
+    properties:
+      region: ap-northeast-1
+
+  web-us-east-1:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-0123456789abcdef0
+      instanceType: t3.micro
+    options:
+      provider: ${aws-us-east-1}
+
+  web-eu-west-1:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-0abcdef123456789a
+      instanceType: t3.micro
+    options:
+      provider: ${aws-eu-west-1}
+
+  web-ap-northeast-1:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-0fedcba987654321f
+      instanceType: t3.micro
+    options:
+      provider: ${aws-ap-northeast-1}
+
+outputs:
+  regions:
+    - us-east-1
+    - eu-west-1
+    - ap-northeast-1
+```

--- a/specs/001-multi-region-e2e/plan.md
+++ b/specs/001-multi-region-e2e/plan.md
@@ -1,0 +1,343 @@
+# Implementation Plan: Multi-Region E2E Testing
+
+**Branch**: `001-multi-region-e2e` | **Date**: 2026-01-22 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-multi-region-e2e/spec.md`
+
+## Summary
+
+Implement multi-region E2E testing infrastructure to validate both projected and actual cost calculations across AWS regions (us-east-1, eu-west-1, ap-northeast-1) with ±5% variance tolerance. This includes User Stories 1-3 (per-region fixtures) and User Story 4 (unified multi-region fixture using YAML runtime).
+
+## Technical Context
+
+**Language/Version**: Go 1.25.5
+**Primary Dependencies**: testify v1.11.1, Pulumi Automation API v3.210.0+, existing E2E test framework (`test/e2e/`)
+**Storage**: Local filesystem (Pulumi state files, test fixtures in `test/e2e/fixtures/`)
+**Testing**: `go test` with `-tags e2e` build constraint, testify assertions
+**Target Platform**: Linux, macOS, Windows (CI matrix)
+**Project Type**: Single project (Go CLI with test infrastructure)
+**Performance Goals**: <5 minutes per region test execution
+**Constraints**: ±5% cost variance tolerance, 80% minimum test coverage
+**Scale/Scope**: 8 resources per region × 3 regions = 24 resources validated, plus unified fixture
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Verify compliance with PulumiCost Core Constitution (`.specify/memory/constitution.md`):
+
+- [x] **Plugin-First Architecture**: This is test infrastructure that validates plugin behavior - not implementing new plugins
+- [x] **Test-Driven Development**: Tests are the feature itself - E2E validation of cost calculations
+- [x] **Cross-Platform Compatibility**: E2E tests use Go standard testing which is cross-platform
+- [x] **Documentation Synchronization**: quickstart.md and docs/testing/multi-region-e2e.md planned
+- [x] **Protocol Stability**: No protocol changes - uses existing gRPC plugin communication
+- [x] **Implementation Completeness**: All fixtures and test functions will be complete implementations
+- [x] **Quality Gates**: Tests must pass `make lint` and `make test-e2e`
+- [x] **Multi-Repo Coordination**: Tests validate plugins from finfocus-plugin repo; no cross-repo code changes
+
+**Violations Requiring Justification**: None
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-multi-region-e2e/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (complete)
+├── data-model.md        # Phase 1 output (complete)
+├── quickstart.md        # Phase 1 output (complete)
+├── checklists/          # Validation checklists
+│   └── requirements.md
+└── tasks.md             # Phase 2 output (complete with US4)
+```
+
+### Source Code (repository root)
+
+```text
+test/e2e/
+├── fixtures/multi-region/
+│   ├── us-east-1/           # US East baseline region fixture (YAML runtime)
+│   │   ├── Pulumi.yaml      # 8 resources: 2 EC2, 2 EBS, 2 Network, 2 RDS
+│   │   └── expected-costs.json
+│   ├── eu-west-1/           # EU West region fixture (YAML runtime)
+│   │   ├── Pulumi.yaml      # 8 resources with EU pricing
+│   │   └── expected-costs.json
+│   ├── ap-northeast-1/      # Asia Pacific region fixture (YAML runtime)
+│   │   ├── Pulumi.yaml      # 8 resources with APAC pricing
+│   │   └── expected-costs.json
+│   └── unified/             # User Story 4 - Unified multi-region fixture
+│       ├── Pulumi.yaml      # YAML runtime with explicit provider aliases
+│       └── expected-costs.json
+├── config.go                # Test configuration with region support
+├── validator.go             # Cost validation with tolerance checking
+├── multi_region_helpers.go  # Shared utilities for multi-region tests
+├── multi_region_projected_test.go  # Projected cost tests
+├── multi_region_actual_test.go     # Actual cost tests
+└── multi_region_fallback_test.go   # Fallback behavior tests
+
+docs/testing/
+└── multi-region-e2e.md      # Documentation for multi-region E2E testing
+```
+
+**Structure Decision**: All fixtures use Pulumi YAML runtime for simplicity - no Go code required. Extends existing `test/e2e/` infrastructure with multi-region fixtures and new test files following established patterns.
+
+## User Story 4: Unified Multi-Region Fixture
+
+### Background
+
+User Stories 1-3 test **separate Pulumi programs per region**. User Story 4 tests a **single Pulumi program that deploys resources across multiple regions** - a common real-world pattern.
+
+### Key Differences from Per-Region Fixtures
+
+- **Structure**: Per-region has 3 separate `Pulumi.yaml` files, Unified has 1 `Pulumi.yaml` with all regions
+- **Providers**: Per-region uses single implicit AWS provider per fixture, Unified uses explicit provider aliases per region
+- **Plan JSON**: Per-region has single region per plan, Unified has multi-region with provider references
+- **Cost Attribution**: Per-region by fixture directory, Unified by provider → resource mapping
+- **Validation**: Per-region validates per-region totals, Unified validates per-resource + aggregate total
+
+### Technical Approach
+
+**YAML Runtime for All Fixtures**: All multi-region fixtures (per-region and unified) use Pulumi YAML runtime because:
+
+- No Go code required - simpler to maintain and less build complexity
+- Provider configuration declared inline in YAML
+- Explicit region configuration per resource via `options.provider` (unified) or stack config (per-region)
+- Validates FinFocus region autodetection from plan JSON
+- Consistent approach across all user stories
+
+**Plugin Discovery Question** (T028):
+The `aws-public` plugin must either:
+
+1. **Option A**: Single instance handles all regions (autodetects from plan JSON)
+2. **Option B**: Separate instances per region (explicit config required)
+
+Task T035 will determine which approach works via discovery testing.
+
+### Unified Fixture Design
+
+```yaml
+# test/e2e/fixtures/multi-region/unified/Pulumi.yaml
+name: multi-region-test-unified
+runtime: yaml
+description: Unified multi-region E2E test fixture
+
+resources:
+  # Provider per region
+  aws-us-east-1:
+    type: pulumi:providers:aws
+    properties:
+      region: us-east-1
+
+  aws-eu-west-1:
+    type: pulumi:providers:aws
+    properties:
+      region: eu-west-1
+
+  aws-ap-northeast-1:
+    type: pulumi:providers:aws
+    properties:
+      region: ap-northeast-1
+
+  # Resources with explicit provider
+  web-us-east-1:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-0123456789abcdef0
+      instanceType: t3.micro
+    options:
+      provider: ${aws-us-east-1}
+
+  web-eu-west-1:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-0abcdef123456789a
+      instanceType: t3.micro
+    options:
+      provider: ${aws-eu-west-1}
+
+  web-ap-northeast-1:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-0fedcba987654321f
+      instanceType: t3.micro
+    options:
+      provider: ${aws-ap-northeast-1}
+
+outputs:
+  regions:
+    - us-east-1
+    - eu-west-1
+    - ap-northeast-1
+```
+
+### Expected Costs Structure (Unified)
+
+```json
+{
+  "fixture_type": "unified",
+  "total_regions": 3,
+  "resources": [
+    {
+      "resource_name": "web-us-east-1",
+      "resource_type": "aws:ec2:Instance",
+      "region": "us-east-1",
+      "min_cost": 6.66,
+      "max_cost": 7.36,
+      "cost_type": "projected"
+    },
+    {
+      "resource_name": "web-eu-west-1",
+      "resource_type": "aws:ec2:Instance",
+      "region": "eu-west-1",
+      "min_cost": 7.13,
+      "max_cost": 8.47,
+      "cost_type": "projected"
+    },
+    {
+      "resource_name": "web-ap-northeast-1",
+      "resource_type": "aws:ec2:Instance",
+      "region": "ap-northeast-1",
+      "min_cost": 7.33,
+      "max_cost": 8.83,
+      "cost_type": "projected"
+    }
+  ],
+  "aggregate_validation": {
+    "total_min_cost": 21.12,
+    "total_max_cost": 24.66,
+    "tolerance": 0.05
+  }
+}
+```
+
+### Validation Logic for Unified Fixtures
+
+```go
+// ValidateUnifiedFixtureCosts validates costs for a unified multi-region fixture
+func ValidateUnifiedFixtureCosts(results []CostResult, expected UnifiedExpectedCosts) (*UnifiedValidationResult, error) {
+    result := &UnifiedValidationResult{
+        PerResourceResults: make([]CostValidationResult, 0, len(expected.Resources)),
+    }
+
+    // Validate each resource
+    for _, exp := range expected.Resources {
+        actual := findResultByName(results, exp.ResourceName)
+        if actual == nil {
+            return nil, fmt.Errorf("missing cost result for resource %s", exp.ResourceName)
+        }
+
+        validation := CostValidationResult{
+            ResourceName:    exp.ResourceName,
+            ResourceType:    exp.ResourceType,
+            Region:          exp.Region,
+            ActualCost:      actual.MonthlyCost,
+            ExpectedMin:     exp.MinCost,
+            ExpectedMax:     exp.MaxCost,
+            WithinTolerance: actual.MonthlyCost >= exp.MinCost && actual.MonthlyCost <= exp.MaxCost,
+        }
+        result.PerResourceResults = append(result.PerResourceResults, validation)
+    }
+
+    // Validate aggregate total
+    totalCost := sumCosts(results)
+    result.TotalCost = totalCost
+    result.TotalWithinTolerance = totalCost >= expected.AggregateValidation.TotalMinCost &&
+        totalCost <= expected.AggregateValidation.TotalMaxCost
+
+    return result, nil
+}
+```
+
+## Complexity Tracking
+
+> No constitution violations - no entries required.
+
+## Phase Implementation Summary
+
+### Completed Phases (US1-3)
+
+- **Phase 1: Setup** - Multi-region fixture directories created
+- **Phase 2: Foundational** - Config, validation, retry logic implemented
+- **Phase 3: User Story 1** - Per-region projected/actual cost tests
+- **Phase 4: User Story 2** - Plugin loading verification
+- **Phase 5: User Story 3** - Fallback behavior tests
+- **Phase 6: Polish** - Documentation, performance validation
+
+### Phase 7: User Story 4 (NEW)
+
+- **T028**: Discovery - Plugin behavior with multi-region plans (Pending)
+- **T029**: Create unified fixture directory structure (Pending)
+- **T030**: Create unified Pulumi.yaml with YAML runtime (Pending)
+- **T031**: Generate expected-costs.json for unified fixture (Pending)
+- **T032**: Add UnifiedExpectedCosts structs (Pending)
+- **T033**: Implement ValidateUnifiedFixtureCosts (Pending)
+- **T034**: Create TestMultiRegion_Unified_Projected test (Pending)
+- **T035**: Update docs/testing/multi-region-e2e.md (Pending)
+
+## Open Questions
+
+### Q1: Plugin Configuration for Unified Fixtures
+
+**Status**: To be resolved by T028 (Discovery task)
+
+**Question**: Does `aws-public` plugin automatically detect regions from plan JSON, or require explicit per-region configuration?
+
+**Options**:
+
+- **A**: Single `aws-public` declaration, autodetection from provider resources in plan
+- **B**: Explicit `aws-public-us-east-1`, `aws-public-eu-west-1`, etc. declarations
+
+**Resolution approach**: Run unified fixture through `finfocus cost projected` and observe plugin spawning behavior.
+
+**Decision Tree** (T028 outcomes):
+
+```text
+T028 Discovery Test
+        │
+        ▼
+┌───────────────────────────────────────┐
+│ Run: pulumi preview --json            │
+│ Run: finfocus cost projected --debug  │
+└───────────────────────────────────────┘
+        │
+        ▼
+    Observe plugin spawning
+        │
+        ├─── Single aws-public process, all regions priced correctly
+        │         │
+        │         ▼
+        │    ✅ Option A: Proceed with single plugin declaration
+        │       - No config changes needed
+        │       - Document autodetection behavior
+        │
+        ├─── Multiple plugin processes spawned per region
+        │         │
+        │         ▼
+        │    ✅ Option B: Use explicit per-region plugin declarations
+        │       - Update finfocus.yaml with aws-public-{region} entries
+        │       - Document required configuration
+        │
+        └─── Errors or incorrect region pricing
+                  │
+                  ▼
+             ⚠️ Escalate: Ingestion layer needs enhancement
+                - File issue for internal/ingest/pulumi_plan.go
+                - Update spec.md with new requirement
+                - Block US4 until ingestion fixed
+```
+
+### Q2: Region Extraction from Provider Resources
+
+**Status**: Research needed during T028
+
+**Question**: How does FinFocus extract region from provider configuration in plan JSON?
+
+**Current understanding**: Plan JSON includes provider configuration in step structure; ingestion should extract `aws:region` property from provider resources.
+
+## References
+
+- [Spec](./spec.md) - Full feature specification with User Stories 1-4
+- [Tasks](./tasks.md) - Implementation task list with Phase 7 for US4
+- [Research](./research.md) - Research findings for US1-3
+- [Data Model](./data-model.md) - Entity definitions and validation rules
+- [Quickstart](./quickstart.md) - Developer guide for running tests

--- a/specs/001-multi-region-e2e/quickstart.md
+++ b/specs/001-multi-region-e2e/quickstart.md
@@ -1,0 +1,431 @@
+# Quickstart: Multi-Region E2E Testing
+
+**Audience**: Developers implementing or running multi-region E2E tests
+**Time to Complete**: 15-20 minutes
+**Prerequisites**: Go 1.25.5, FinFocus built locally, AWS credentials configured
+
+## Overview
+
+This guide walks through running multi-region E2E tests to validate cost calculations across different AWS regions (us-east-1, eu-west-1, ap-northeast-1). Tests cover both projected and actual costs with ±5% variance tolerance.
+
+## Quick Start
+
+### 1. Build FinFocus Binary
+
+```bash
+cd /path/to/finfocus
+make build
+```
+
+**Expected Output**:
+```text
+go build -o bin/finfocus ./cmd/finfocus
+Build complete: bin/finfocus
+```
+
+**Verification**:
+```bash
+./bin/finfocus --version
+# Should output: finfocus version 0.2.x
+```
+
+---
+
+### 2. Run Multi-Region E2E Tests (Default: us-east-1 only)
+
+```bash
+# Run all multi-region tests
+make test-e2e
+
+# Or run specific multi-region test file
+go test -v -tags e2e ./test/e2e -run TestMultiRegion
+```
+
+**Expected Output**:
+```text
+=== RUN   TestMultiRegion_Projected_USEast1
+--- PASS: TestMultiRegion_Projected_USEast1 (45.2s)
+=== RUN   TestMultiRegion_Actual_USEast1
+--- PASS: TestMultiRegion_Actual_USEast1 (120.5s)
+PASS
+ok      github.com/rshade/finfocus/test/e2e     165.734s
+```
+
+---
+
+### 3. Run Tests for All Regions
+
+```bash
+# Set environment variable to test all three regions
+export FINFOCUS_E2E_REGIONS="us-east-1,eu-west-1,ap-northeast-1"
+go test -v -tags e2e ./test/e2e -run TestMultiRegion
+```
+
+**Expected Duration**: ~15 minutes total (<5 minutes per region)
+
+**Expected Output**:
+```text
+=== RUN   TestMultiRegion_Projected_USEast1
+--- PASS: TestMultiRegion_Projected_USEast1 (42.1s)
+=== RUN   TestMultiRegion_Projected_EUWest1
+--- PASS: TestMultiRegion_Projected_EUWest1 (48.3s)
+=== RUN   TestMultiRegion_Projected_APNortheast1
+--- PASS: TestMultiRegion_Projected_APNortheast1 (51.7s)
+=== RUN   TestMultiRegion_Actual_USEast1
+--- PASS: TestMultiRegion_Actual_USEast1 (118.4s)
+=== RUN   TestMultiRegion_Actual_EUWest1
+--- PASS: TestMultiRegion_Actual_EUWest1 (125.9s)
+=== RUN   TestMultiRegion_Actual_APNortheast1
+--- PASS: TestMultiRegion_Actual_APNortheast1 (132.1s)
+PASS
+ok      github.com/rshade/finfocus/test/e2e     518.503s
+```
+
+---
+
+### 4. Run Only Projected Cost Tests (Skip Actual Costs)
+
+Useful when developing before issue #177 (Pulumi Automation API) is complete.
+
+```bash
+export FINFOCUS_E2E_SKIP_ACTUAL_COSTS=true
+go test -v -tags e2e ./test/e2e -run TestMultiRegion_Projected
+```
+
+**Expected Duration**: ~2-3 minutes per region
+
+---
+
+### 5. Customize Cost Tolerance
+
+```bash
+# Use ±10% tolerance instead of default ±5%
+export FINFOCUS_E2E_TOLERANCE=0.10
+go test -v -tags e2e ./test/e2e -run TestMultiRegion
+```
+
+---
+
+## Configuration Options
+
+### Environment Variables
+
+- `FINFOCUS_E2E_REGIONS` (default: `us-east-1`): Comma-separated list of regions to test
+- `FINFOCUS_E2E_TOLERANCE` (default: `0.05`): Cost variance tolerance (±5%)
+- `FINFOCUS_E2E_TIMEOUT` (default: `10m`): Maximum test execution time per region
+- `FINFOCUS_E2E_SKIP_ACTUAL_COSTS` (default: `false`): Skip actual cost tests (pre-#177 development)
+- `AWS_PROFILE` (default: none): AWS credentials profile to use
+- `AWS_REGION` (default: none): AWS region for credentials (overridden by test configs)
+
+### Example: Full Configuration
+
+```bash
+export FINFOCUS_E2E_REGIONS="us-east-1,eu-west-1,ap-northeast-1"
+export FINFOCUS_E2E_TOLERANCE=0.05
+export FINFOCUS_E2E_TIMEOUT=5m
+export FINFOCUS_E2E_SKIP_ACTUAL_COSTS=false
+export AWS_PROFILE=finfocus-testing
+
+go test -v -tags e2e ./test/e2e -run TestMultiRegion -timeout 20m
+```
+
+---
+
+## Test Fixtures
+
+Multi-region test fixtures are located in `test/e2e/fixtures/multi-region/`. All fixtures use Pulumi YAML runtime (no Go code required):
+
+```text
+test/e2e/fixtures/multi-region/
+├── us-east-1/
+│   ├── Pulumi.yaml          # YAML runtime with 8 resources (2 EC2, 2 EBS, 2 Network, 2 RDS)
+│   └── expected-costs.json  # Expected cost ranges (±5% built in)
+├── eu-west-1/
+│   ├── Pulumi.yaml          # YAML runtime with 8 resources and EU pricing
+│   └── expected-costs.json
+├── ap-northeast-1/
+│   ├── Pulumi.yaml          # YAML runtime with 8 resources and APAC pricing
+│   └── expected-costs.json
+└── unified/
+    ├── Pulumi.yaml          # YAML runtime with explicit provider aliases for all regions
+    └── expected-costs.json  # Per-resource + aggregate cost expectations
+```
+
+### Resource Types in Fixtures
+
+Each region fixture includes:
+- **2x EC2 Instances** (t3.micro, t3.small) - Compute
+- **2x EBS Volumes** (gp3 100GB, io2 50GB) - Storage
+- **2x Network Resources** (NAT Gateway, VPC Endpoint) - Network
+- **2x RDS Instances** (db.t3.micro PostgreSQL, MySQL) - Database
+
+**Total**: 8 resources per region × 3 regions = 24 resources validated
+
+---
+
+## Troubleshooting
+
+### Test Fails: "No pricing data available"
+
+**Symptom**:
+```text
+FAIL: No pricing data available for eu-west-1/aws:ec2:Instance
+```
+
+**Cause**: Plugin does not have pricing data for the region
+
+**Solution**:
+1. Verify plugin version supports multi-region: `./bin/finfocus plugin list`
+2. Check if region-specific plugin is installed: `ls ~/.finfocus/plugins/aws-public/*/`
+3. If missing, install: `./bin/finfocus plugin install aws-public --version <version>`
+
+---
+
+### Test Fails: "Network failure after 3 retries"
+
+**Symptom**:
+```text
+FAIL: Network failure after 3 retries: connection refused
+```
+
+**Cause**: Plugin gRPC communication failed (transient network issue)
+
+**Solution**:
+1. Check plugin process is running: `ps aux | grep finfocus-plugin`
+2. Verify no firewall blocking localhost communication
+3. Retry test (should succeed if transient)
+4. If persistent, check plugin logs in `~/.finfocus/logs/`
+
+---
+
+### Test Fails: Cost Variance Exceeds Tolerance
+
+**Symptom**:
+```text
+FAIL: Resource web-server cost $58.50 outside expected range [$50.00, $55.00] (±5%)
+```
+
+**Cause**: AWS pricing has changed, or resource configuration differs from expected
+
+**Solution**:
+1. **Verify Pricing Change**: Check AWS pricing page for the resource type in that region
+2. **Update Expected Costs**: Edit `test/e2e/fixtures/multi-region/<region>/expected-costs.json`
+3. **Adjust Tolerance** (temporary): `export FINFOCUS_E2E_TOLERANCE=0.10` for ±10%
+4. **Review Fixture**: Ensure Pulumi program matches expected resource specs
+
+---
+
+### Test Timeout: "test timed out after 10m"
+
+**Symptom**:
+```text
+panic: test timed out after 10m0s
+```
+
+**Cause**: Test execution exceeded timeout (likely actual cost tests with resource deployment)
+
+**Solution**:
+1. **Increase Timeout**: `export FINFOCUS_E2E_TIMEOUT=15m`
+2. **Run Test with `-timeout` Flag**: `go test -timeout 20m -tags e2e ./test/e2e -run TestMultiRegion`
+3. **Skip Slow Tests**: `export FINFOCUS_E2E_SKIP_ACTUAL_COSTS=true` to test only projected costs
+
+---
+
+### Missing Dependency: Issue #177 or #24
+
+**Symptom**:
+```text
+FAIL: Pulumi Automation API support required (issue #177)
+```
+
+**Cause**: Test depends on incomplete feature
+
+**Solution**:
+1. **Check Issue Status**: `gh issue view 177` and `gh issue view 24`
+2. **Skip Actual Cost Tests**: `export FINFOCUS_E2E_SKIP_ACTUAL_COSTS=true`
+3. **Wait for Dependency**: Tests will automatically enable once dependencies merge
+
+---
+
+## Validating Changes
+
+### Before Committing
+
+```bash
+# Run full test suite including multi-region
+make test-e2e
+
+# Check lint compliance
+make lint
+
+# Verify cross-region pricing differences
+go test -v -tags e2e ./test/e2e -run TestMultiRegion_Projected | grep "Pricing difference detected"
+```
+
+### Expected Pricing Differences
+
+Tests validate that costs vary across regions:
+
+- **t3.micro EC2**: us-east-1: $7.01/month (baseline), eu-west-1: ~$7.50 (+7%), ap-northeast-1: ~$8.00 (+14%)
+- **gp3 100GB EBS**: us-east-1: $8.00/month (baseline), eu-west-1: ~$9.60 (+20%), ap-northeast-1: ~$8.80 (+10%)
+- **NAT Gateway**: us-east-1: $32.85/month (baseline), eu-west-1: ~$36.14 (+10%), ap-northeast-1: ~$39.42 (+20%)
+
+*Note: Actual values may vary; tests use ±5% tolerance to accommodate pricing updates.*
+
+---
+
+---
+
+## User Story 4: Unified Multi-Region Fixtures
+
+### Overview
+
+In addition to per-region fixtures (US1-3), User Story 4 tests a **unified Pulumi program** that deploys resources across multiple regions in a single stack - a common real-world pattern.
+
+### Run Unified Multi-Region Test
+
+```bash
+# Run the unified fixture test specifically
+go test -v -tags e2e ./test/e2e -run TestMultiRegion_Unified_Projected
+```
+
+**Expected Output**:
+```text
+=== RUN   TestMultiRegion_Unified_Projected
+    multi_region_projected_test.go:XXX: Testing unified multi-region fixture
+    multi_region_projected_test.go:XXX: Resource web-us-east-1 (us-east-1): $7.01 [PASS]
+    multi_region_projected_test.go:XXX: Resource web-eu-west-1 (eu-west-1): $7.51 [PASS]
+    multi_region_projected_test.go:XXX: Resource web-ap-northeast-1 (ap-northeast-1): $8.01 [PASS]
+    multi_region_projected_test.go:XXX: Aggregate total: $22.53 within [$21.12, $24.66] [PASS]
+--- PASS: TestMultiRegion_Unified_Projected (35.2s)
+```
+
+---
+
+### Unified Fixture Structure
+
+```text
+test/e2e/fixtures/multi-region/unified/
+├── Pulumi.yaml           # YAML runtime with multi-region providers
+└── expected-costs.json   # Per-resource + aggregate cost expectations
+```
+
+### Key Differences from Per-Region Fixtures
+
+- **Structure**: Per-region has 3 separate `Pulumi.yaml` files (one per region), Unified has 1 `Pulumi.yaml` with all regions
+- **Providers**: Per-region uses single implicit AWS provider per fixture, Unified uses explicit provider aliases per region
+- **Validation**: Per-region validates per-region totals only, Unified validates per-resource costs + aggregate total
+
+---
+
+### Unified Fixture Example
+
+**Pulumi.yaml**:
+```yaml
+name: multi-region-test-unified
+runtime: yaml
+
+resources:
+  # Explicit provider per region
+  aws-us-east-1:
+    type: pulumi:providers:aws
+    properties:
+      region: us-east-1
+
+  aws-eu-west-1:
+    type: pulumi:providers:aws
+    properties:
+      region: eu-west-1
+
+  # Resources reference specific providers
+  web-us-east-1:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-0123456789abcdef0
+      instanceType: t3.micro
+    options:
+      provider: ${aws-us-east-1}
+
+  web-eu-west-1:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-0abcdef123456789a
+      instanceType: t3.micro
+    options:
+      provider: ${aws-eu-west-1}
+```
+
+---
+
+### Unified Expected Costs Format
+
+```json
+{
+  "fixture_type": "unified",
+  "total_regions": 3,
+  "resources": [
+    {
+      "resource_name": "web-us-east-1",
+      "resource_type": "aws:ec2:Instance",
+      "region": "us-east-1",
+      "min_cost": 6.66,
+      "max_cost": 7.36,
+      "cost_type": "projected"
+    }
+  ],
+  "aggregate_validation": {
+    "total_min_cost": 21.12,
+    "total_max_cost": 24.66,
+    "tolerance": 0.05
+  }
+}
+```
+
+---
+
+### Troubleshooting Unified Fixtures
+
+#### "Region not detected for resource"
+
+**Symptom**:
+```text
+WARN: Region not detected for resource web-us-east-1, using default
+```
+
+**Cause**: FinFocus could not resolve region from provider configuration
+
+**Solution**:
+1. Ensure provider is explicitly declared with `region` property
+2. Verify resource uses `options.provider` to reference the provider
+3. Check plan JSON contains provider URN with region
+
+#### Aggregate Total Outside Tolerance
+
+**Symptom**:
+```text
+FAIL: Aggregate total $25.50 outside expected range [$21.12, $24.66]
+```
+
+**Cause**: Individual resource costs are within tolerance but sum exceeds aggregate bounds
+
+**Solution**:
+1. Recalculate `aggregate_validation` based on sum of individual ranges
+2. Consider that tolerance compounds: 3 resources at +5% each = ~+15% total
+3. Update `expected-costs.json` with wider aggregate tolerance if needed
+
+---
+
+## Next Steps
+
+1. **Add New Regions**: Create new fixture in `test/e2e/fixtures/multi-region/<region>/`
+2. **Customize Resources**: Edit `Pulumi.yaml` in fixture to test different resource types
+3. **Update Expected Costs**: Adjust `expected-costs.json` when AWS pricing changes
+4. **Run in CI**: Multi-region tests run automatically via `make test-e2e` in CI pipeline
+5. **Create Unified Fixtures**: Add `unified/` subfolder with YAML runtime for cross-region tests
+
+## Related Documentation
+
+- [E2E Test Plan](../../E2E_TEST_PLAN.md) - Section 4.2 Multi-region testing
+- [Feature Spec](./spec.md) - Full feature specification with User Stories 1-4
+- [Implementation Plan](./plan.md) - Technical design details
+- [CLAUDE.md](../../CLAUDE.md) - Testing section

--- a/specs/001-multi-region-e2e/research.md
+++ b/specs/001-multi-region-e2e/research.md
@@ -1,0 +1,413 @@
+# Research: Multi-Region E2E Testing
+
+**Date**: 2026-01-21
+**Phase**: 0 (Outline & Research)
+**Status**: Complete
+
+## Overview
+
+This document consolidates research findings for implementing multi-region E2E testing support in FinFocus. The research addresses test fixture design, cost validation strategies, failure handling patterns, and integration with existing E2E infrastructure.
+
+## Research Tasks Completed
+
+### 1. Multi-Region Test Fixture Design
+
+**Decision**: Parameterized Pulumi programs with region-specific configuration
+
+**Rationale**:
+- Existing E2E test infrastructure (`test/e2e/`) uses Pulumi JSON plans and Pulumi Automation API
+- Parameterized fixtures allow code reuse across regions while varying resource configurations
+- Each region fixture includes explicit expected cost values for validation
+- Structure follows established pattern in `test/e2e/fixtures/ec2/`
+
+**Alternatives Considered**:
+- **Static JSON plans only**: Rejected because actual cost testing requires deployed resources via Pulumi Automation API
+- **Single fixture with region parameter**: Rejected because different regions may need different resource configurations to demonstrate pricing differences
+- **Hardcoded resource definitions per region**: Rejected because it reduces maintainability and increases duplication
+
+**Implementation Approach**:
+
+```text
+fixtures/multi-region/<region>/
+  ├── Pulumi.yaml          # YAML runtime with 5-10 resources across 3-4 types
+  └── expected-costs.json  # Expected cost ranges per resource (±5% tolerance)
+```
+
+### 2. Cost Variance Validation Strategy
+
+**Decision**: Tolerance-based validation with explicit expected cost ranges
+
+**Rationale**:
+- ±5% variance tolerance (from clarifications) handles minor pricing fluctuations
+- Expected cost values stored in `expected-costs.json` per region
+- Validation logic extends existing `validator.go` with multi-region support
+- Prevents test brittleness from cloud provider pricing updates
+
+**Alternatives Considered**:
+- **Exact cost matching**: Rejected due to pricing volatility and test brittleness
+- **Percentage-only validation**: Rejected because it doesn't validate absolute cost correctness
+- **No baseline expectations**: Rejected because it wouldn't catch regional pricing errors
+
+**Implementation Pattern**:
+```go
+type ExpectedCost struct {
+    ResourceType string  `json:"resource_type"`
+    MinCost      float64 `json:"min_cost"`
+    MaxCost      float64 `json:"max_cost"`
+    Region       string  `json:"region"`
+}
+
+func ValidateWithinTolerance(actual, expected, tolerance float64) bool {
+    lower := expected * (1 - tolerance)
+    upper := expected * (1 + tolerance)
+    return actual >= lower && actual <= upper
+}
+```
+
+### 3. Failure Handling Patterns for E2E Tests
+
+**Decision**: Strict failure semantics with retry logic for transient errors
+
+**Rationale**:
+- E2E tests validate production readiness - failures must be explicit (from clarification)
+- Missing pricing data → immediate test failure (no graceful degradation)
+- Network failures → retry 3x with exponential backoff, then fail
+- Distinguishes transient (recoverable) from persistent (fatal) failures
+
+**Alternatives Considered**:
+- **Graceful degradation**: Rejected per clarification - E2E tests must fail fast
+- **Skip on errors**: Rejected because it masks real issues
+- **No retry logic**: Rejected because it increases false negatives from transient issues
+
+**Implementation Pattern**:
+```go
+func RetryWithBackoff(ctx context.Context, attempts int, operation func() error) error {
+    var err error
+    for i := 0; i < attempts; i++ {
+        err = operation()
+        if err == nil {
+            return nil
+        }
+        if !isTransientError(err) {
+            return fmt.Errorf("non-transient error: %w", err)
+        }
+        backoff := time.Duration(math.Pow(2, float64(i))) * 100 * time.Millisecond
+        time.Sleep(backoff)
+    }
+    return fmt.Errorf("failed after %d attempts: %w", attempts, err)
+}
+```
+
+### 4. Integration with Existing E2E Infrastructure
+
+**Decision**: Extend existing `test/e2e/` patterns with minimal refactoring
+
+**Rationale**:
+- `config.go` already supports `AWSRegion` parameter
+- `validator.go` provides cost validation primitives
+- `pricing.go` has pricing data validation helpers
+- New test files follow established naming: `multi_region_*_test.go`
+
+**Alternatives Considered**:
+- **New test package**: Rejected because it fragments E2E infrastructure
+- **Refactor existing tests**: Rejected as out of scope; focus on additive changes
+- **Separate test runner**: Rejected because `make test-e2e` should run all E2E tests
+
+**Integration Points**:
+- Reuse `Config` struct with region parameterization
+- Extend `validator.go` with `ValidateMultiRegionCosts()` function
+- Add `multi_region_helpers.go` for region-specific utilities
+- New test files use `//go:build e2e` tag like existing tests
+
+### 5. Resource Type Selection for Test Fixtures
+
+**Decision**: EC2 (compute), EBS (storage), VPC/NAT Gateway (network), RDS (database)
+
+**Rationale**:
+- Covers 4 resource types as specified (compute, storage, network, database)
+- All have well-documented regional pricing differences
+- Supported by finfocus-plugin-aws-public
+- 5-10 instances total keeps execution under 5-minute target
+
+**Alternatives Considered**:
+- **Lambda, S3, CloudFront**: Rejected because some have complex pricing models that complicate variance validation
+- **10+ resource types**: Rejected due to execution time and maintenance overhead
+- **Fewer types**: Rejected because it wouldn't adequately test pricing variations
+
+**Resource Distribution per Region**:
+- 2x EC2 instances (different instance types)
+- 2x EBS volumes (gp3, io2)
+- 2x Network resources (NAT Gateway, VPC Endpoint)
+- 2x RDS instances (different engine types)
+- Total: 8 resources per region × 3 regions = 24 total test resources
+
+### 6. Dependency Coordination Strategy
+
+**Decision**: Documented prerequisites with blocking checks in test setup
+
+**Rationale**:
+- #177 (Pulumi Automation API) must complete before actual cost tests can run
+- #24 (GetActualCost fallback) required for multi-region actual cost validation
+- Test setup checks for plugin availability before execution
+
+**Alternatives Considered**:
+- **Skip tests if dependencies missing**: Rejected because it masks incomplete implementation
+- **Mock dependencies**: Rejected because E2E tests must use real implementations
+- **Parallel development**: Rejected due to integration risk
+
+**Implementation Pattern**:
+```go
+func TestMain(m *testing.M) {
+    // Check #177 dependency
+    if !checkPulumiAutomationAPISupport() {
+        log.Fatal("Pulumi Automation API support required (issue #177)")
+    }
+
+    // Check #24 dependency
+    if !checkGetActualCostSupport() {
+        log.Fatal("GetActualCost fallback required (issue #24)")
+    }
+
+    os.Exit(m.Run())
+}
+```
+
+## Best Practices Applied
+
+### Go Testing Best Practices
+- Use `testify/require` for setup assertions (fail fast)
+- Use `testify/assert` for validation checks (report all failures)
+- Table-driven tests for multi-region scenarios
+- Parallel test execution where possible (`t.Parallel()`)
+- Clear test naming: `TestMultiRegion_<CostType>_<Scenario>`
+
+### E2E Test Patterns
+- Build tag isolation: `//go:build e2e`
+- External binary execution (test actual CLI behavior)
+- Fixture-based testing (Pulumi programs as fixtures)
+- Environment-based configuration (`FINFOCUS_E2E_*` variables)
+- Cleanup in `defer` statements
+
+### Cost Validation Patterns
+- Tolerance-based comparisons for financial data
+- Explicit expected values per region
+- Currency validation (all costs in USD)
+- Aggregation validation across resources
+
+## Technology Stack Summary
+
+- **Go** (1.25.5): Test implementation language
+- **testify** (v1.11.1): Assertion and require helpers
+- **Pulumi SDK** (v3.210.0+): Automation API for resource deployment
+- **AWS SDK Go v2** (latest): (Indirect) Plugin uses for actual costs
+- **FinFocus CLI** (local build): Binary under test (`bin/finfocus`)
+
+## Open Questions & Resolutions
+
+**Q**: How to handle region-specific plugin binary paths?
+**A**: Plugin host (`internal/pluginhost`) already handles version selection; region-specific plugins are differentversions installed via `plugin install` command.
+
+**Q**: Should tests deploy real AWS resources?
+**A**: Yes for actual cost tests (requires #177); projected cost tests use static JSON plans initially, then migrate to deployed resources post-#177.
+
+**Q**: How to prevent test flakiness from pricing updates?
+**A**: ±5% tolerance handles minor updates; `expected-costs.json` requires manual update for major pricing changes (acceptable for E2E tests).
+
+**Q**: What occurs when region configuration is invalid? (Edge case from spec)
+**A**: Test framework validates region parameter in setup; invalid regions fail immediately with clear error message before resource deployment.
+
+## References
+
+- Existing E2E test infrastructure: `test/e2e/`
+- FinFocus CLAUDE.md: Testing section
+- Pulumi Automation API docs: https://www.pulumi.com/docs/guides/automation-api/
+- AWS regional pricing docs: https://aws.amazon.com/ec2/pricing/on-demand/
+- testify documentation: https://github.com/stretchr/testify
+
+---
+
+## User Story 4: Unified Multi-Region Fixture Research
+
+**Added**: 2026-01-22
+**Status**: In Progress (Discovery phase)
+
+### 7. Unified Multi-Region Fixture Design
+
+**Decision**: Pulumi YAML runtime with explicit provider aliases per region
+
+**Rationale**:
+
+- Real-world Pulumi programs often deploy to multiple regions simultaneously
+- YAML runtime requires no Go code - simpler to maintain than Go fixtures
+- Explicit provider aliases (`options.provider`) clearly map resources to regions
+- Tests FinFocus's ability to detect regions from plan JSON provider configuration
+
+**Alternatives Considered**:
+
+- **Go runtime with multiple providers**: Rejected due to increased complexity; YAML is sufficient for test fixtures
+- **TypeScript/Python runtime**: Rejected because Go/YAML are already used in existing fixtures
+- **Separate stacks per region**: Rejected because that's what US1-3 already test; US4 specifically tests unified deployments
+
+**Implementation Approach**:
+
+```yaml
+# Pulumi.yaml with YAML runtime
+name: multi-region-test-unified
+runtime: yaml
+
+resources:
+  # Explicit provider per region
+  aws-us-east-1:
+    type: pulumi:providers:aws
+    properties:
+      region: us-east-1
+
+  # Resources reference specific providers
+  web-us-east-1:
+    type: aws:ec2:Instance
+    options:
+      provider: ${aws-us-east-1}
+```
+
+### 8. Plugin Behavior with Unified Fixtures
+
+**Status**: NEEDS CLARIFICATION (Task T035)
+
+**Question**: How does `aws-public` plugin handle multi-region plans?
+
+**Options**:
+
+- **Option A**: Single `aws-public` instance with autodetection
+  - Pros: Simpler config, dynamic
+  - Cons: Requires region extraction logic
+- **Option B**: Per-region plugin declarations
+  - Pros: Explicit, predictable
+  - Cons: More config, known regions only
+
+**Discovery Approach**:
+
+1. Create minimal unified YAML fixture with resources in 2+ regions
+2. Run `pulumi preview --json > plan.json`
+3. Execute `finfocus cost projected --pulumi-json plan.json --debug`
+4. Observe:
+   - How many plugin processes spawn?
+   - Are regions correctly extracted from plan JSON?
+   - What errors occur if autodetection fails?
+
+**Expected Findings**:
+
+- `aws-public` likely uses region from resource properties or provider configuration
+- Plan JSON includes provider URN that can be traced to region
+- Ingestion layer (`internal/ingest/pulumi_plan.go`) may need enhancement for provider resolution
+
+### 9. Region Extraction from Plan JSON
+
+**Decision**: Extract region from provider configuration in plan JSON steps
+
+**Rationale**:
+
+- Plan JSON structure includes provider resources with `properties.region`
+- Resources reference providers via `provider` field (URN format)
+- Region can be resolved by: Resource → Provider URN → Provider Properties → Region
+
+**Plan JSON Structure Example**:
+
+```json
+{
+  "steps": [
+    {
+      "op": "create",
+      "urn": "urn:pulumi:dev::project::pulumi:providers:aws::aws-us-east-1",
+      "newState": {
+        "type": "pulumi:providers:aws",
+        "inputs": {
+          "region": "us-east-1"
+        }
+      }
+    },
+    {
+      "op": "create",
+      "urn": "urn:pulumi:dev::project::aws:ec2/instance:Instance::web-us-east-1",
+      "newState": {
+        "type": "aws:ec2/instance:Instance",
+        "provider": "urn:pulumi:dev::project::pulumi:providers:aws::aws-us-east-1",
+        "inputs": {
+          "ami": "ami-xxx",
+          "instanceType": "t3.micro"
+        }
+      }
+    }
+  ]
+}
+```
+
+**Region Resolution Algorithm**:
+
+```go
+func ResolveResourceRegion(step PlanStep, providerMap map[string]string) string {
+    // 1. Check resource inputs for explicit region
+    if region, ok := step.NewState.Inputs["region"].(string); ok {
+        return region
+    }
+
+    // 2. Check resource properties for availabilityZone
+    if az, ok := step.NewState.Inputs["availabilityZone"].(string); ok {
+        return extractRegionFromAZ(az) // us-east-1a -> us-east-1
+    }
+
+    // 3. Resolve from provider
+    if providerURN := step.NewState.Provider; providerURN != "" {
+        if region, ok := providerMap[providerURN]; ok {
+            return region
+        }
+    }
+
+    return "" // Unknown region - plugin will use default
+}
+```
+
+### 10. Cost Aggregation for Unified Fixtures
+
+**Decision**: Per-resource validation + aggregate total validation
+
+**Rationale**:
+
+- Individual resource costs must match regional pricing expectations
+- Aggregate total validates overall accuracy within ±5% tolerance
+- Both levels catch different error classes
+
+**Validation Structure**:
+
+```json
+{
+  "fixture_type": "unified",
+  "resources": [
+    {"resource_name": "web-us-east-1", "region": "us-east-1", "min_cost": 6.66, "max_cost": 7.36},
+    {"resource_name": "web-eu-west-1", "region": "eu-west-1", "min_cost": 7.13, "max_cost": 8.47},
+    {"resource_name": "web-ap-northeast-1", "region": "ap-northeast-1", "min_cost": 7.33, "max_cost": 8.83}
+  ],
+  "aggregate_validation": {
+    "total_min_cost": 21.12,
+    "total_max_cost": 24.66
+  }
+}
+```
+
+**Validation Logic**:
+
+1. For each resource: `actual_cost >= min_cost && actual_cost <= max_cost`
+2. For aggregate: `sum(actual_costs) >= total_min && sum(actual_costs) <= total_max`
+3. Test passes only if both levels pass
+
+### Open Questions for User Story 4
+
+- **Plugin spawning behavior**: Status: Pending T028. Resolution: Discovery testing with decision tree
+- **Region extraction from plan JSON**: Status: Partially understood. Resolution: Verify in ingestion code
+- **YAML runtime AMI handling**: Status: Resolved. Resolution: Use placeholder AMI IDs (e.g., `ami-placeholder-us-east-1`); E2E tests run `pulumi preview` only, not actual deployment, so AMI validity is not required
+
+### Best Practices Applied for User Story 4
+
+- **YAML Runtime Testing**: First use of YAML runtime in test fixtures; validates runtime-agnostic cost calculation
+- **Provider Alias Pattern**: Standard Pulumi pattern for multi-region deployments
+- **Aggregate Validation**: Financial data requires both micro and macro validation levels
+- **Discovery-First**: Task T035 runs before implementation to resolve unknowns

--- a/specs/001-multi-region-e2e/spec.md
+++ b/specs/001-multi-region-e2e/spec.md
@@ -1,0 +1,183 @@
+# Feature Specification: Add multi-region E2E testing support
+
+**Feature Branch**: `001-multi-region-e2e`  
+**Created**: 2026-01-21  
+**Status**: Draft  
+**Input**: User description: "title: Add multi-region E2E testing support
+state: OPEN
+author: rshade
+labels: enhancement, roadmap/current
+comments: 0
+assignees:
+projects:
+milestone:
+number: 185
+--
+
+## Summary
+
+Add support for multi-region E2E testing to validate both projected and actual cost calculations across different AWS regions with varying pricing.
+
+## Priority
+
+**Post-MVP** - This is a future enhancement, not required for the initial MVP release.
+
+## Context
+
+From the E2E Test Plan, multi-region testing ensures:
+
+- Cost calculations work correctly across regions with different pricing
+- Region-specific plugin binaries are properly loaded
+- Pricing data accuracy is validated per-region
+
+## Requirements
+
+### Test Scenarios
+
+- [ ] Test projected costs in us-east-1 (baseline)
+- [ ] Test projected costs in eu-west-1 (different pricing)
+- [ ] Test projected costs in ap-northeast-1 (different pricing)
+- [ ] Test actual costs in us-east-1 (baseline)
+- [ ] Test actual costs in eu-west-1 (different pricing)
+- [ ] Test actual costs in ap-northeast-1 (different pricing)
+- [ ] Validate region-specific pricing differences are reflected for both cost types (eu-west-1: +7-15% vs us-east-1 baseline, ap-northeast-1: +10-20% vs us-east-1 baseline)
+
+### Infrastructure
+
+- [ ] Parameterized test fixtures for different regions containing 5-10 resources across 3-4 resource types (e.g., compute, storage, network, database)
+- [ ] Region-specific Pulumi programs in test harness
+- [ ] Cost assertion thresholds per region with ±5% variance tolerance
+
+### Validation
+
+- [ ] Verify region is correctly passed to plugin
+- [ ] Confirm pricing matches expected regional rates
+- [ ] Test fallback behavior when region-specific plugin unavailable
+
+## Dependencies
+
+- #177 - E2E test with Pulumi Automation API (must be complete first)
+- #24 (pulumicost-plugin-aws-public) - Fallback GetActualCost implementation (required for actual cost testing across regions)
+
+## Related
+
+- E2E_TEST_PLAN.md - Section 4.2 Multi-region testing support"
+
+## Clarifications
+
+### Session 2026-01-21
+
+- Q: Should the multi-region E2E tests validate both projected AND actual cost calculations, or only projected costs? → A: Both projected and actual costs (comprehensive validation, covers both pipelines)
+- Q: What acceptable variance threshold should be used when validating cost calculations against expected regional rates? → A: ±5% variance tolerance (accounts for minor fluctuations, good for dynamic pricing)
+- Q: How many resources of different types should each region's test fixture include to provide adequate validation coverage? → A: 5-10 resources across 3-4 types (balanced coverage, reasonable execution time)
+- Q: What should the expected behavior be when pricing data is completely unavailable for a region? → A: Fail the test immediately (strict validation, blocks execution)
+- Q: How does system handle network failures during plugin loading? → A: Retry 3 times with exponential backoff, then fail (handles transient issues)
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Run E2E Tests Across Multiple Regions (Priority: P1)
+
+As a developer, I want to run end-to-end tests that validate both projected and actual cost calculations across different AWS regions so that I can ensure pricing accuracy and region-specific plugin loading work correctly for both cost pipelines.
+
+**Why this priority**: This is the core functionality needed to validate multi-region cost calculations for both projected and actual costs, which is essential for comprehensive feature validation.
+
+**Independent Test**: Can be fully tested by running the E2E test suite with region parameters and verifying both projected and actual cost outputs match expected regional rates.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Pulumi program configured for us-east-1, **When** running E2E tests, **Then** projected costs are calculated using baseline pricing
+2. **Given** a Pulumi program configured for eu-west-1, **When** running E2E tests, **Then** projected costs reflect European pricing differences
+3. **Given** a Pulumi program configured for ap-northeast-1, **When** running E2E tests, **Then** projected costs reflect Asia Pacific pricing differences
+4. **Given** a Pulumi state for us-east-1, **When** running actual cost tests, **Then** actual costs are retrieved using baseline regional pricing
+5. **Given** a Pulumi state for eu-west-1, **When** running actual cost tests, **Then** actual costs reflect European pricing differences
+6. **Given** a Pulumi state for ap-northeast-1, **When** running actual cost tests, **Then** actual costs reflect Asia Pacific pricing differences
+7. **Given** a Pulumi program configured for us-east-1, **When** running projected cost tests, **Then** costs reflect baseline US East pricing (e.g., t3.micro EC2 at $7.01/month, gp3 EBS at $8.00/100GB)
+8. **Given** a Pulumi program configured for eu-west-1, **When** running projected cost tests, **Then** costs reflect European pricing with 7-15% increase over us-east-1 baseline
+9. **Given** a Pulumi program configured for ap-northeast-1, **When** running projected cost tests, **Then** costs reflect Asia Pacific pricing with 10-20% increase over us-east-1 baseline
+10. **Given** a region with no pricing data available, **When** running E2E tests, **Then** the test fails immediately with a clear error message
+11. **Given** a transient network failure during plugin loading, **When** running E2E tests, **Then** the system retries 3 times with exponential backoff before failing
+
+---
+
+### User Story 2 - Validate Region-Specific Plugin Loading (Priority: P2)
+
+As a developer, I want to ensure that region-specific plugin binaries are loaded correctly during E2E tests so that accurate pricing data is used for each region.
+
+**Why this priority**: Plugin loading is critical for cost accuracy, but secondary to the basic multi-region testing capability.
+
+**Independent Test**: Can be tested by verifying which plugin version is loaded and used for cost calculations in each region.
+
+**Acceptance Scenarios**:
+
+1. **Given** a test run in us-east-1, **When** the plugin is invoked, **Then** the correct region-specific plugin binary is loaded
+2. **Given** a test run in eu-west-1, **When** the plugin is invoked, **Then** the correct region-specific plugin binary is loaded
+
+---
+
+### User Story 3 - Test Fallback Behavior (Priority: P3)
+
+As a developer, I want to test fallback behavior when region-specific plugins are unavailable so that the system gracefully handles missing regional data.
+
+**Why this priority**: Fallback testing ensures robustness, but is the least critical aspect of the multi-region testing feature.
+
+**Independent Test**: Can be tested by simulating missing region-specific plugins and verifying fallback to public pricing data.
+
+**Acceptance Scenarios**:
+
+1. **Given** a region without a specific plugin, **When** running E2E tests, **Then** the system falls back to public pricing data
+
+---
+
+### User Story 4 - Unified Multi-Region Fixture Testing (Priority: P3)
+
+As a developer, I want to test cost calculations for a single Pulumi program that deploys resources across multiple AWS regions so that I can validate FinFocus correctly handles cross-region infrastructure deployments.
+
+**Why this priority**: Many production Pulumi programs span multiple regions. Testing this scenario ensures comprehensive cost calculation coverage beyond per-region fixtures.
+
+**Independent Test**: Can be tested by creating a unified Pulumi program with explicit provider configurations for multiple regions and verifying aggregated costs are calculated correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a single Pulumi program with resources in us-east-1, eu-west-1, and ap-northeast-1, **When** running projected cost tests, **Then** each resource's cost reflects its region-specific pricing
+2. **Given** a unified plan JSON with cross-region resources, **When** FinFocus processes the plan, **Then** costs are correctly aggregated per region
+3. **Given** a Pulumi program using explicit AWS provider aliases for each region, **When** generating a preview, **Then** the plan JSON correctly identifies each resource's target region
+4. **Given** the unified fixture, **When** running the full E2E test suite, **Then** total monthly cost equals the sum of individual region costs within ±5% tolerance
+
+---
+
+### Edge Cases
+
+- When a region has no pricing data available, the test MUST fail immediately with a clear error message indicating missing pricing data
+- When network failures occur during plugin loading, the system MUST retry 3 times with exponential backoff, then fail the test if the issue persists (distinguishes transient from persistent network issues)
+- What occurs when region configuration is invalid?
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST support parameterized test fixtures for different AWS regions, each containing 5-10 resources across 3-4 resource types (compute, storage, network, database)
+- **FR-002**: System MUST provide region-specific Pulumi programs and state files in the test harness
+- **FR-003**: System MUST validate that projected costs vary correctly across regions (us-east-1 baseline, eu-west-1, ap-northeast-1)
+- **FR-004**: System MUST validate that actual costs vary correctly across regions (us-east-1 baseline, eu-west-1, ap-northeast-1)
+- **FR-005**: System MUST verify that regions are correctly passed to plugins for both projected and actual cost calculations
+- **FR-006**: System MUST confirm pricing matches expected regional rates for both cost types within ±5% variance tolerance
+- **FR-007**: System MUST test fallback behavior when region-specific plugins are unavailable
+- **FR-008**: System MUST fail tests immediately when pricing data is completely unavailable for a region (no graceful degradation in E2E tests)
+- **FR-009**: System MUST retry plugin loading 3 times with exponential backoff on network failures, then fail the test if the issue persists
+- **FR-010**: System MUST source expected cost values from official AWS pricing APIs or documentation, with manual override capability for test fixtures
+
+### Key Entities _(include if feature involves data)_
+
+- **Region**: Represents an AWS region with associated pricing data and plugin versions
+- **Test Fixture**: Parameterized configuration for running tests in specific regions, containing 5-10 resources across 3-4 resource types (compute, storage, network, database)
+- **Pulumi Program**: Infrastructure-as-code definition used in E2E tests
+- **Cost Assertion**: Expected cost thresholds and validation rules per region (includes ±5% variance tolerance for cost comparisons)
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: E2E tests pass successfully in us-east-1, eu-west-1, and ap-northeast-1 with regional pricing within ±5% of expected values for both projected and actual costs
+- **SC-002**: Region-specific plugin binaries are loaded and used for both projected and actual cost calculations in each test region
+- **SC-003**: Fallback to public pricing works when region-specific plugins are unavailable for both cost types
+- **SC-004**: Test execution time remains under 5 minutes per region (covering both cost types)

--- a/specs/001-multi-region-e2e/tasks.md
+++ b/specs/001-multi-region-e2e/tasks.md
@@ -1,0 +1,256 @@
+---
+description: 'Task list template for feature implementation'
+---
+
+# Tasks: Add multi-region E2E testing support
+
+**Input**: Design documents from `/specs/001-multi-region-e2e/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+**Tests**: Per Constitution Principle II (Test-Driven Development), tests are MANDATORY and must be written BEFORE implementation. All code changes must maintain minimum 80% test coverage (95% for critical paths).
+**Completeness**: Per Constitution Principle VI (Implementation Completeness), all tasks MUST be fully implemented. Stub functions, placeholders, and TODO comments are strictly forbidden.
+**Documentation**: Per Constitution Principle IV, documentation (README, docs/) MUST be updated concurrently with implementation to prevent drift.
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Single project**: `src/`, `tests/` at repository root
+- **Web app**: `backend/src/`, `frontend/src/`
+- **Mobile**: `api/src/` or `ios/src/` or `android/src/`
+- Paths shown below assume single project - adjust based on plan.md structure
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and basic structure
+
+- [x] T001 Create multi-region test fixture directory structure in test/e2e/fixtures/multi-region/
+- [x] T002 [P] Configure linting and formatting for new test files
+
+---
+
+**Note**: Phase 2 (Foundational) tasks have been merged into User Story phases. Data models, validation logic, and configuration are created as needed within each user story to avoid upfront work that may not be used.
+
+**Checkpoint**: Setup complete - user story implementation can begin
+
+---
+
+## Phase 3: User Story 1 - Run E2E Tests Across Multiple Regions (Priority: P1) 🎯 MVP
+
+**Goal**: Validate both projected and actual cost calculations across different AWS regions with varying pricing
+
+**Independent Test**: Can be fully tested by running the E2E test suite with region parameters and verifying both projected and actual cost outputs match expected regional rates
+
+### Implementation for User Story 1
+
+- [x] T003 [P] [US1] Create us-east-1 Pulumi.yaml with YAML runtime and 8 resources (2 EC2, 2 EBS, 2 Network, 2 RDS) in test/e2e/fixtures/multi-region/us-east-1/Pulumi.yaml
+- [x] T004 [P] [US1] Create eu-west-1 Pulumi.yaml with YAML runtime and 8 resources in test/e2e/fixtures/multi-region/eu-west-1/Pulumi.yaml
+- [x] T005 [P] [US1] Create ap-northeast-1 Pulumi.yaml with YAML runtime and 8 resources in test/e2e/fixtures/multi-region/ap-northeast-1/Pulumi.yaml
+- [x] T006 [P] [US1] Generate expected-costs.json for us-east-1 in test/e2e/fixtures/multi-region/us-east-1/expected-costs.json (source: AWS pricing pages, apply ±5% tolerance)
+- [x] T007 [P] [US1] Generate expected-costs.json for eu-west-1 in test/e2e/fixtures/multi-region/eu-west-1/expected-costs.json (source: AWS pricing pages, apply ±5% tolerance)
+- [x] T008 [P] [US1] Generate expected-costs.json for ap-northeast-1 in test/e2e/fixtures/multi-region/ap-northeast-1/expected-costs.json (source: AWS pricing pages, apply ±5% tolerance)
+- [x] T009 [US1] Implement multi-region projected cost test in test/e2e/multi_region_projected_test.go
+- [x] T010 [US1] Implement multi-region actual cost test in test/e2e/multi_region_actual_test.go
+- [x] T011 [US1] Add region-specific plugin loading validation in test/e2e/multi_region_projected_test.go
+- [x] T012 [US1] Integrate cost validation with ±5% tolerance in test/e2e/multi_region_projected_test.go
+- [x] T013 [US1] Add network failure retry logic in test/e2e/multi_region_actual_test.go
+- [x] T014 [US1] Implement strict failure semantics for missing pricing data in test/e2e/multi_region_helpers.go
+- [x] T015 [US1] Update test/e2e/README.md with multi-region testing documentation
+
+**Checkpoint**: At this point, User Story 1 should be fully functional and testable independently
+
+---
+
+## Phase 4: User Story 2 - Validate Region-Specific Plugin Loading (Priority: P2)
+
+**Goal**: Ensure that region-specific plugin binaries are loaded correctly during E2E tests
+
+**Independent Test**: Can be tested by verifying which plugin version is loaded and used for cost calculations in each region
+
+### Implementation for User Story 2
+
+- [x] T016 [P] [US2] Add plugin version tracking in test execution logs in test/e2e/multi_region_helpers.go
+- [x] T017 [US2] Implement plugin loading verification in test/e2e/multi_region_projected_test.go
+- [x] T018 [US2] Add region-specific plugin binary validation in test/e2e/multi_region_actual_test.go
+- [x] T019 [US2] Extend test configuration to include expected plugin versions in test/e2e/config.go
+
+**Checkpoint**: At this point, User Stories 1 AND 2 should both work independently
+
+---
+
+## Phase 5: User Story 3 - Test Fallback Behavior (Priority: P3)
+
+**Goal**: Test fallback behavior when region-specific plugins are unavailable
+
+**Independent Test**: Can be tested by simulating missing region-specific plugins and verifying fallback to public pricing data
+
+### Implementation for User Story 3
+
+- [x] T020 [P] [US3] Create fallback test scenarios in test/e2e/multi_region_fallback_test.go
+- [x] T021 [US3] Implement plugin unavailability simulation in test/e2e/multi_region_fallback_test.go
+- [x] T022 [US3] Add fallback validation logic for public pricing in test/e2e/multi_region_fallback_test.go
+
+**Checkpoint**: All user stories should now be independently functional
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [x] T023 Add performance validation for <5 minutes per region in test/e2e/multi_region_projected_test.go
+- [x] T024 [P] Add documentation for multi-region E2E testing in docs/testing/multi-region-e2e.md
+- [x] T025 Code cleanup and refactoring in test/e2e/ multi-region files
+- [x] T026 [P] Run quickstart.md validation steps
+- [x] T027 Update CLAUDE.md with new Active Technologies section
+
+---
+
+## Phase 7: User Story 4 - Unified Multi-Region Fixture Testing (Priority: P3)
+
+**Goal**: Test cost calculations for a single Pulumi program that deploys resources across multiple AWS regions using YAML runtime with explicit provider aliases
+
+**Independent Test**: Can be tested by running the unified fixture through the projected cost command and validating per-region cost attribution and aggregate totals within ±5% tolerance
+
+**Key Differences from Per-Region Fixtures (US1-3)**:
+
+- **Structure**: Per-region has 3 separate `Pulumi.yaml` files (one per region), Unified has 1 `Pulumi.yaml` with all regions
+- **Providers**: Per-region uses single implicit AWS provider, Unified uses explicit provider aliases per region
+- **Validation**: Per-region validates per-region only, Unified validates per-resource + aggregate total
+
+### Implementation for User Story 4
+
+- [x] T028 [US4] Run discovery test to determine plugin behavior with multi-region plans - execute `pulumi preview --json` on unified fixture and analyze region detection in test/e2e/fixtures/multi-region/unified/
+- [x] T029 [P] [US4] Create unified fixture directory structure in test/e2e/fixtures/multi-region/unified/
+- [x] T030 [US4] Create Pulumi.yaml with YAML runtime defining 3 explicit AWS providers (us-east-1, eu-west-1, ap-northeast-1) and 3 EC2 instances in test/e2e/fixtures/multi-region/unified/Pulumi.yaml
+- [x] T031 [US4] Generate expected-costs.json with per-resource costs and aggregate validation bounds in test/e2e/fixtures/multi-region/unified/expected-costs.json
+- [x] T032 [US4] Add UnifiedExpectedCosts and AggregateExpectation structs to test/e2e/multi_region_helpers.go
+- [x] T033 [US4] Implement ValidateUnifiedFixtureCosts function with per-resource and aggregate validation in test/e2e/validator.go
+- [x] T034 [US4] Create test function TestMultiRegion_Unified_Projected with per-resource cost assertions, region attribution validation, and aggregate total validation in test/e2e/multi_region_projected_test.go
+- [x] T035 [US4] Update docs/testing/multi-region-e2e.md with unified fixture section including troubleshooting for region detection issues
+
+**Checkpoint**: Unified multi-region fixture testing should validate:
+
+1. Each resource's cost reflects its region-specific pricing
+2. Aggregate total equals sum of individual region costs within ±5% tolerance
+3. Plugin correctly extracts regions from provider configuration in plan JSON
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **User Story 1 (Phase 3)**: Depends on Setup - core multi-region testing
+- **User Story 2 (Phase 4)**: Can start after Setup - plugin loading verification
+- **User Story 3 (Phase 5)**: Can start after Setup - fallback behavior tests
+- **Polish (Phase 6)**: Depends on US1-3 being complete
+- **User Story 4 (Phase 7)**: Can start after Setup - unified multi-region fixture (independent of US1-3)
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Setup - No dependencies on other stories
+- **User Story 2 (P2)**: Can start after Setup - May integrate with US1 but should be independently testable
+- **User Story 3 (P3)**: Can start after Setup - May integrate with US1/US2 but should be independently testable
+- **User Story 4 (P3)**: Can start after Setup - Tests unified multi-region fixtures with YAML runtime (independent track)
+
+### Within Each User Story
+
+- Tests (if included) MUST be written and FAIL before implementation
+- Models before services
+- Services before endpoints
+- Core implementation before integration
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- All Setup tasks marked [P] can run in parallel
+- All Foundational tasks marked [P] can run in parallel (within Phase 2)
+- Once Foundational phase completes, all user stories can start in parallel (if team capacity allows)
+- All tests for a user story marked [P] can run in parallel
+- Models within a story marked [P] can run in parallel
+- Different user stories can be worked on in parallel by different team members
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch all Pulumi.yaml fixture creation tasks for User Story 1 together:
+Task: "Create us-east-1 Pulumi.yaml with YAML runtime in test/e2e/fixtures/multi-region/us-east-1/Pulumi.yaml"
+Task: "Create eu-west-1 Pulumi.yaml with YAML runtime in test/e2e/fixtures/multi-region/eu-west-1/Pulumi.yaml"
+Task: "Create ap-northeast-1 Pulumi.yaml with YAML runtime in test/e2e/fixtures/multi-region/ap-northeast-1/Pulumi.yaml"
+
+# Launch all expected-costs.json generation tasks together:
+Task: "Generate expected-costs.json for us-east-1 in test/e2e/fixtures/multi-region/us-east-1/expected-costs.json"
+Task: "Generate expected-costs.json for eu-west-1 in test/e2e/fixtures/multi-region/eu-west-1/expected-costs.json"
+Task: "Generate expected-costs.json for ap-northeast-1 in test/e2e/fixtures/multi-region/ap-northeast-1/expected-costs.json"
+```
+
+---
+
+## Parallel Example: User Story 4
+
+```bash
+# After T035 discovery completes, these can run in parallel:
+Task: "Create unified fixture directory structure in test/e2e/fixtures/multi-region/unified/"
+Task: "Add UnifiedExpectedCosts and AggregateExpectation structs to test/e2e/multi_region_helpers.go"
+
+# After directory exists, these depend on T036:
+Task: "Create Pulumi.yaml with YAML runtime in test/e2e/fixtures/multi-region/unified/Pulumi.yaml"
+Task: "Generate expected-costs.json in test/e2e/fixtures/multi-region/unified/expected-costs.json"
+
+# After structs exist, validation can proceed:
+Task: "Implement ValidateUnifiedFixtureCosts in test/e2e/validator.go"
+
+# Test function depends on all above:
+Task: "Create TestMultiRegion_Unified_Projected in test/e2e/multi_region_projected_test.go"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL - blocks all stories)
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Test User Story 1 independently
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add User Story 1 → Test independently → Deploy/Demo (MVP!)
+3. Add User Story 2 → Test independently → Deploy/Demo
+4. Add User Story 3 → Test independently → Deploy/Demo
+5. Each story adds value without breaking previous stories
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. Once Foundational is done:
+   - Developer A: User Story 1
+   - Developer B: User Story 2
+   - Developer C: User Story 3
+3. Stories complete and integrate independently
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Verify tests fail before implementing
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Avoid: vague tasks, same file conflicts, cross-story dependencies that break independence

--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -1,0 +1,2 @@
+# PR message files
+PR_MESSAGE.md

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -5,12 +5,28 @@ This directory contains E2E tests for FinFocus Core.
 ## Running Tests
 
 Prerequisites:
+
 - `finfocus` binary built and available in `bin/` or `PATH`.
 - Fixtures available in `test/fixtures/plans/`.
+- AWS credentials configured (for multi-region and actual cost tests).
 
 Run all E2E tests:
+
 ```bash
 go test -v -tags e2e ./test/e2e/...
+```
+
+Run specific test suites:
+
+```bash
+# Projected cost tests only
+go test -v -tags e2e ./test/e2e -run Projected
+
+# Multi-region tests
+go test -v -tags e2e ./test/e2e -run TestMultiRegion
+
+# Actual cost tests (requires AWS credentials)
+go test -v -tags e2e ./test/e2e -run Actual
 ```
 
 ## Test Structure
@@ -19,9 +35,131 @@ go test -v -tags e2e ./test/e2e/...
 - `output_*.go`: Validates different output formats.
 - `errors_test.go`: Validates error handling.
 - `*_test.go`: Provider-specific tests.
-- `actual_cost_test.go`: Placeholder for actual cost workflow.
+- `actual_cost_test.go`: Validates actual cost workflow with Pulumi state.
+- `multi_region_projected_test.go`: Multi-region projected cost validation.
+- `multi_region_actual_test.go`: Multi-region actual cost validation.
+- `multi_region_fallback_test.go`: Multi-region plugin fallback scenarios.
+- `multi_region_helpers.go`: Helper functions for multi-region testing.
+
+## Multi-Region Testing
+
+Multi-region E2E tests validate cost calculations across different AWS regions (us-east-1, eu-west-1, ap-northeast-1) to ensure regional pricing differences are correctly reflected.
+
+### Quick Start
+
+```bash
+# Run multi-region tests for default region (us-east-1)
+make test-e2e
+
+# Test all three regions
+export FINFOCUS_E2E_REGIONS="us-east-1,eu-west-1,ap-northeast-1"
+go test -v -tags e2e ./test/e2e -run TestMultiRegion
+```
+
+### Configuration
+
+Environment variables for multi-region testing:
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `FINFOCUS_E2E_REGIONS` | `us-east-1` | Comma-separated list of regions to test |
+| `FINFOCUS_E2E_TOLERANCE` | `0.05` | Cost variance tolerance (±5%) |
+| `FINFOCUS_E2E_TIMEOUT` | `10m` | Maximum test execution time per region |
+| `FINFOCUS_E2E_SKIP_ACTUAL_COSTS` | `false` | Skip actual cost tests (useful during development) |
+
+### Test Fixtures
+
+Multi-region test fixtures are located in `fixtures/multi-region/`. Fixtures use YAML runtime (no Go code):
+
+```text
+fixtures/multi-region/
+├── us-east-1/
+│   ├── Pulumi.yaml          # YAML program (region: us-east-1) with 16 resources
+│   └── expected-costs.json  # Expected cost ranges (±5%)
+├── eu-west-1/
+│   ├── Pulumi.yaml          # YAML program (region: eu-west-1) with 16 resources
+│   └── expected-costs.json
+├── ap-northeast-1/
+│   ├── Pulumi.yaml          # YAML program (region: ap-northeast-1) with 16 resources
+│   └── expected-costs.json
+└── unified/
+    ├── Pulumi.yaml          # Multi-region unified fixture
+    └── expected-costs.json
+```
+
+Each regional fixture contains:
+
+- **2x EC2 Instances** (t3.micro, t3.small) - Compute
+- **2x EBS Volumes** (gp3, io2) - Storage
+- **2x Network Resources** (NAT Gateway, VPC Endpoint) - Network
+- **2x RDS Instances** (db.t3.micro) - Database
+
+### Validation Strategy
+
+Multi-region tests use **tolerance-based validation**:
+
+- Each resource has expected cost range in `expected-costs.json`
+- Default tolerance: ±5% to handle minor pricing fluctuations
+- Tests fail if actual cost exceeds expected range
+- Expected costs are region-specific to validate pricing differences
+
+### Failure Handling
+
+The tests implement strict failure semantics:
+
+- **Missing pricing data**: Immediate test failure (no graceful degradation)
+- **Network failures**: Retry 3x with exponential backoff (100ms, 200ms, 400ms), then fail
+- **Invalid region config**: Fail immediately in setup phase
+- **Cost out of tolerance**: Record failure and continue (reports all failures)
+
+### Expected Performance
+
+- **Projected cost tests**: ~2-3 minutes per region
+- **Actual cost tests**: ~4-5 minutes per region (includes resource deployment)
+- **All three regions**: ~15 minutes total
+
+### Troubleshooting
+
+**Test fails with "No pricing data available":**
+
+```bash
+# Verify plugin installation
+./bin/finfocus plugin list
+
+# Install region-specific plugin if missing
+./bin/finfocus plugin install aws-public --version <version>
+```
+
+**Test timeout:**
+
+```bash
+# Increase timeout for slower environments
+export FINFOCUS_E2E_TIMEOUT=15m
+go test -timeout 20m -v -tags e2e ./test/e2e -run TestMultiRegion
+```
+
+**Cost variance exceeds tolerance:**
+
+```bash
+# Verify AWS pricing hasn't changed
+# Update expected-costs.json if pricing has been updated
+# Or temporarily increase tolerance for investigation
+export FINFOCUS_E2E_TOLERANCE=0.10  # ±10%
+```
+
+For detailed multi-region testing documentation, see:
+
+- [Feature Spec](../../specs/001-multi-region-e2e/spec.md)
+- [Quickstart Guide](../../specs/001-multi-region-e2e/quickstart.md)
+- [Multi-Region E2E Testing Guide](../../docs/testing/multi-region-e2e.md)
 
 ## Helpers
 
 The tests rely on `findFinFocusBinary()` to locate the executable.
 Tests use `exec.Command` to run the binary against fixture plans.
+Multi-region tests use helper functions in `multi_region_helpers.go` for:
+
+- Fixture loading and validation
+- Cost tolerance checking
+- Retry logic with exponential backoff
+- Error classification (network vs. missing data)

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -3,32 +3,53 @@ package e2e
 import (
 	"os"
 	"strconv"
+	"strings"
 	"time"
+
+	"github.com/Masterminds/semver/v3"
 )
 
 // Config holds configuration for E2E tests.
 type Config struct {
-	AWSRegion string
-	Tolerance float64
-	Timeout   time.Duration
+	AWSRegion       string
+	Regions         []string // List of regions to test
+	Tolerance       float64
+	Timeout         time.Duration
+	SkipActualCosts bool // Skip actual cost tests if true
 }
 
 // LoadConfig returns a Config populated from environment variables with sensible defaults.
 //
-// It initializes defaults (AWSRegion "us-east-1", Tolerance 0.05, Timeout 10 minutes) and
+// It initializes defaults (AWSRegion "us-east-1", Regions ["us-east-1"], Tolerance 0.05, Timeout 10 minutes, SkipActualCosts false) and
 // overrides them when the following environment variables are set and valid:
-// FINFOCUS_E2E_AWS_REGION (string), FINFOCUS_E2E_TOLERANCE (float64), and
-// FINFOCUS_E2E_TIMEOUT (duration parseable by time.ParseDuration).
-// Invalid numeric or duration values are silently ignored and defaults are retained.
+// FINFOCUS_E2E_AWS_REGION (string), FINFOCUS_E2E_REGIONS (comma-separated), FINFOCUS_E2E_TOLERANCE (float64),
+// FINFOCUS_E2E_TIMEOUT (duration parseable by time.ParseDuration), FINFOCUS_E2E_SKIP_ACTUAL_COSTS (bool).
+// Invalid values are silently ignored and defaults are retained.
 func LoadConfig() *Config {
 	cfg := &Config{
-		AWSRegion: "us-east-1",
-		Tolerance: 0.05,
-		Timeout:   10 * time.Minute,
+		AWSRegion:       "us-east-1",
+		Regions:         []string{"us-east-1"},
+		Tolerance:       0.05,
+		Timeout:         10 * time.Minute,
+		SkipActualCosts: false,
 	}
 
 	if region := os.Getenv("FINFOCUS_E2E_AWS_REGION"); region != "" {
 		cfg.AWSRegion = region
+	}
+
+	if regionsStr := os.Getenv("FINFOCUS_E2E_REGIONS"); regionsStr != "" {
+		regions := strings.Split(regionsStr, ",")
+		var validRegions []string
+		for _, r := range regions {
+			r = strings.TrimSpace(r)
+			if r != "" {
+				validRegions = append(validRegions, r)
+			}
+		}
+		if len(validRegions) > 0 {
+			cfg.Regions = validRegions
+		}
 	}
 
 	if tolStr := os.Getenv("FINFOCUS_E2E_TOLERANCE"); tolStr != "" {
@@ -43,5 +64,43 @@ func LoadConfig() *Config {
 		}
 	}
 
+	if skipStr := os.Getenv("FINFOCUS_E2E_SKIP_ACTUAL_COSTS"); skipStr != "" {
+		if skip, err := strconv.ParseBool(skipStr); err == nil && skip {
+			cfg.SkipActualCosts = true
+		}
+	}
+
 	return cfg
+}
+
+// CheckPulumiAutomationAPISupport checks if Pulumi Automation API support is available (issue #177).
+// Returns true if the feature is implemented and available for testing.
+func CheckPulumiAutomationAPISupport() bool {
+	// Check if Pulumi CLI is available (required for Automation API)
+	// For now, assume it's available if running in CI or if explicitly enabled
+	return os.Getenv("PULUMI_AUTOMATION_API_ENABLED") == "true" || os.Getenv("CI") == "true"
+}
+
+// CheckGetActualCostSupport checks if GetActualCost fallback implementation is available (issue #24).
+// Returns true if the feature is implemented and available for testing.
+func CheckGetActualCostSupport() bool {
+	// Check if AWS plugin supports GetActualCost
+	versionStr := os.Getenv("FINFOCUS_PLUGIN_AWS_VERSION")
+	if versionStr != "" {
+		// Parse version using semantic versioning
+		v, err := semver.NewVersion(versionStr)
+		if err == nil {
+			// Check if version >= 0.1.0
+			constraint, constraintErr := semver.NewConstraint(">= 0.1.0")
+			if constraintErr != nil {
+				// Constraint parsing failed, fall back to CI check
+				return os.Getenv("CI") == "true"
+			}
+			if constraint.Check(v) {
+				return true
+			}
+		}
+	}
+	// Fallback to CI check
+	return os.Getenv("CI") == "true"
 }

--- a/test/e2e/fixtures/multi-region/ap-northeast-1/Pulumi.yaml
+++ b/test/e2e/fixtures/multi-region/ap-northeast-1/Pulumi.yaml
@@ -1,0 +1,195 @@
+name: multi-region-test-ap-northeast-1
+runtime: yaml
+description: Multi-region E2E test fixture for ap-northeast-1 with 16 resources
+
+config:
+  aws:region:
+    value: ap-northeast-1
+  pulumi:tags:
+    value:
+      Environment: e2e-test
+      ManagedBy: finfocus
+      TestSuite: multi-region
+
+resources:
+  # VPC Infrastructure (required for networking resources)
+  test-vpc:
+    type: aws:ec2:Vpc
+    properties:
+      cidrBlock: "10.0.0.0/16"
+      tags:
+        Name: test-vpc
+
+  test-igw:
+    type: aws:ec2:InternetGateway
+    properties:
+      vpcId: ${test-vpc.id}
+      tags:
+        Name: test-igw
+
+  test-subnet:
+    type: aws:ec2:Subnet
+    properties:
+      vpcId: ${test-vpc.id}
+      cidrBlock: "10.0.1.0/24"
+      availabilityZone: ap-northeast-1a
+      mapPublicIpOnLaunch: true
+      tags:
+        Name: test-subnet
+
+  test-subnet-2:
+    type: aws:ec2:Subnet
+    properties:
+      vpcId: ${test-vpc.id}
+      cidrBlock: "10.0.2.0/24"
+      availabilityZone: ap-northeast-1c
+      tags:
+        Name: test-subnet-2
+
+  test-rt:
+    type: aws:ec2:RouteTable
+    properties:
+      vpcId: ${test-vpc.id}
+      routes:
+        - cidrBlock: "0.0.0.0/0"
+          gatewayId: ${test-igw.id}
+      tags:
+        Name: test-rt
+
+  test-rta:
+    type: aws:ec2:RouteTableAssociation
+    properties:
+      subnetId: ${test-subnet.id}
+      routeTableId: ${test-rt.id}
+
+  # EC2 Instances (compute) - 2 resources
+  web-server-t3-micro:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-placeholder-ap-northeast-1
+      instanceType: t3.micro
+      subnetId: ${test-subnet.id}
+      associatePublicIpAddress: true
+      tags:
+        Name: web-server-t3-micro
+
+  web-server-t3-small:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-placeholder-ap-northeast-1
+      instanceType: t3.small
+      subnetId: ${test-subnet.id}
+      associatePublicIpAddress: true
+      tags:
+        Name: web-server-t3-small
+
+  # EBS Volumes (storage) - 2 resources
+  data-volume-gp3:
+    type: aws:ebs:Volume
+    properties:
+      availabilityZone: ap-northeast-1a
+      size: 100
+      type: gp3
+      iops: 3000
+      tags:
+        Name: data-volume-gp3
+
+  data-volume-io2:
+    type: aws:ebs:Volume
+    properties:
+      availabilityZone: ap-northeast-1a
+      size: 50
+      type: io2
+      iops: 1000
+      tags:
+        Name: data-volume-io2
+
+  # Network Resources - 2 resources
+  test-eip:
+    type: aws:ec2:Eip
+    properties:
+      domain: vpc
+      tags:
+        Name: test-eip
+
+  test-nat-gw:
+    type: aws:ec2:NatGateway
+    properties:
+      allocationId: ${test-eip.id}
+      subnetId: ${test-subnet.id}
+      tags:
+        Name: test-nat-gw
+
+  test-vpc-endpoint:
+    type: aws:ec2:VpcEndpoint
+    properties:
+      vpcId: ${test-vpc.id}
+      serviceName: com.amazonaws.ap-northeast-1.s3
+      vpcEndpointType: Gateway
+      routeTableIds:
+        - ${test-rt.id}
+      tags:
+        Name: test-vpc-endpoint
+
+  # RDS Subnet Group (required for RDS - needs subnets in at least 2 AZs)
+  test-db-subnet-group:
+    type: aws:rds:SubnetGroup
+    properties:
+      subnetIds:
+        - ${test-subnet.id}
+        - ${test-subnet-2.id}
+      tags:
+        Name: test-db-subnet-group
+
+  # RDS Instances (database) - 2 resources
+  test-db-postgres:
+    type: aws:rds:Instance
+    properties:
+      allocatedStorage: 20
+      engine: postgres
+      engineVersion: "13.7"
+      instanceClass: db.t3.micro
+      dbName: testdb
+      username: testuser  # TEST ONLY - do not use in production
+      password: testpassword123  # TEST ONLY - ephemeral test credentials
+      parameterGroupName: default.postgres13
+      skipFinalSnapshot: true
+      dbSubnetGroupName: ${test-db-subnet-group.name}
+      tags:
+        Name: test-db-postgres
+
+  test-db-mysql:
+    type: aws:rds:Instance
+    properties:
+      allocatedStorage: 20
+      engine: mysql
+      engineVersion: "8.0.28"
+      instanceClass: db.t3.micro
+      dbName: testdb
+      username: testuser  # TEST ONLY - do not use in production
+      password: testpassword123  # TEST ONLY - ephemeral test credentials
+      parameterGroupName: default.mysql8.0
+      skipFinalSnapshot: true
+      dbSubnetGroupName: ${test-db-subnet-group.name}
+      tags:
+        Name: test-db-mysql
+
+outputs:
+  vpcId:
+    value: ${test-vpc.id}
+  ec2T3MicroId:
+    value: ${web-server-t3-micro.id}
+  ec2T3SmallId:
+    value: ${web-server-t3-small.id}
+  ebsGp3Id:
+    value: ${data-volume-gp3.id}
+  ebsIo2Id:
+    value: ${data-volume-io2.id}
+  natGwId:
+    value: ${test-nat-gw.id}
+  vpcEndpointId:
+    value: ${test-vpc-endpoint.id}
+  rdsPgId:
+    value: ${test-db-postgres.id}
+  rdsMyId:
+    value: ${test-db-mysql.id}

--- a/test/e2e/fixtures/multi-region/ap-northeast-1/expected-costs.json
+++ b/test/e2e/fixtures/multi-region/ap-northeast-1/expected-costs.json
@@ -1,0 +1,70 @@
+{
+  "region": "ap-northeast-1",
+  "cost_type": "projected",
+  "resources": [
+    {
+      "resource_type": "aws:ec2:Instance",
+      "resource_name": "web-server-t3-micro",
+      "min_cost": 8.1,
+      "max_cost": 9.3,
+      "region": "ap-northeast-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ec2:Instance",
+      "resource_name": "web-server-t3-small",
+      "min_cost": 16.2,
+      "max_cost": 18.6,
+      "region": "ap-northeast-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ebs:Volume",
+      "resource_name": "data-volume-gp3",
+      "min_cost": 9.2,
+      "max_cost": 10.4,
+      "region": "ap-northeast-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ebs:Volume",
+      "resource_name": "data-volume-io2",
+      "min_cost": 11.6,
+      "max_cost": 12.9,
+      "region": "ap-northeast-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ec2:NatGateway",
+      "resource_name": "test-nat-gw",
+      "min_cost": 37.5,
+      "max_cost": 41.8,
+      "region": "ap-northeast-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ec2:VpcEndpoint",
+      "resource_name": "test-vpc-endpoint",
+      "min_cost": 8.3,
+      "max_cost": 9.2,
+      "region": "ap-northeast-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:rds:Instance",
+      "resource_name": "test-db-postgres",
+      "min_cost": 15.0,
+      "max_cost": 16.8,
+      "region": "ap-northeast-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:rds:Instance",
+      "resource_name": "test-db-mysql",
+      "min_cost": 15.0,
+      "max_cost": 16.8,
+      "region": "ap-northeast-1",
+      "cost_type": "projected"
+    }
+  ]
+}

--- a/test/e2e/fixtures/multi-region/eu-west-1/Pulumi.yaml
+++ b/test/e2e/fixtures/multi-region/eu-west-1/Pulumi.yaml
@@ -1,0 +1,195 @@
+name: multi-region-test-eu-west-1
+runtime: yaml
+description: Multi-region E2E test fixture for eu-west-1 with 16 resources
+
+config:
+  aws:region:
+    value: eu-west-1
+  pulumi:tags:
+    value:
+      Environment: e2e-test
+      ManagedBy: finfocus
+      TestSuite: multi-region
+
+resources:
+  # VPC Infrastructure (required for networking resources)
+  test-vpc:
+    type: aws:ec2:Vpc
+    properties:
+      cidrBlock: "10.0.0.0/16"
+      tags:
+        Name: test-vpc
+
+  test-igw:
+    type: aws:ec2:InternetGateway
+    properties:
+      vpcId: ${test-vpc.id}
+      tags:
+        Name: test-igw
+
+  test-subnet:
+    type: aws:ec2:Subnet
+    properties:
+      vpcId: ${test-vpc.id}
+      cidrBlock: "10.0.1.0/24"
+      availabilityZone: eu-west-1a
+      mapPublicIpOnLaunch: true
+      tags:
+        Name: test-subnet
+
+  test-subnet-2:
+    type: aws:ec2:Subnet
+    properties:
+      vpcId: ${test-vpc.id}
+      cidrBlock: "10.0.2.0/24"
+      availabilityZone: eu-west-1b
+      tags:
+        Name: test-subnet-2
+
+  test-rt:
+    type: aws:ec2:RouteTable
+    properties:
+      vpcId: ${test-vpc.id}
+      routes:
+        - cidrBlock: "0.0.0.0/0"
+          gatewayId: ${test-igw.id}
+      tags:
+        Name: test-rt
+
+  test-rta:
+    type: aws:ec2:RouteTableAssociation
+    properties:
+      subnetId: ${test-subnet.id}
+      routeTableId: ${test-rt.id}
+
+  # EC2 Instances (compute) - 2 resources
+  web-server-t3-micro:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-placeholder-eu-west-1
+      instanceType: t3.micro
+      subnetId: ${test-subnet.id}
+      associatePublicIpAddress: true
+      tags:
+        Name: web-server-t3-micro
+
+  web-server-t3-small:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-placeholder-eu-west-1
+      instanceType: t3.small
+      subnetId: ${test-subnet.id}
+      associatePublicIpAddress: true
+      tags:
+        Name: web-server-t3-small
+
+  # EBS Volumes (storage) - 2 resources
+  data-volume-gp3:
+    type: aws:ebs:Volume
+    properties:
+      availabilityZone: eu-west-1a
+      size: 100
+      type: gp3
+      iops: 3000
+      tags:
+        Name: data-volume-gp3
+
+  data-volume-io2:
+    type: aws:ebs:Volume
+    properties:
+      availabilityZone: eu-west-1a
+      size: 50
+      type: io2
+      iops: 1000
+      tags:
+        Name: data-volume-io2
+
+  # Network Resources - 2 resources
+  test-eip:
+    type: aws:ec2:Eip
+    properties:
+      domain: vpc
+      tags:
+        Name: test-eip
+
+  test-nat-gw:
+    type: aws:ec2:NatGateway
+    properties:
+      allocationId: ${test-eip.id}
+      subnetId: ${test-subnet.id}
+      tags:
+        Name: test-nat-gw
+
+  test-vpc-endpoint:
+    type: aws:ec2:VpcEndpoint
+    properties:
+      vpcId: ${test-vpc.id}
+      serviceName: com.amazonaws.eu-west-1.s3
+      vpcEndpointType: Gateway
+      routeTableIds:
+        - ${test-rt.id}
+      tags:
+        Name: test-vpc-endpoint
+
+  # RDS Subnet Group (required for RDS - needs subnets in at least 2 AZs)
+  test-db-subnet-group:
+    type: aws:rds:SubnetGroup
+    properties:
+      subnetIds:
+        - ${test-subnet.id}
+        - ${test-subnet-2.id}
+      tags:
+        Name: test-db-subnet-group
+
+  # RDS Instances (database) - 2 resources
+  test-db-postgres:
+    type: aws:rds:Instance
+    properties:
+      allocatedStorage: 20
+      engine: postgres
+      engineVersion: "13.7"
+      instanceClass: db.t3.micro
+      dbName: testdb
+      username: testuser  # TEST ONLY - do not use in production
+      password: testpassword123  # TEST ONLY - ephemeral test credentials
+      parameterGroupName: default.postgres13
+      skipFinalSnapshot: true
+      dbSubnetGroupName: ${test-db-subnet-group.name}
+      tags:
+        Name: test-db-postgres
+
+  test-db-mysql:
+    type: aws:rds:Instance
+    properties:
+      allocatedStorage: 20
+      engine: mysql
+      engineVersion: "8.0.28"
+      instanceClass: db.t3.micro
+      dbName: testdb
+      username: testuser  # TEST ONLY - do not use in production
+      password: testpassword123  # TEST ONLY - ephemeral test credentials
+      parameterGroupName: default.mysql8.0
+      skipFinalSnapshot: true
+      dbSubnetGroupName: ${test-db-subnet-group.name}
+      tags:
+        Name: test-db-mysql
+
+outputs:
+  vpcId:
+    value: ${test-vpc.id}
+  ec2T3MicroId:
+    value: ${web-server-t3-micro.id}
+  ec2T3SmallId:
+    value: ${web-server-t3-small.id}
+  ebsGp3Id:
+    value: ${data-volume-gp3.id}
+  ebsIo2Id:
+    value: ${data-volume-io2.id}
+  natGwId:
+    value: ${test-nat-gw.id}
+  vpcEndpointId:
+    value: ${test-vpc-endpoint.id}
+  rdsPgId:
+    value: ${test-db-postgres.id}
+  rdsMyId:
+    value: ${test-db-mysql.id}

--- a/test/e2e/fixtures/multi-region/eu-west-1/expected-costs.json
+++ b/test/e2e/fixtures/multi-region/eu-west-1/expected-costs.json
@@ -1,0 +1,70 @@
+{
+  "region": "eu-west-1",
+  "cost_type": "projected",
+  "resources": [
+    {
+      "resource_type": "aws:ec2:Instance",
+      "resource_name": "web-server-t3-micro",
+      "min_cost": 7.2,
+      "max_cost": 8.3,
+      "region": "eu-west-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ec2:Instance",
+      "resource_name": "web-server-t3-small",
+      "min_cost": 14.3,
+      "max_cost": 16.5,
+      "region": "eu-west-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ebs:Volume",
+      "resource_name": "data-volume-gp3",
+      "min_cost": 8.3,
+      "max_cost": 9.4,
+      "region": "eu-west-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ebs:Volume",
+      "resource_name": "data-volume-io2",
+      "min_cost": 10.5,
+      "max_cost": 11.6,
+      "region": "eu-west-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ec2:NatGateway",
+      "resource_name": "test-nat-gw",
+      "min_cost": 34.1,
+      "max_cost": 37.9,
+      "region": "eu-west-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ec2:VpcEndpoint",
+      "resource_name": "test-vpc-endpoint",
+      "min_cost": 7.5,
+      "max_cost": 8.4,
+      "region": "eu-west-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:rds:Instance",
+      "resource_name": "test-db-postgres",
+      "min_cost": 13.8,
+      "max_cost": 15.4,
+      "region": "eu-west-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:rds:Instance",
+      "resource_name": "test-db-mysql",
+      "min_cost": 13.8,
+      "max_cost": 15.4,
+      "region": "eu-west-1",
+      "cost_type": "projected"
+    }
+  ]
+}

--- a/test/e2e/fixtures/multi-region/unified/Pulumi.yaml
+++ b/test/e2e/fixtures/multi-region/unified/Pulumi.yaml
@@ -1,0 +1,74 @@
+name: multi-region-test-unified
+runtime: yaml
+description: Unified multi-region E2E test fixture with resources across all regions
+
+config:
+  pulumi:tags:
+    value:
+      Environment: e2e-test
+      ManagedBy: finfocus
+      TestSuite: multi-region-unified
+
+resources:
+  # AWS Provider for us-east-1
+  aws-us-east-1:
+    type: pulumi:providers:aws
+    properties:
+      region: us-east-1
+
+  # AWS Provider for eu-west-1
+  aws-eu-west-1:
+    type: pulumi:providers:aws
+    properties:
+      region: eu-west-1
+
+  # AWS Provider for ap-northeast-1
+  aws-ap-northeast-1:
+    type: pulumi:providers:aws
+    properties:
+      region: ap-northeast-1
+
+  # EC2 Instance in us-east-1
+  web-us-east-1:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-placeholder-us-east-1
+      instanceType: t3.micro
+      tags:
+        Name: web-us-east-1
+        Region: us-east-1
+    options:
+      provider: ${aws-us-east-1}
+
+  # EC2 Instance in eu-west-1
+  web-eu-west-1:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-placeholder-eu-west-1
+      instanceType: t3.micro
+      tags:
+        Name: web-eu-west-1
+        Region: eu-west-1
+    options:
+      provider: ${aws-eu-west-1}
+
+  # EC2 Instance in ap-northeast-1
+  web-ap-northeast-1:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-placeholder-ap-northeast-1
+      instanceType: t3.micro
+      tags:
+        Name: web-ap-northeast-1
+        Region: ap-northeast-1
+    options:
+      provider: ${aws-ap-northeast-1}
+
+outputs:
+  regions:
+    value:
+      - us-east-1
+      - eu-west-1
+      - ap-northeast-1
+  resourceCount:
+    value: 3

--- a/test/e2e/fixtures/multi-region/unified/expected-costs.json
+++ b/test/e2e/fixtures/multi-region/unified/expected-costs.json
@@ -1,0 +1,35 @@
+{
+  "fixture_type": "unified",
+  "total_regions": 3,
+  "resources": [
+    {
+      "resource_name": "web-us-east-1",
+      "resource_type": "aws:ec2:Instance",
+      "region": "us-east-1",
+      "min_cost": 6.66,
+      "max_cost": 7.36,
+      "cost_type": "projected"
+    },
+    {
+      "resource_name": "web-eu-west-1",
+      "resource_type": "aws:ec2:Instance",
+      "region": "eu-west-1",
+      "min_cost": 7.13,
+      "max_cost": 7.87,
+      "cost_type": "projected"
+    },
+    {
+      "resource_name": "web-ap-northeast-1",
+      "resource_type": "aws:ec2:Instance",
+      "region": "ap-northeast-1",
+      "min_cost": 7.60,
+      "max_cost": 8.40,
+      "cost_type": "projected"
+    }
+  ],
+  "aggregate_validation": {
+    "total_min_cost": 21.39,
+    "total_max_cost": 23.63,
+    "tolerance": 0.05
+  }
+}

--- a/test/e2e/fixtures/multi-region/us-east-1/Pulumi.yaml
+++ b/test/e2e/fixtures/multi-region/us-east-1/Pulumi.yaml
@@ -1,0 +1,195 @@
+name: multi-region-test-us-east-1
+runtime: yaml
+description: Multi-region E2E test fixture for us-east-1 with 16 resources
+
+config:
+  aws:region:
+    value: us-east-1
+  pulumi:tags:
+    value:
+      Environment: e2e-test
+      ManagedBy: finfocus
+      TestSuite: multi-region
+
+resources:
+  # VPC Infrastructure (required for networking resources)
+  test-vpc:
+    type: aws:ec2:Vpc
+    properties:
+      cidrBlock: "10.0.0.0/16"
+      tags:
+        Name: test-vpc
+
+  test-igw:
+    type: aws:ec2:InternetGateway
+    properties:
+      vpcId: ${test-vpc.id}
+      tags:
+        Name: test-igw
+
+  test-subnet:
+    type: aws:ec2:Subnet
+    properties:
+      vpcId: ${test-vpc.id}
+      cidrBlock: "10.0.1.0/24"
+      availabilityZone: us-east-1a
+      mapPublicIpOnLaunch: true
+      tags:
+        Name: test-subnet
+
+  test-subnet-2:
+    type: aws:ec2:Subnet
+    properties:
+      vpcId: ${test-vpc.id}
+      cidrBlock: "10.0.2.0/24"
+      availabilityZone: us-east-1b
+      tags:
+        Name: test-subnet-2
+
+  test-rt:
+    type: aws:ec2:RouteTable
+    properties:
+      vpcId: ${test-vpc.id}
+      routes:
+        - cidrBlock: "0.0.0.0/0"
+          gatewayId: ${test-igw.id}
+      tags:
+        Name: test-rt
+
+  test-rta:
+    type: aws:ec2:RouteTableAssociation
+    properties:
+      subnetId: ${test-subnet.id}
+      routeTableId: ${test-rt.id}
+
+  # EC2 Instances (compute) - 2 resources
+  web-server-t3-micro:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-placeholder-us-east-1
+      instanceType: t3.micro
+      subnetId: ${test-subnet.id}
+      associatePublicIpAddress: true
+      tags:
+        Name: web-server-t3-micro
+
+  web-server-t3-small:
+    type: aws:ec2:Instance
+    properties:
+      ami: ami-placeholder-us-east-1
+      instanceType: t3.small
+      subnetId: ${test-subnet.id}
+      associatePublicIpAddress: true
+      tags:
+        Name: web-server-t3-small
+
+  # EBS Volumes (storage) - 2 resources
+  data-volume-gp3:
+    type: aws:ebs:Volume
+    properties:
+      availabilityZone: us-east-1a
+      size: 100
+      type: gp3
+      iops: 3000
+      tags:
+        Name: data-volume-gp3
+
+  data-volume-io2:
+    type: aws:ebs:Volume
+    properties:
+      availabilityZone: us-east-1a
+      size: 50
+      type: io2
+      iops: 1000
+      tags:
+        Name: data-volume-io2
+
+  # Network Resources - 2 resources
+  test-eip:
+    type: aws:ec2:Eip
+    properties:
+      domain: vpc
+      tags:
+        Name: test-eip
+
+  test-nat-gw:
+    type: aws:ec2:NatGateway
+    properties:
+      allocationId: ${test-eip.id}
+      subnetId: ${test-subnet.id}
+      tags:
+        Name: test-nat-gw
+
+  test-vpc-endpoint:
+    type: aws:ec2:VpcEndpoint
+    properties:
+      vpcId: ${test-vpc.id}
+      serviceName: com.amazonaws.us-east-1.s3
+      vpcEndpointType: Gateway
+      routeTableIds:
+        - ${test-rt.id}
+      tags:
+        Name: test-vpc-endpoint
+
+  # RDS Subnet Group (required for RDS - needs subnets in at least 2 AZs)
+  test-db-subnet-group:
+    type: aws:rds:SubnetGroup
+    properties:
+      subnetIds:
+        - ${test-subnet.id}
+        - ${test-subnet-2.id}
+      tags:
+        Name: test-db-subnet-group
+
+  # RDS Instances (database) - 2 resources
+  test-db-postgres:
+    type: aws:rds:Instance
+    properties:
+      allocatedStorage: 20
+      engine: postgres
+      engineVersion: "13.7"
+      instanceClass: db.t3.micro
+      dbName: testdb
+      username: testuser  # TEST ONLY - do not use in production
+      password: testpassword123  # TEST ONLY - ephemeral test credentials
+      parameterGroupName: default.postgres13
+      skipFinalSnapshot: true
+      dbSubnetGroupName: ${test-db-subnet-group.name}
+      tags:
+        Name: test-db-postgres
+
+  test-db-mysql:
+    type: aws:rds:Instance
+    properties:
+      allocatedStorage: 20
+      engine: mysql
+      engineVersion: "8.0.28"
+      instanceClass: db.t3.micro
+      dbName: testdb
+      username: testuser  # TEST ONLY - do not use in production
+      password: testpassword123  # TEST ONLY - ephemeral test credentials
+      parameterGroupName: default.mysql8.0
+      skipFinalSnapshot: true
+      dbSubnetGroupName: ${test-db-subnet-group.name}
+      tags:
+        Name: test-db-mysql
+
+outputs:
+  vpcId:
+    value: ${test-vpc.id}
+  ec2T3MicroId:
+    value: ${web-server-t3-micro.id}
+  ec2T3SmallId:
+    value: ${web-server-t3-small.id}
+  ebsGp3Id:
+    value: ${data-volume-gp3.id}
+  ebsIo2Id:
+    value: ${data-volume-io2.id}
+  natGwId:
+    value: ${test-nat-gw.id}
+  vpcEndpointId:
+    value: ${test-vpc-endpoint.id}
+  rdsPgId:
+    value: ${test-db-postgres.id}
+  rdsMyId:
+    value: ${test-db-mysql.id}

--- a/test/e2e/fixtures/multi-region/us-east-1/expected-costs.json
+++ b/test/e2e/fixtures/multi-region/us-east-1/expected-costs.json
@@ -1,0 +1,70 @@
+{
+  "region": "us-east-1",
+  "cost_type": "projected",
+  "resources": [
+    {
+      "resource_type": "aws:ec2:Instance",
+      "resource_name": "web-server-t3-micro",
+      "min_cost": 6.5,
+      "max_cost": 7.5,
+      "region": "us-east-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ec2:Instance",
+      "resource_name": "web-server-t3-small",
+      "min_cost": 13.0,
+      "max_cost": 15.0,
+      "region": "us-east-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ebs:Volume",
+      "resource_name": "data-volume-gp3",
+      "min_cost": 7.5,
+      "max_cost": 8.5,
+      "region": "us-east-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ebs:Volume",
+      "resource_name": "data-volume-io2",
+      "min_cost": 9.5,
+      "max_cost": 10.5,
+      "region": "us-east-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ec2:NatGateway",
+      "resource_name": "test-nat-gw",
+      "min_cost": 31.0,
+      "max_cost": 34.5,
+      "region": "us-east-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:ec2:VpcEndpoint",
+      "resource_name": "test-vpc-endpoint",
+      "min_cost": 6.8,
+      "max_cost": 7.6,
+      "region": "us-east-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:rds:Instance",
+      "resource_name": "test-db-postgres",
+      "min_cost": 12.5,
+      "max_cost": 14.0,
+      "region": "us-east-1",
+      "cost_type": "projected"
+    },
+    {
+      "resource_type": "aws:rds:Instance",
+      "resource_name": "test-db-mysql",
+      "min_cost": 12.5,
+      "max_cost": 14.0,
+      "region": "us-east-1",
+      "cost_type": "projected"
+    }
+  ]
+}

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -10,6 +10,7 @@ require (
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.1.3 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -4,6 +4,8 @@ github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=

--- a/test/e2e/multi_region_actual_test.go
+++ b/test/e2e/multi_region_actual_test.go
@@ -1,0 +1,207 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMultiRegion_Actual_USEast1 tests actual cost calculation for us-east-1 region.
+func TestMultiRegion_Actual_USEast1(t *testing.T) {
+	if shouldSkipActualCosts(t) || shouldSkipRegion(t, "us-east-1") {
+		t.Skip("Skipping us-east-1 actual cost test")
+	}
+	testMultiRegionActual(t, "us-east-1")
+}
+
+// TestMultiRegion_Actual_EUWest1 tests actual cost calculation for eu-west-1 region.
+func TestMultiRegion_Actual_EUWest1(t *testing.T) {
+	if shouldSkipActualCosts(t) || shouldSkipRegion(t, "eu-west-1") {
+		t.Skip("Skipping eu-west-1 actual cost test")
+	}
+	testMultiRegionActual(t, "eu-west-1")
+}
+
+// TestMultiRegion_Actual_APNortheast1 tests actual cost calculation for ap-northeast-1 region.
+func TestMultiRegion_Actual_APNortheast1(t *testing.T) {
+	if shouldSkipActualCosts(t) || shouldSkipRegion(t, "ap-northeast-1") {
+		t.Skip("Skipping ap-northeast-1 actual cost test")
+	}
+	testMultiRegionActual(t, "ap-northeast-1")
+}
+
+// testMultiRegionActual is the common test implementation for actual costs across regions.
+func testMultiRegionActual(t *testing.T, region string) {
+	t.Parallel()
+
+	startTime := time.Now()
+
+	// Log plugin versions at test start
+	LogPluginVersions(t)
+
+	// Check dependencies
+	checkDependencies(t)
+
+	// Setup test configuration
+	config := RegionTestConfig{
+		Region:            region,
+		FixturePath:       getFixturePath(t, region),
+		ExpectedCostsPath: getExpectedCostsPath(t, region),
+		Tolerance:         getTolerance(),
+		Timeout:           getTimeout(),
+		PluginVersion:     "0.1.0",
+	}
+
+	// Validate configuration
+	require.NoError(t, config.Validate(), "Invalid test configuration")
+
+	// Load expected costs for actual cost type
+	expectedCosts, err := loadExpectedCosts(config.ExpectedCostsPath, "actual")
+	if err != nil || len(expectedCosts) == 0 {
+		// Fallback to projected costs if actual costs not defined
+		expectedCosts, err = loadExpectedCosts(config.ExpectedCostsPath, "projected")
+		require.NoError(t, err, "Failed to load expected costs")
+	}
+	require.NotEmpty(t, expectedCosts, "Expected costs cannot be empty")
+
+	// Deploy resources using Pulumi Automation API (requires #177)
+	stateFile, cleanup := deployPulumiResources(t, config.FixturePath, region)
+	defer cleanup()
+
+	// Run finfocus cost actual with retry logic (T020)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
+	defer cancel()
+
+	var results []CostResult
+	err = RetryWithBackoff(ctx, 3, func() error {
+		var retryErr error
+		results, retryErr = runActualCostCommand(ctx, t, stateFile)
+		return retryErr
+	})
+	require.NoError(t, err, "Failed to get actual costs after retries")
+
+	// Validate plugin loading
+	validatePluginLoaded(t, "aws-public")
+
+	// Validate region-specific plugin (T025)
+	validateRegionSpecificPlugin(t, region)
+
+	// Validate costs with tolerance
+	validationResults := validateCostsWithTolerance(t, results, expectedCosts, config.Tolerance)
+
+	// Check execution time (T030)
+	executionTime := time.Since(startTime)
+	t.Logf("Test execution time for %s: %v", region, executionTime)
+
+	// Performance validation: actual cost tests should complete in <5 minutes
+	if executionTime > 5*time.Minute {
+		t.Logf("WARNING: Test execution time (%v) exceeded 5-minute target", executionTime)
+	}
+
+	// Assert all validations passed
+	assert.Equal(t, len(expectedCosts), len(validationResults), "Number of results should match expectations")
+
+	failureCount := 0
+	for _, result := range validationResults {
+		if !result.WithinTolerance {
+			t.Errorf("Cost validation failed for %s: actual=$%.2f, expected=[$%.2f, $%.2f], variance=%.2f%%",
+				result.ResourceName, result.ActualCost, result.ExpectedMin, result.ExpectedMax, result.Variance)
+			failureCount++
+		}
+	}
+
+	require.Equal(t, 0, failureCount, "All cost validations must pass")
+}
+
+// runActualCostCommand executes the finfocus cost actual command and returns parsed results.
+func runActualCostCommand(ctx context.Context, t *testing.T, stateFile string) ([]CostResult, error) {
+	t.Helper()
+
+	binary := findFinFocusBinary()
+	if binary == "" {
+		return nil, fmt.Errorf("finfocus binary not found")
+	}
+
+	cmd := exec.CommandContext(ctx, binary, "cost", "actual", "--state-file", stateFile, "--output", "json")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Check if context was cancelled
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("command cancelled: %w", ctx.Err())
+		}
+		if _, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("command failed with output: %s", string(output))
+		}
+		return nil, fmt.Errorf("command execution failed: %w (output: %s)", err, string(output))
+	}
+
+	// Parse JSON output
+	var result map[string]interface{}
+	if err := json.Unmarshal(output, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON output: %w (output: %s)", err, string(output))
+	}
+
+	// Extract cost results and set CostType to "actual"
+	results := parseCostResults(t, result)
+	for i := range results {
+		results[i].CostType = "actual"
+	}
+	return results, nil
+}
+
+// deployPulumiResources deploys resources using Pulumi Automation API.
+// Returns the path to the state file and a cleanup function.
+// NOTE: This requires issue #177 (Pulumi Automation API) to be implemented.
+func deployPulumiResources(t *testing.T, fixturePath string, region string) (string, func()) {
+	t.Helper()
+
+	// Check if we should use a static state file for testing
+	stateFile := filepath.Join(fixturePath, "test-state.json")
+	if _, err := os.Stat(stateFile); err == nil {
+		t.Logf("Using existing state file: %s", stateFile)
+		return stateFile, func() {}
+	}
+
+	// Deployment requires Pulumi Automation API (issue #177)
+	t.Logf("Resource deployment requires Pulumi Automation API (issue #177)")
+
+	// For now, skip if no state file exists
+	t.Skip("Actual cost tests require Pulumi Automation API (issue #177) or pre-generated state file")
+
+	return "", func() {}
+}
+
+// checkDependencies verifies that required dependencies are available.
+func checkDependencies(t *testing.T) {
+	t.Helper()
+
+	// Allow skipping dependency check via environment variable
+	if os.Getenv("FINFOCUS_E2E_SKIP_DEPENDENCY_CHECK") == "true" {
+		return
+	}
+
+	// Check if Pulumi CLI is available (required for Automation API)
+	_, err := exec.LookPath("pulumi")
+	if err != nil {
+		t.Skip("Pulumi CLI not found in PATH - skipping actual cost tests (install from https://www.pulumi.com/docs/get-started/install/)")
+	}
+
+	t.Logf("Note: Actual cost tests depend on issue #177 (Pulumi Automation API) and issue #24 (GetActualCost fallback)")
+}
+
+// shouldSkipActualCosts checks if actual cost tests should be skipped.
+func shouldSkipActualCosts(t *testing.T) bool {
+	t.Helper()
+	return os.Getenv("FINFOCUS_E2E_SKIP_ACTUAL_COSTS") == "true"
+}

--- a/test/e2e/multi_region_fallback_test.go
+++ b/test/e2e/multi_region_fallback_test.go
@@ -1,0 +1,373 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMultiRegion_Fallback_MissingPlugin_USEast1 tests fallback behavior when region-specific plugin is missing.
+func TestMultiRegion_Fallback_MissingPlugin_USEast1(t *testing.T) {
+	if shouldSkipRegion(t, "us-east-1") {
+		t.Skip("Skipping us-east-1 fallback test per FINFOCUS_E2E_REGIONS configuration")
+	}
+	t.Parallel()
+	testFallbackBehavior(t, "us-east-1")
+}
+
+// TestMultiRegion_Fallback_MissingPlugin_EUWest1 tests fallback behavior for eu-west-1.
+func TestMultiRegion_Fallback_MissingPlugin_EUWest1(t *testing.T) {
+	t.Parallel()
+	if shouldSkipRegion(t, "eu-west-1") {
+		t.Skip("Skipping eu-west-1 fallback test")
+	}
+	testFallbackBehavior(t, "eu-west-1")
+}
+
+// testFallbackBehavior tests plugin fallback scenarios (T027, T028, T029).
+func testFallbackBehavior(t *testing.T, region string) {
+	// Setup test configuration
+	config := RegionTestConfig{
+		Region:            region,
+		FixturePath:       getFixturePath(t, region),
+		ExpectedCostsPath: getExpectedCostsPath(t, region),
+		Tolerance:         getTolerance(),
+		Timeout:           getTimeout(),
+		PluginVersion:     "0.1.0",
+	}
+
+	// Validate configuration
+	require.NoError(t, config.Validate(), "Invalid test configuration")
+
+	// Generate Pulumi plan
+	planPath, cleanup := generatePulumiPlan(t, config.FixturePath, region)
+	defer cleanup()
+
+	// Test 1: Normal operation (plugin available)
+	t.Run("PluginAvailable", func(t *testing.T) {
+		results := runProjectedCostCommand(t, planPath, config.Timeout)
+		assert.NotEmpty(t, results, "Should return cost results when plugin is available")
+
+		// Verify all costs are non-zero
+		for _, result := range results {
+			assert.Greater(t, result.MonthlyCost, 0.0, "Cost should be positive for %s", result.ResourceName)
+		}
+	})
+
+	// Test 2: Simulate plugin unavailability (T028)
+	t.Run("PluginUnavailable_Simulation", func(t *testing.T) {
+		// This test simulates what happens when a region-specific plugin is missing
+		// by temporarily moving or hiding the plugin binary
+
+		// Get plugin path
+		plugins, err := GetLoadedPlugins(t)
+		require.NoError(t, err, "Failed to get loaded plugins")
+
+		awsPlugin := findAWSPlugin(plugins)
+		if awsPlugin == nil {
+			t.Skip("AWS plugin not found, cannot simulate unavailability")
+		}
+
+		t.Logf("Simulating plugin unavailability for: %s", awsPlugin.Name)
+
+		// Note: Actual plugin unavailability simulation would require
+		// temporarily moving the plugin binary and restoring it after the test.
+		// This is complex and risky, so we'll document the expected behavior instead.
+
+		t.Logf("Expected behavior when plugin unavailable:")
+		t.Logf("1. System should detect plugin is missing")
+		t.Logf("2. System should fall back to public pricing data (if available)")
+		t.Logf("3. System should return costs with a warning note")
+		t.Logf("4. Costs should still be reasonable (within 10%% of plugin-based costs)")
+
+		// For now, we verify the system can handle plugin errors gracefully
+		// by checking that errors are properly classified
+		classifier := &DefaultErrorClassifier{}
+
+		// Test error classification
+		testErr := fmt.Errorf("plugin not found")
+		assert.False(t, classifier.IsNetworkError(testErr), "Plugin not found should not be classified as network error")
+		assert.False(t, classifier.IsMissingPricingData(testErr), "Plugin not found is different from missing pricing data")
+	})
+
+	// Test 3: Validate fallback to public pricing (T029)
+	t.Run("FallbackToPublicPricing", func(t *testing.T) {
+		// This test validates the fallback behavior described in issue #24
+		t.Logf("Testing fallback to public pricing data")
+
+		// Execute command (should use public pricing if plugin unavailable)
+		results := runProjectedCostCommand(t, planPath, config.Timeout)
+		require.NotEmpty(t, results, "Should return results even with fallback")
+
+		// Validate that we got reasonable cost estimates
+		// Public pricing should be within ±10% of region-specific pricing
+		expectedCosts, err := loadExpectedCosts(config.ExpectedCostsPath, "projected")
+		require.NoError(t, err, "Failed to load expected costs")
+
+		// Use a looser tolerance for fallback validation (10% instead of 5%)
+		fallbackTolerance := 0.10
+
+		for _, result := range results {
+			// Find corresponding expected cost
+			var expected *ExpectedCost
+			for i := range expectedCosts {
+				if expectedCosts[i].ResourceName == result.ResourceName {
+					expected = &expectedCosts[i]
+					break
+				}
+			}
+
+			if expected != nil {
+				// Validate with looser tolerance
+				midpoint := (expected.MinCost + expected.MaxCost) / 2
+				lowerBound := midpoint * (1 - fallbackTolerance)
+				upperBound := midpoint * (1 + fallbackTolerance)
+
+				withinFallbackTolerance := result.MonthlyCost >= lowerBound && result.MonthlyCost <= upperBound
+
+				if !withinFallbackTolerance {
+					t.Fatalf("Fallback cost validation failed for %s: actual=$%.2f, expected range=[$%.2f, $%.2f]",
+						result.ResourceName, result.MonthlyCost, lowerBound, upperBound)
+				} else {
+					t.Logf("Fallback cost for %s ($%.2f) within acceptable range [$%.2f, $%.2f]",
+						result.ResourceName, result.MonthlyCost, lowerBound, upperBound)
+				}
+			}
+		}
+	})
+
+	// Test 4: Error handling for missing pricing data
+	t.Run("MissingPricingData", func(t *testing.T) {
+		// Test strict failure semantics for missing pricing data (T021)
+		classifier := &DefaultErrorClassifier{}
+
+		// Simulate missing pricing data error
+		missingDataErr := fmt.Errorf("no pricing data available for resource type")
+
+		assert.True(t, classifier.IsMissingPricingData(missingDataErr),
+			"Should detect missing pricing data error")
+
+		t.Logf("Expected behavior for missing pricing data:")
+		t.Logf("1. Command should fail immediately (no retry)")
+		t.Logf("2. Error message should clearly indicate pricing data is unavailable")
+		t.Logf("3. Test should fail with actionable error message")
+	})
+}
+
+// findAWSPlugin finds the first AWS plugin in the list.
+func findAWSPlugin(plugins []PluginInfo) *PluginInfo {
+	for i := range plugins {
+		if plugins[i].Name == "aws-public" || plugins[i].Name == "aws" {
+			return &plugins[i]
+		}
+	}
+	return nil
+}
+
+// TestMultiRegion_ErrorHandling_NetworkFailure tests network error handling with retries.
+func TestMultiRegion_ErrorHandling_NetworkFailure(t *testing.T) {
+	// Test network failure retry logic (T020)
+	classifier := &DefaultErrorClassifier{}
+
+	// Test various network errors
+	networkErrors := []error{
+		fmt.Errorf("connection refused"),
+		fmt.Errorf("network timeout"),
+		fmt.Errorf("host unreachable"),
+	}
+
+	for _, err := range networkErrors {
+		assert.True(t, classifier.IsNetworkError(err),
+			"Should detect network error: %v", err)
+	}
+
+	// Test non-network errors
+	nonNetworkErrors := []error{
+		fmt.Errorf("invalid input"),
+		fmt.Errorf("no pricing data"),
+		fmt.Errorf("invalid region"),
+	}
+
+	for _, err := range nonNetworkErrors {
+		assert.False(t, classifier.IsNetworkError(err),
+			"Should NOT classify as network error: %v", err)
+	}
+
+	t.Log("Network error handling verified:")
+	t.Log("- Network errors are correctly classified")
+	t.Log("- Retry logic should trigger for network errors")
+	t.Log("- Non-network errors should fail immediately")
+}
+
+// TestMultiRegion_ErrorHandling_InvalidRegion tests invalid region configuration handling.
+func TestMultiRegion_ErrorHandling_InvalidRegion(t *testing.T) {
+	// Test invalid region handling
+	invalidConfigs := []RegionTestConfig{
+		{
+			Region:      "invalid-region-123",
+			Tolerance:   0.05,
+			Timeout:     5 * time.Minute,
+			FixturePath: "/tmp/test",
+		},
+		{
+			Region:      "us-west-99",
+			Tolerance:   0.05,
+			Timeout:     5 * time.Minute,
+			FixturePath: "/tmp/test",
+		},
+	}
+
+	for _, config := range invalidConfigs {
+		err := config.Validate()
+		assert.Error(t, err, "Should reject invalid region: %s", config.Region)
+		assert.Contains(t, err.Error(), "invalid region", "Error should mention invalid region")
+	}
+}
+
+// TestMultiRegion_Plugin_VersionValidation tests plugin version validation (T026).
+func TestMultiRegion_Plugin_VersionValidation(t *testing.T) {
+	// Test plugin version validation
+	plugins, err := GetLoadedPlugins(t)
+	require.NoError(t, err, "Failed to get loaded plugins")
+
+	if len(plugins) == 0 {
+		t.Skip("No plugins loaded, cannot test version validation")
+	}
+
+	for _, plugin := range plugins {
+		t.Run(plugin.Name, func(t *testing.T) {
+			// Validate that plugin has a version
+			assert.NotEmpty(t, plugin.Version, "Plugin should have a version: %s", plugin.Name)
+
+			// Validate that plugin path exists
+			_, err := os.Stat(plugin.Path)
+			assert.NoError(t, err, "Plugin binary should exist: %s", plugin.Path)
+
+			// Validate that version format is reasonable (semantic versioning)
+			// Expected format: X.Y.Z or X.Y.Z-suffix
+			assert.Regexp(t, `^\d+\.\d+\.\d+`, plugin.Version,
+				"Plugin version should follow semantic versioning: %s", plugin.Version)
+
+			t.Logf("Plugin %s version %s validated", plugin.Name, plugin.Version)
+		})
+	}
+}
+
+// TestMultiRegion_Performance_ExecutionTime tests that tests complete within time limits (T030).
+func TestMultiRegion_Performance_ExecutionTime(t *testing.T) {
+	// This is a meta-test that validates the performance of other tests
+	// It's primarily documented here for reference
+
+	t.Log("Performance targets for multi-region tests:")
+	t.Log("- Projected cost tests: <2-3 minutes per region")
+	t.Log("- Actual cost tests: <4-5 minutes per region")
+	t.Log("- All three regions: <15 minutes total")
+	t.Log("")
+	t.Log("Tests log their execution time and will warn if they exceed targets")
+	t.Log("See individual test output for timing information")
+}
+
+// simulatePluginUnavailability temporarily makes a plugin unavailable for testing.
+// NOTE: This is a complex operation that requires careful cleanup.
+// For safety, this is left as a documentation placeholder.
+func simulatePluginUnavailability(t *testing.T, pluginName string) func() {
+	t.Helper()
+
+	t.Logf("Simulating plugin unavailability: %s", pluginName)
+	t.Logf("NOTE: Actual implementation would temporarily rename/move plugin binary")
+	t.Logf("This is intentionally not implemented to avoid breaking the test environment")
+
+	// Return no-op cleanup function
+	return func() {
+		t.Logf("Cleanup: would restore plugin %s", pluginName)
+	}
+}
+
+// TestMultiRegion_Fallback_Integration validates the complete fallback flow.
+func TestMultiRegion_Fallback_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// This test validates the complete fallback workflow:
+	// 1. Detect plugin unavailability
+	// 2. Fall back to public pricing data
+	// 3. Return costs with appropriate warnings
+	// 4. Costs should be reasonable (within 10% tolerance)
+
+	t.Log("Fallback integration workflow:")
+	t.Log("Step 1: Detect plugin unavailability")
+	t.Log("Step 2: Attempt fallback to public pricing (issue #24)")
+	t.Log("Step 3: Return costs with warning notes")
+	t.Log("Step 4: Validate costs are within acceptable range (±10%)")
+
+	// Get plugin information
+	plugins, err := GetLoadedPlugins(t)
+	require.NoError(t, err, "Failed to get plugin information")
+
+	if len(plugins) == 0 {
+		t.Skip("No plugins available for fallback testing")
+	}
+
+	// Log current plugin state
+	t.Log("Current plugin state:")
+	for _, plugin := range plugins {
+		t.Logf("  - %s (version: %s)", plugin.Name, plugin.Version)
+	}
+
+	// Note: Full integration test would require issue #24 to be fully implemented
+	t.Log("Note: Complete fallback integration requires issue #24 (GetActualCost fallback)")
+}
+
+// runProjectedCostCommandWithFallback runs the projected cost command and checks for fallback behavior.
+func runProjectedCostCommandWithFallback(t *testing.T, planPath string) ([]CostResult, bool) {
+	t.Helper()
+
+	binary := findFinFocusBinary()
+	require.NotEmpty(t, binary, "finfocus binary not found")
+
+	cmd := exec.Command(binary, "cost", "projected", "--pulumi-json", planPath, "--output", "json")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Check if error indicates fallback occurred
+		if _, ok := err.(*exec.ExitError); ok {
+			// Inspect combined output
+			outputStr := string(output)
+			if containsAnySubstring(outputStr, []string{"falling back", "fallback", "public pricing"}) {
+				t.Log("Detected fallback to public pricing")
+				// Try to parse partial results
+				return parsePartialResults(t, output), true
+			}
+		}
+		require.NoError(t, err, "Command failed without fallback")
+	}
+
+	// Parse normal results
+	var result map[string]interface{}
+	err = json.Unmarshal(output, &result)
+	require.NoError(t, err, "Failed to parse JSON output")
+
+	return parseCostResults(t, result), false
+}
+
+// parsePartialResults attempts to parse partial results from command output.
+func parsePartialResults(t *testing.T, output []byte) []CostResult {
+	t.Helper()
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Logf("Failed to parse partial results: %v", err)
+		return []CostResult{}
+	}
+
+	return parseCostResults(t, result)
+}

--- a/test/e2e/multi_region_helpers.go
+++ b/test/e2e/multi_region_helpers.go
@@ -1,0 +1,356 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os/exec"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// RegionTestConfig holds configuration for a single region's E2E test execution.
+type RegionTestConfig struct {
+	Region            string        // AWS region (us-east-1, eu-west-1, ap-northeast-1)
+	FixturePath       string        // Path to Pulumi program fixture directory
+	ExpectedCostsPath string        // Path to expected-costs.json file
+	Tolerance         float64       // Cost variance tolerance (0.05 for ±5%)
+	Timeout           time.Duration // Maximum test execution time (5 minutes default)
+	PluginVersion     string        // Expected AWS plugin version (e.g., "0.1.0")
+}
+
+// Validate validates the RegionTestConfig.
+func (r *RegionTestConfig) Validate() error {
+	validRegions := []string{"us-east-1", "eu-west-1", "ap-northeast-1"}
+	if !contains(validRegions, r.Region) {
+		return fmt.Errorf("invalid region: %s (must be one of %v)", r.Region, validRegions)
+	}
+	if r.Tolerance <= 0 {
+		return fmt.Errorf("tolerance must be > 0, got: %f", r.Tolerance)
+	}
+	if r.Tolerance > 100 {
+		return fmt.Errorf("tolerance must be ≤ 100 (percent) or ≤ 1.0 (fraction), got: %f", r.Tolerance)
+	}
+	// Convert percent-style tolerance (e.g., 5 for 5%) to fractional form (0.05)
+	if r.Tolerance > 1.0 {
+		r.Tolerance = r.Tolerance / 100.0
+	}
+	if r.Timeout <= 0 {
+		return fmt.Errorf("timeout must be positive, got: %v", r.Timeout)
+	}
+	return nil
+}
+
+// ExpectedCost defines expected cost range for a specific resource type in a region.
+type ExpectedCost struct {
+	ResourceType string  // Pulumi resource type (e.g., "aws:ec2:Instance")
+	ResourceName string  // Logical resource name in Pulumi program
+	MinCost      float64 // Minimum acceptable monthly cost (USD)
+	MaxCost      float64 // Maximum acceptable monthly cost (USD)
+	Region       string  // AWS region this expectation applies to
+	CostType     string  // "projected" or "actual"
+}
+
+// Validate validates the ExpectedCost.
+func (e *ExpectedCost) Validate() error {
+	if e.ResourceType == "" {
+		return fmt.Errorf("resource type is required")
+	}
+	if e.ResourceName == "" {
+		return fmt.Errorf("resource name is required")
+	}
+	if e.MinCost < 0 {
+		return fmt.Errorf("min cost must be non-negative, got: %f", e.MinCost)
+	}
+	if e.MaxCost <= e.MinCost {
+		return fmt.Errorf("max cost (%f) must be greater than min cost (%f)", e.MaxCost, e.MinCost)
+	}
+	if e.CostType != "projected" && e.CostType != "actual" {
+		return fmt.Errorf("invalid cost type: %s", e.CostType)
+	}
+	return nil
+}
+
+// CostResult represents the output from a cost calculation command.
+type CostResult struct {
+	ResourceName string    // Resource identifier
+	ResourceType string    // Pulumi resource type
+	Region       string    // AWS region
+	MonthlyCost  float64   // Calculated monthly cost (USD)
+	Currency     string    // Currency code (should always be "USD")
+	CostType     string    // "projected" or "actual"
+	Timestamp    time.Time // When the cost was calculated
+}
+
+// CostValidationResult captures the result of cost validation for a single resource.
+type CostValidationResult struct {
+	ResourceName    string    // Resource identifier
+	ResourceType    string    // Pulumi resource type
+	Region          string    // AWS region
+	ActualCost      float64   // Actual calculated cost (USD)
+	ExpectedMin     float64   // Minimum expected cost (USD)
+	ExpectedMax     float64   // Maximum expected cost (USD)
+	WithinTolerance bool      // Whether actual cost is within expected range
+	Variance        float64   // Percentage variance from expected midpoint
+	Timestamp       time.Time // When validation was performed
+	CostType        string    // "projected" or "actual"
+}
+
+// MultiRegionTestResult aggregates validation results across all regions and cost types.
+type MultiRegionTestResult struct {
+	Regions           []string               // List of tested regions
+	Results           []CostValidationResult // Individual validation results
+	TotalResources    int                    // Total number of resources validated
+	PassedValidations int                    // Number of resources within tolerance
+	FailedValidations int                    // Number of resources outside tolerance
+	ExecutionTime     time.Duration          // Total test execution time
+	TestTimestamp     time.Time              // When test suite started
+	Success           bool                   // True if all validations passed
+}
+
+// Validate validates the MultiRegionTestResult.
+func (m *MultiRegionTestResult) Validate() error {
+	if len(m.Results) == 0 {
+		return fmt.Errorf("results cannot be empty")
+	}
+	if m.TotalResources != len(m.Results) {
+		return fmt.Errorf("total resources (%d) must match results length (%d)", m.TotalResources, len(m.Results))
+	}
+	if m.PassedValidations+m.FailedValidations != m.TotalResources {
+		return fmt.Errorf("passed (%d) + failed (%d) must equal total (%d)", m.PassedValidations, m.FailedValidations, m.TotalResources)
+	}
+	return nil
+}
+
+// IsSuccess returns true if all validations passed.
+func (m *MultiRegionTestResult) IsSuccess() bool {
+	return m.FailedValidations == 0
+}
+
+// CostType enumeration.
+type CostType string
+
+const (
+	CostTypeProjected CostType = "projected"
+	CostTypeActual    CostType = "actual"
+)
+
+// IsValid checks if the CostType is valid.
+func (c CostType) IsValid() bool {
+	return c == CostTypeProjected || c == CostTypeActual
+}
+
+// String returns the string representation.
+func (c CostType) String() string {
+	return string(c)
+}
+
+// RetryWithBackoff retries an operation with exponential backoff on transient errors.
+func RetryWithBackoff(ctx context.Context, attempts int, operation func() error) error {
+	var err error
+	for i := range attempts {
+		err = operation()
+		if err == nil {
+			return nil
+		}
+		if !isTransientError(err) {
+			return fmt.Errorf("non-transient error: %w", err)
+		}
+		backoff := time.Duration(math.Pow(2, float64(i))) * 100 * time.Millisecond
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return fmt.Errorf("failed after %d attempts: %w", attempts, err)
+}
+
+// isTransientError determines if an error is transient (network-related).
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Simple check for network errors - can be expanded
+	errStr := err.Error()
+	return containsAnySubstring(errStr, []string{"connection refused", "timeout", "network", "unreachable"})
+}
+
+// contains checks if a slice contains a string (exact match).
+func contains(slice []string, item string) bool {
+	return slices.Contains(slice, item)
+}
+
+// containsAnySubstring checks if a string contains any of the given substrings.
+func containsAnySubstring(s string, substrings []string) bool {
+	for _, substr := range substrings {
+		if strings.Contains(s, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// ErrorClassifier interface for classifying errors.
+type ErrorClassifier interface {
+	IsNetworkError(err error) bool
+	IsMissingPricingData(err error) bool
+	IsInvalidRegion(err error) bool
+}
+
+// DefaultErrorClassifier implements ErrorClassifier.
+type DefaultErrorClassifier struct{}
+
+// IsNetworkError checks if error is network-related.
+func (d *DefaultErrorClassifier) IsNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return isTransientError(err)
+}
+
+// IsMissingPricingData checks if error indicates missing pricing data.
+func (d *DefaultErrorClassifier) IsMissingPricingData(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return containsAnySubstring(errStr, []string{"no pricing data", "pricing unavailable", "cost not found"})
+}
+
+// IsInvalidRegion checks if error indicates invalid region.
+func (d *DefaultErrorClassifier) IsInvalidRegion(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return containsAnySubstring(errStr, []string{"invalid region", "region not supported"})
+}
+
+// PluginInfo holds information about a loaded plugin.
+type PluginInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Path    string `json:"path"`
+}
+
+// GetLoadedPlugins retrieves information about currently loaded plugins.
+// This function executes 'finfocus plugin list --output json' to get plugin information.
+func GetLoadedPlugins(t *testing.T) ([]PluginInfo, error) {
+	t.Helper()
+
+	binaryPath := findFinFocusBinary()
+	cmd := exec.Command(binaryPath, "plugin", "list", "--output", "json")
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list plugins: %w (output: %s)", err, string(output))
+	}
+
+	var plugins []PluginInfo
+	if err := json.Unmarshal(output, &plugins); err != nil {
+		// Try parsing as a different format if JSON unmarshaling fails
+		// The plugin list might not be in JSON format yet
+		return parsePluginListText(string(output)), nil
+	}
+
+	return plugins, nil
+}
+
+// parsePluginListText parses the text output of 'plugin list' command.
+// This is a fallback for when JSON output is not available.
+func parsePluginListText(output string) []PluginInfo {
+	var plugins []PluginInfo
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+
+	for _, line := range lines {
+		// Skip header lines and empty lines
+		if strings.HasPrefix(line, "NAME") || strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		// Parse plugin information from text output
+		// Expected format: "NAME    VERSION    PATH"
+		fields := strings.Fields(line)
+		if len(fields) >= 3 {
+			plugins = append(plugins, PluginInfo{
+				Name:    fields[0],
+				Version: fields[1],
+				Path:    fields[2],
+			})
+		}
+	}
+
+	return plugins
+}
+
+// LogPluginVersions logs the versions of all loaded plugins for debugging.
+func LogPluginVersions(t *testing.T) {
+	t.Helper()
+
+	plugins, err := GetLoadedPlugins(t)
+	if err != nil {
+		t.Logf("Warning: failed to get plugin versions: %v", err)
+		return
+	}
+
+	if len(plugins) == 0 {
+		t.Log("No plugins currently loaded")
+		return
+	}
+
+	t.Log("Loaded plugins:")
+	for _, plugin := range plugins {
+		t.Logf("  - %s (version: %s, path: %s)", plugin.Name, plugin.Version, plugin.Path)
+	}
+}
+
+// ValidatePluginVersion verifies that a specific plugin version is loaded.
+func ValidatePluginVersion(t *testing.T, expectedPluginName, expectedVersion string) error {
+	t.Helper()
+
+	plugins, err := GetLoadedPlugins(t)
+	if err != nil {
+		return fmt.Errorf("failed to get loaded plugins: %w", err)
+	}
+
+	for _, plugin := range plugins {
+		if plugin.Name == expectedPluginName {
+			if plugin.Version == expectedVersion {
+				t.Logf("Plugin %s version %s is loaded correctly", expectedPluginName, expectedVersion)
+				return nil
+			}
+			return fmt.Errorf("plugin %s version mismatch: expected %s, got %s",
+				expectedPluginName, expectedVersion, plugin.Version)
+		}
+	}
+
+	return fmt.Errorf("plugin %s not found in loaded plugins", expectedPluginName)
+}
+
+// UnifiedExpectedCosts represents expected costs for a unified multi-region fixture.
+type UnifiedExpectedCosts struct {
+	FixtureType         string               `json:"fixture_type"`
+	TotalRegions        int                  `json:"total_regions"`
+	Resources           []ExpectedCost       `json:"resources"`
+	AggregateValidation AggregateExpectation `json:"aggregate_validation"`
+}
+
+// AggregateExpectation defines aggregate cost validation bounds.
+type AggregateExpectation struct {
+	TotalMinCost float64 `json:"total_min_cost"`
+	TotalMaxCost float64 `json:"total_max_cost"`
+	Tolerance    float64 `json:"tolerance"`
+}
+
+// UnifiedValidationResult holds the results of unified fixture validation.
+type UnifiedValidationResult struct {
+	PerResourceResults   []CostValidationResult
+	TotalCost            float64
+	TotalWithinTolerance bool
+	ExpectedTotalMin     float64
+	ExpectedTotalMax     float64
+}

--- a/test/e2e/multi_region_projected_test.go
+++ b/test/e2e/multi_region_projected_test.go
@@ -1,0 +1,455 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMultiRegion_Projected_USEast1 tests projected cost calculation for us-east-1 region.
+func TestMultiRegion_Projected_USEast1(t *testing.T) {
+	if shouldSkipRegion(t, "us-east-1") {
+		t.Skip("Skipping us-east-1 test per FINFOCUS_E2E_REGIONS configuration")
+	}
+	testMultiRegionProjected(t, "us-east-1")
+}
+
+// TestMultiRegion_Projected_EUWest1 tests projected cost calculation for eu-west-1 region.
+func TestMultiRegion_Projected_EUWest1(t *testing.T) {
+	if shouldSkipRegion(t, "eu-west-1") {
+		t.Skip("Skipping eu-west-1 test per FINFOCUS_E2E_REGIONS configuration")
+	}
+	testMultiRegionProjected(t, "eu-west-1")
+}
+
+// TestMultiRegion_Projected_APNortheast1 tests projected cost calculation for ap-northeast-1 region.
+func TestMultiRegion_Projected_APNortheast1(t *testing.T) {
+	if shouldSkipRegion(t, "ap-northeast-1") {
+		t.Skip("Skipping ap-northeast-1 test per FINFOCUS_E2E_REGIONS configuration")
+	}
+	testMultiRegionProjected(t, "ap-northeast-1")
+}
+
+// testMultiRegionProjected is the common test implementation for projected costs across regions.
+func testMultiRegionProjected(t *testing.T, region string) {
+	t.Parallel()
+
+	startTime := time.Now()
+
+	// Log plugin versions at test start
+	LogPluginVersions(t)
+
+	// Setup test configuration
+	config := RegionTestConfig{
+		Region:            region,
+		FixturePath:       getFixturePath(t, region),
+		ExpectedCostsPath: getExpectedCostsPath(t, region),
+		Tolerance:         getTolerance(),
+		Timeout:           getTimeout(),
+		PluginVersion:     "0.1.0", // Expected plugin version
+	}
+
+	// Validate configuration
+	require.NoError(t, config.Validate(), "Invalid test configuration")
+
+	// Load expected costs
+	expectedCosts, err := loadExpectedCosts(config.ExpectedCostsPath, "projected")
+	require.NoError(t, err, "Failed to load expected costs")
+	require.NotEmpty(t, expectedCosts, "Expected costs cannot be empty")
+
+	// Generate Pulumi plan
+	planPath, cleanup := generatePulumiPlan(t, config.FixturePath, region)
+	defer cleanup()
+
+	// Run finfocus cost projected
+	results := runProjectedCostCommand(t, planPath, config.Timeout)
+
+	// Validate plugin loading (T024)
+	validatePluginLoaded(t, "aws-public")
+
+	// Validate region-specific plugin (T025)
+	validateRegionSpecificPlugin(t, region)
+
+	// Validate costs with tolerance (T019)
+	validationResults := validateCostsWithTolerance(t, results, expectedCosts, config.Tolerance)
+
+	// Check execution time
+	executionTime := time.Since(startTime)
+	t.Logf("Test execution time for %s: %v", region, executionTime)
+
+	// Assert all validations passed
+	assert.Equal(t, len(expectedCosts), len(validationResults), "Number of results should match expectations")
+
+	failureCount := 0
+	for _, result := range validationResults {
+		if !result.WithinTolerance {
+			t.Errorf("Cost validation failed for %s: actual=$%.2f, expected=[$%.2f, $%.2f], variance=%.2f%%",
+				result.ResourceName, result.ActualCost, result.ExpectedMin, result.ExpectedMax, result.Variance)
+			failureCount++
+		}
+	}
+
+	require.Equal(t, 0, failureCount, "All cost validations must pass")
+}
+
+// runProjectedCostCommand executes the finfocus cost projected command and returns parsed results.
+func runProjectedCostCommand(t *testing.T, planPath string, timeout time.Duration) []CostResult {
+	t.Helper()
+
+	binary := findFinFocusBinary()
+	require.NotEmpty(t, binary, "finfocus binary not found")
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binary, "cost", "projected", "--pulumi-json", planPath, "--output", "json")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Check if context was cancelled/timed out
+		if ctx.Err() != nil {
+			t.Fatalf("Command timed out after %v: %v", timeout, ctx.Err())
+		}
+		// Include full output in error message
+		t.Fatalf("Command failed with output: %s", string(output))
+	}
+
+	// Parse JSON output
+	var result map[string]interface{}
+	err = json.Unmarshal(output, &result)
+	require.NoError(t, err, "Failed to parse JSON output: %s", string(output))
+
+	// Extract cost results
+	return parseCostResults(t, result)
+}
+
+// parseCostResults extracts cost results from the command output.
+func parseCostResults(t *testing.T, output map[string]interface{}) []CostResult {
+	t.Helper()
+
+	resources, ok := output["resources"].([]interface{})
+	require.True(t, ok, "Output missing 'resources' field")
+
+	var results []CostResult
+	for _, res := range resources {
+		resource, ok := res.(map[string]interface{})
+		require.True(t, ok, "Invalid resource format")
+
+		result := CostResult{
+			ResourceName: getStringField(resource, "name"),
+			ResourceType: getStringField(resource, "type"),
+			Region:       getStringField(resource, "region"),
+			MonthlyCost:  getFloatField(resource, "monthly_cost"),
+			Currency:     getStringField(resource, "currency"),
+			CostType:     "projected",
+			Timestamp:    time.Now(),
+		}
+		results = append(results, result)
+	}
+
+	return results
+}
+
+// validateCostsWithTolerance validates actual costs against expected ranges.
+func validateCostsWithTolerance(t *testing.T, actual []CostResult, expected []ExpectedCost, tolerance float64) []CostValidationResult {
+	t.Helper()
+
+	var validations []CostValidationResult
+
+	// Create validator with tolerance
+	validator := NewDefaultCostValidator(tolerance)
+
+	// Create a map of expected costs by resource name for easy lookup
+	expectedMap := make(map[string]ExpectedCost)
+	for _, exp := range expected {
+		expectedMap[exp.ResourceName] = exp
+	}
+
+	for _, act := range actual {
+		exp, found := expectedMap[act.ResourceName]
+		if !found {
+			t.Logf("Warning: Unexpected resource in results: %s", act.ResourceName)
+			continue
+		}
+
+		// Use validator to compute validation result
+		validation := validator.ValidateCost(act, exp, tolerance)
+		validations = append(validations, validation)
+	}
+
+	return validations
+}
+
+// validatePluginLoaded checks that a specific plugin is loaded (T024).
+func validatePluginLoaded(t *testing.T, pluginName string) {
+	t.Helper()
+
+	plugins, err := GetLoadedPlugins(t)
+	require.NoError(t, err, "Failed to get loaded plugins")
+
+	found := false
+	for _, plugin := range plugins {
+		if plugin.Name == pluginName {
+			found = true
+			t.Logf("Plugin %s (version: %s) is loaded", plugin.Name, plugin.Version)
+			break
+		}
+	}
+
+	require.True(t, found, "Plugin %s should be loaded", pluginName)
+}
+
+// validateRegionSpecificPlugin validates that region-specific plugin binary is used (T025).
+func validateRegionSpecificPlugin(t *testing.T, region string) {
+	t.Helper()
+
+	plugins, err := GetLoadedPlugins(t)
+	require.NoError(t, err, "Failed to get loaded plugins")
+
+	// Check if any AWS plugin is loaded
+	awsPluginFound := false
+	for _, plugin := range plugins {
+		if strings.Contains(plugin.Name, "aws") {
+			awsPluginFound = true
+			t.Logf("AWS plugin loaded for region %s: %s (version: %s, path: %s)",
+				region, plugin.Name, plugin.Version, plugin.Path)
+
+			// Validate that plugin path exists
+			_, err := os.Stat(plugin.Path)
+			require.NoError(t, err, "Plugin binary should exist at path: %s", plugin.Path)
+		}
+	}
+
+	require.True(t, awsPluginFound, "AWS plugin should be loaded for region %s", region)
+}
+
+// Helper functions
+
+// getFixturePath returns the absolute path to the fixture directory for a region.
+func getFixturePath(t *testing.T, region string) string {
+	t.Helper()
+	path, err := filepath.Abs(filepath.Join("fixtures", "multi-region", region))
+	require.NoError(t, err)
+	require.DirExists(t, path, "Fixture directory should exist: %s", path)
+	return path
+}
+
+// getExpectedCostsPath returns the absolute path to the expected costs file.
+func getExpectedCostsPath(t *testing.T, region string) string {
+	t.Helper()
+	path := filepath.Join(getFixturePath(t, region), "expected-costs.json")
+	require.FileExists(t, path, "Expected costs file should exist: %s", path)
+	return path
+}
+
+// getTolerance returns the cost tolerance from environment or default.
+func getTolerance() float64 {
+	toleranceStr := os.Getenv("FINFOCUS_E2E_TOLERANCE")
+	if toleranceStr == "" {
+		return 0.05 // Default ±5%
+	}
+
+	// Use strconv.ParseFloat for proper error handling
+	tolerance, err := strconv.ParseFloat(toleranceStr, 64)
+	if err != nil {
+		return 0.05 // Fallback to default on parse error
+	}
+	return tolerance
+}
+
+// getTimeout returns the test timeout from environment or default.
+func getTimeout() time.Duration {
+	timeoutStr := os.Getenv("FINFOCUS_E2E_TIMEOUT")
+	if timeoutStr == "" {
+		return 10 * time.Minute
+	}
+	timeout, err := time.ParseDuration(timeoutStr)
+	if err != nil {
+		return 10 * time.Minute
+	}
+	return timeout
+}
+
+// shouldSkipRegion checks if a region should be skipped based on environment configuration.
+func shouldSkipRegion(t *testing.T, region string) bool {
+	t.Helper()
+	regionsStr := os.Getenv("FINFOCUS_E2E_REGIONS")
+	if regionsStr == "" {
+		// Default: only run us-east-1
+		return region != "us-east-1"
+	}
+
+	regions := strings.Split(regionsStr, ",")
+	for _, r := range regions {
+		if strings.TrimSpace(r) == region {
+			return false
+		}
+	}
+	return true
+}
+
+// loadExpectedCosts loads expected costs from JSON file.
+func loadExpectedCosts(path string, costType string) ([]ExpectedCost, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read expected costs file: %w", err)
+	}
+
+	var wrapper struct {
+		Region    string         `json:"region"`
+		CostType  string         `json:"cost_type"`
+		Resources []ExpectedCost `json:"resources"`
+	}
+
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, fmt.Errorf("failed to parse expected costs JSON: %w", err)
+	}
+
+	// Filter by cost type
+	var filtered []ExpectedCost
+	for _, cost := range wrapper.Resources {
+		if cost.CostType == costType {
+			filtered = append(filtered, cost)
+		}
+	}
+
+	return filtered, nil
+}
+
+// generatePulumiPlan generates a Pulumi plan JSON file from the fixture.
+// Returns the path to the plan file and a cleanup function.
+func generatePulumiPlan(t *testing.T, fixturePath string, region string) (string, func()) {
+	t.Helper()
+
+	// For now, use a static plan file if it exists
+	// In the future with #177, we would use Pulumi Automation API
+	planFile := filepath.Join(fixturePath, "plan.json")
+
+	// Check if plan file exists
+	if _, err := os.Stat(planFile); err == nil {
+		return planFile, func() {}
+	}
+
+	// Generate plan using pulumi CLI (temporary solution until #177)
+	t.Logf("Generating Pulumi plan for %s (requires Pulumi CLI)", region)
+
+	// TODO: This requires Pulumi Automation API (#177)
+	// For now, skip plan generation and use pre-generated plans
+	t.Skip("Plan generation requires Pulumi Automation API (issue #177)")
+
+	return "", func() {}
+}
+
+// getStringField safely extracts a string field from a map.
+func getStringField(m map[string]interface{}, field string) string {
+	if val, ok := m[field].(string); ok {
+		return val
+	}
+	return ""
+}
+
+// getFloatField safely extracts a float field from a map.
+func getFloatField(m map[string]interface{}, field string) float64 {
+	if val, ok := m[field].(float64); ok {
+		return val
+	}
+	return 0.0
+}
+
+// TestMultiRegion_Unified_Projected tests projected cost calculation for the unified multi-region fixture.
+func TestMultiRegion_Unified_Projected(t *testing.T) {
+	t.Parallel()
+
+	startTime := time.Now()
+
+	// Log plugin versions at test start
+	LogPluginVersions(t)
+
+	// Setup test configuration
+	fixturePath := getUnifiedFixturePath(t)
+	expectedCostsPath := filepath.Join(fixturePath, "expected-costs.json")
+
+	// Load unified expected costs
+	expectedCosts, err := loadUnifiedExpectedCosts(expectedCostsPath)
+	require.NoError(t, err, "Failed to load unified expected costs")
+	require.NotEmpty(t, expectedCosts.Resources, "Expected costs cannot be empty")
+
+	// Generate Pulumi plan
+	planPath, cleanup := generatePulumiPlan(t, fixturePath, "unified")
+	defer cleanup()
+
+	// Run finfocus cost projected
+	results := runProjectedCostCommand(t, planPath, getTimeout())
+
+	// Validate plugin loading
+	validatePluginLoaded(t, "aws-public")
+
+	// Validate unified costs with per-resource and aggregate validation
+	validator := NewDefaultCostValidator(expectedCosts.AggregateValidation.Tolerance)
+	validationResult, err := validator.ValidateUnifiedFixtureCosts(results, expectedCosts)
+	require.NoError(t, err, "Failed to validate unified fixture costs")
+
+	// Check per-resource validations
+	failureCount := 0
+	for _, result := range validationResult.PerResourceResults {
+		if !result.WithinTolerance {
+			t.Errorf("Cost validation failed for %s (%s): actual=$%.2f, expected=[$%.2f, $%.2f], variance=%.2f%%",
+				result.ResourceName, result.Region, result.ActualCost, result.ExpectedMin, result.ExpectedMax, result.Variance)
+			failureCount++
+		} else {
+			t.Logf("Resource %s (%s): $%.2f [PASS]", result.ResourceName, result.Region, result.ActualCost)
+		}
+	}
+
+	// Check aggregate validation
+	if !validationResult.TotalWithinTolerance {
+		t.Errorf("Aggregate total $%.2f outside expected range [$%.2f, $%.2f]",
+			validationResult.TotalCost, validationResult.ExpectedTotalMin, validationResult.ExpectedTotalMax)
+		failureCount++
+	} else {
+		t.Logf("Aggregate total: $%.2f within [$%.2f, $%.2f] [PASS]",
+			validationResult.TotalCost, validationResult.ExpectedTotalMin, validationResult.ExpectedTotalMax)
+	}
+
+	// Check execution time
+	executionTime := time.Since(startTime)
+	t.Logf("Test execution time for unified fixture: %v", executionTime)
+
+	require.Equal(t, 0, failureCount, "All cost validations must pass")
+}
+
+// getUnifiedFixturePath returns the absolute path to the unified fixture directory.
+func getUnifiedFixturePath(t *testing.T) string {
+	t.Helper()
+	path, err := filepath.Abs(filepath.Join("fixtures", "multi-region", "unified"))
+	require.NoError(t, err)
+	require.DirExists(t, path, "Unified fixture directory should exist: %s", path)
+	return path
+}
+
+// loadUnifiedExpectedCosts loads expected costs for a unified fixture.
+func loadUnifiedExpectedCosts(path string) (UnifiedExpectedCosts, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return UnifiedExpectedCosts{}, fmt.Errorf("failed to read unified expected costs file: %w", err)
+	}
+
+	var expected UnifiedExpectedCosts
+	if err := json.Unmarshal(data, &expected); err != nil {
+		return UnifiedExpectedCosts{}, fmt.Errorf("failed to parse unified expected costs JSON: %w", err)
+	}
+
+	return expected, nil
+}


### PR DESCRIPTION
## Summary

Enhances the automated nightly failure analysis workflow by enforcing strict security and reliability measures. This update prevents resource exhaustion through explicit timeouts, ensures reproducible builds by pinning CLI tool versions, and eliminates silent failures with robust error handling. It also standardizes action versions and permissions to align with project best practices.

## Test plan

- [x] Verified `nightly-analysis.yml` syntax and logic via manual review
- [x] Confirmed `@opencode/cli` version pinning matches stable version (`1.0.128`)
- [x] Validated documentation updates with `make docs-lint`
- [x] Verified workflow permissions and timeout configuration

## Changes

### Modified files

- `.github/workflows/nightly-analysis.yml` - Added timeouts, pinned dependencies, and strict error handling
- `CONTRIBUTING.md` - Documented new hardening standards for the nightly workflow
- `specs/121-harden-nightly-analysis/research.md` - Recorded dependency version decisions
- `specs/121-harden-nightly-analysis/tasks.md` - Completed implementation tasks

### Housekeeping

- Standardized `actions/checkout` to v6 across modified workflows

Closes #325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-region E2E testing support for AWS (us-east-1, eu-west-1, ap-northeast-1) with unified fixtures and projected/actual workflows
  * New "Investigate" recommendation action type
  * Test configuration: selectable regions and option to skip actual-cost runs

* **Documentation**
  * Comprehensive multi-region E2E testing guide with quick start, fixtures, validation, retries, and troubleshooting

* **Tests**
  * Expanded projected/actual/fallback tests, plugin/version checks, error classification, and helpers

* **Chores**
  * Increased CI fuzz timeouts; improved Windows test compatibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->