### PR TITLE
feat(cli): add budget threshold exit codes for CI/CD integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -975,8 +975,7 @@ CodeRabbit now:
 5. **Integrates with existing CI/CD** tools and workflows
 
 ## Active Technologies
-
-- Go 1.25.5 + finfocus-spec v0.5.3+ (protobuf types), google.golang.org/grpc, github.com/stretchr/testify
+- Go 1.25.5 + github.com/spf13/cobra (CLI), github.com/rs/zerolog (logging), github.com/rshade/finfocus-spec v0.5.3+ (proto definitions/SDK), google.golang.org/grpc, github.com/stretchr/testify; YAML config file (~/.finfocus/config.yaml)
 
 ## Recent Changes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,9 +61,8 @@ guardrails in `CONTEXT.md`.
 
 - [x] **Multi-Region Testing** *(Completed 2026-01-24)*
   - [x] Multi-region E2E testing support (#185, PR #485)
-- [ ] **Performance**
-  - [ ] Pagination for large datasets
-        ([#225](https://github.com/rshade/finfocus/issues/225))
+- [x] **Performance** *(Completed 2026-01-24)*
+  - [x] Pagination and NDJSON streaming for CI/CD integration (#225, PR #488)
 
 ## Near-Term Vision (v0.3.0 - Budgeting & Intelligence)
 
@@ -71,10 +70,8 @@ guardrails in `CONTEXT.md`.
   - [ ] Multi-Plugin Routing: Intelligent Feature-Based Plugin Selection
         ([#410](https://github.com/rshade/finfocus/issues/410))
 - [ ] **Budgeting & Cost Controls** *(Budget Health Suite)*
-  - [ ] Budget health calculation & threshold alerting
-        ([#267](https://github.com/rshade/finfocus/issues/267))
-  - [ ] Provider filtering & summary aggregation for Budgets
-        ([#263](https://github.com/rshade/finfocus/issues/263))
+  - [x] Budget health calculation & threshold alerting (#267) *(Completed)*
+  - [x] Provider filtering & summary aggregation for Budgets (#263) *(Completed)*
   - [x] Budget status display in CLI (#217) *(Completed)*
   - [ ] Flexible budget scoping (per-provider, per-resource)
         ([#221](https://github.com/rshade/finfocus/issues/221))

--- a/internal/cli/common_execution.go
+++ b/internal/cli/common_execution.go
@@ -90,3 +90,28 @@ func openPlugins(ctx context.Context, adapter string, audit *auditContext) ([]*p
 
 	return clients, cleanup, nil
 }
+
+// extractCurrencyFromResults scans results to find a single canonical currency.
+// It returns the currency code and a boolean indicating if mixed currencies were detected.
+// If no currency is found, it defaults to "USD".
+func extractCurrencyFromResults(results []engine.CostResult) (string, bool) {
+	currency := ""
+	mixedCurrencies := false
+
+	for _, r := range results {
+		if r.Currency != "" {
+			if currency == "" {
+				currency = r.Currency
+			} else if r.Currency != currency {
+				mixedCurrencies = true
+				break
+			}
+		}
+	}
+
+	if currency == "" {
+		currency = defaultCurrency
+	}
+
+	return currency, mixedCurrencies
+}

--- a/internal/cli/constants.go
+++ b/internal/cli/constants.go
@@ -1,0 +1,4 @@
+package cli
+
+// defaultCurrency is the fallback currency used when none is specified.
+const defaultCurrency = "USD"

--- a/internal/cli/cost_budget_render_test.go
+++ b/internal/cli/cost_budget_render_test.go
@@ -1,0 +1,185 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rshade/finfocus/internal/config"
+	"github.com/rshade/finfocus/internal/engine"
+)
+
+func TestRenderBudgetStatus_Nil(t *testing.T) {
+	err := RenderBudgetStatus(io.Discard, nil)
+	assert.NoError(t, err)
+}
+
+func TestRenderPlainBudget(t *testing.T) {
+	status := &engine.BudgetStatus{
+		Budget: config.BudgetConfig{
+			Amount:   1000.0,
+			Currency: "USD",
+			Period:   "monthly",
+		},
+		CurrentSpend:       500.0,
+		Percentage:         50.0,
+		Currency:           "USD",
+		ForecastedSpend:    1200.0,
+		ForecastPercentage: 120.0,
+		Alerts: []engine.ThresholdStatus{
+			{Threshold: 80.0, Status: engine.ThresholdStatusOK},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := renderPlainBudget(&buf, status)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "BUDGET STATUS")
+	assert.Contains(t, output, "Budget: $1000.00/monthly")
+	assert.Contains(t, output, "Current Spend: $500.00 (50.0%)")
+	assert.Contains(t, output, "Status: OK - Within budget")
+	assert.Contains(t, output, "Forecasted: $1200.00 (120.0%)")
+}
+
+func TestGetStatusMessage(t *testing.T) {
+	tests := []struct {
+		name   string
+		status *engine.BudgetStatus
+		want   string
+	}{
+		{
+			name: "OK",
+			status: &engine.BudgetStatus{
+				Alerts: []engine.ThresholdStatus{},
+			},
+			want: "OK - Within budget",
+		},
+		{
+			name: "Exceeded",
+			status: &engine.BudgetStatus{
+				Alerts: []engine.ThresholdStatus{
+					{Threshold: 100.0, Status: engine.ThresholdStatusExceeded},
+				},
+			},
+			want: "WARNING - Exceeds 100% threshold",
+		},
+		{
+			name: "Approaching",
+			status: &engine.BudgetStatus{
+				Alerts: []engine.ThresholdStatus{
+					{Threshold: 80.0, Status: engine.ThresholdStatusApproaching},
+				},
+			},
+			want: "APPROACHING - Near budget threshold",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getStatusMessage(tt.status)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCurrencySymbol(t *testing.T) {
+	assert.Equal(t, "$", currencySymbol("USD"))
+	assert.Equal(t, "€", currencySymbol("EUR"))
+	assert.Equal(t, "£", currencySymbol("GBP"))
+	assert.Equal(t, "¥", currencySymbol("JPY"))
+	assert.Equal(t, "¥", currencySymbol("CNY"))
+	assert.Equal(t, "C$", currencySymbol("CAD"))
+	assert.Equal(t, "A$", currencySymbol("AUD"))
+	assert.Equal(t, "₹", currencySymbol("INR"))
+	assert.Equal(t, "₩", currencySymbol("KRW"))
+	assert.Equal(t, "BRL ", currencySymbol("BRL"))
+}
+
+func TestCalculateBoxWidth(t *testing.T) {
+	assert.Equal(t, minBoxWidth, calculateBoxWidth(20))
+	assert.Equal(t, defaultBoxWidth, calculateBoxWidth(100))
+	assert.Equal(t, 32, calculateBoxWidth(40))
+}
+
+func TestCalculateProgressBarWidth(t *testing.T) {
+	assert.Equal(t, minProgressBarWidth, calculateProgressBarWidth(20))
+	assert.Equal(t, progressBarWidth, calculateProgressBarWidth(100))
+}
+
+func TestIsWriterTerminal(t *testing.T) {
+	var buf bytes.Buffer
+	assert.False(t, isWriterTerminal(&buf))
+}
+
+func TestRenderProgressBar(t *testing.T) {
+	status := &engine.BudgetStatus{
+		Percentage: 50.0,
+	}
+	// Use a small width to make it easy to verify
+	bar := renderProgressBar(status, 10)
+	assert.Contains(t, bar, "50%")
+}
+
+func TestDetermineProgressBarColor(t *testing.T) {
+	assert.Equal(t, progressOKColor(), determineProgressBarColor(50.0))
+	assert.Equal(t, lipgloss.Color("214"), determineProgressBarColor(85.0))
+	assert.Equal(t, progressExceededColor(), determineProgressBarColor(110.0))
+}
+
+func TestFormatAlertMessage(t *testing.T) {
+	alert := engine.ThresholdStatus{
+		Threshold: 80.0,
+		Type:      config.AlertTypeActual,
+	}
+	assert.Equal(t, "WARNING - spend exceeds 80% threshold", formatAlertMessage(alert, "WARNING"))
+
+	alert.Type = config.AlertTypeForecasted
+	assert.Equal(t, "WARNING - forecasted spend exceeds 80% threshold", formatAlertMessage(alert, "WARNING"))
+}
+
+func TestRenderAlertMessages(t *testing.T) {
+	status := &engine.BudgetStatus{
+		Alerts: []engine.ThresholdStatus{
+			{Threshold: 100.0, Status: engine.ThresholdStatusExceeded, Type: config.AlertTypeActual},
+			{Threshold: 80.0, Status: engine.ThresholdStatusApproaching, Type: config.AlertTypeActual},
+		},
+	}
+	messages := renderAlertMessages(status)
+	assert.Contains(t, messages, "WARNING - spend exceeds 100% threshold")
+	assert.Contains(t, messages, "APPROACHING - spend exceeds 80% threshold")
+}
+
+func TestRenderStyledBudget(t *testing.T) {
+	status := &engine.BudgetStatus{
+		Budget: config.BudgetConfig{
+			Amount:   1000.0,
+			Currency: "USD",
+			Period:   "monthly",
+		},
+		CurrentSpend:       500.0,
+		Percentage:         50.0,
+		Currency:           "USD",
+		ForecastedSpend:    1200.0,
+		ForecastPercentage: 120.0,
+		Alerts: []engine.ThresholdStatus{
+			{Threshold: 80.0, Status: engine.ThresholdStatusOK},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := renderStyledBudget(&buf, status)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, buf.String())
+
+	// Verify key data is present in output
+	output := buf.String()
+	assert.Contains(t, output, "1,000") // Budget amount (formatted)
+	assert.Contains(t, output, "$")     // Currency symbol (for USD)
+	assert.Contains(t, output, "50")    // Percentage
+}

--- a/internal/cli/cost_budget_test.go
+++ b/internal/cli/cost_budget_test.go
@@ -2,9 +2,9 @@ package cli
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -12,430 +12,389 @@ import (
 	"github.com/rshade/finfocus/internal/engine"
 )
 
-func TestRenderBudgetStatus_Nil(t *testing.T) {
-	var buf bytes.Buffer
-	err := RenderBudgetStatus(&buf, nil)
+// T037: Unit test for warning log when exit_code: 0 and threshold exceeded.
+func TestCheckBudgetExit_WarningOnlyMode(t *testing.T) {
+	// Create a test command to capture output
+	cmd := &cobra.Command{}
+	var errBuf bytes.Buffer
+	cmd.SetErr(&errBuf)
+
+	// Create budget status with warning-only mode (exit_code: 0)
+	status := &engine.BudgetStatus{
+		Budget: config.BudgetConfig{
+			Amount:          1000.0,
+			Currency:        "USD",
+			ExitOnThreshold: true,
+			ExitCode:        0, // Warning-only mode
+		},
+		Alerts: []engine.ThresholdStatus{
+			{Threshold: 80.0, Status: engine.ThresholdStatusExceeded},
+		},
+	}
+
+	// checkBudgetExit should return nil (no exit) but log a warning
+	err := checkBudgetExit(cmd, status, nil)
+
+	// Should not return an error (no exit)
+	assert.NoError(t, err, "warning-only mode should not return an error")
+
+	// Should have logged a warning to stderr
+	assert.Contains(t, errBuf.String(), "WARNING:")
+	assert.Contains(t, errBuf.String(), "budget threshold exceeded")
+}
+
+// T036: Unit test for exit_code: 0 with exit_on_threshold: true returns exit 0.
+func TestBudgetStatus_ExitCode_WarningOnly(t *testing.T) {
+	status := &engine.BudgetStatus{
+		Budget: config.BudgetConfig{
+			Amount:          1000.0,
+			Currency:        "USD",
+			ExitOnThreshold: true,
+			ExitCode:        0, // Warning-only mode
+		},
+		Alerts: []engine.ThresholdStatus{
+			{Threshold: 80.0, Status: engine.ThresholdStatusExceeded},
+		},
+	}
+
+	// ShouldExit should return true (threshold is exceeded and exit is enabled)
+	assert.True(t, status.ShouldExit())
+
+	// GetExitCode should return 0 (warning-only mode)
+	assert.Equal(t, 0, status.GetExitCode())
+}
+
+// T038: Integration test for warning-only mode (tested at CLI level).
+func TestCheckBudgetExit_WarningOnlyNoExitError(t *testing.T) {
+	cmd := &cobra.Command{}
+	var errBuf bytes.Buffer
+	cmd.SetErr(&errBuf)
+
+	status := &engine.BudgetStatus{
+		Budget: config.BudgetConfig{
+			Amount:          1000.0,
+			Currency:        "USD",
+			ExitOnThreshold: true,
+			ExitCode:        0, // Warning-only mode
+		},
+		CurrentSpend: 1500.0,
+		Percentage:   150.0,
+		Alerts: []engine.ThresholdStatus{
+			{Threshold: 100.0, Status: engine.ThresholdStatusExceeded},
+		},
+	}
+
+	err := checkBudgetExit(cmd, status, nil)
+
+	// Warning-only mode should NOT return a BudgetExitError
+	assert.NoError(t, err)
+
+	// But should log the warning
+	warningOutput := errBuf.String()
+	assert.Contains(t, warningOutput, "WARNING:")
+}
+
+// Test checkBudgetExit returns BudgetExitError for non-zero exit codes.
+func TestCheckBudgetExit_ReturnsExitError(t *testing.T) {
+	cmd := &cobra.Command{}
+	var errBuf bytes.Buffer
+	cmd.SetErr(&errBuf)
+
+	status := &engine.BudgetStatus{
+		Budget: config.BudgetConfig{
+			Amount:          1000.0,
+			Currency:        "USD",
+			ExitOnThreshold: true,
+			ExitCode:        2,
+		},
+		Alerts: []engine.ThresholdStatus{
+			{Threshold: 80.0, Status: engine.ThresholdStatusExceeded},
+		},
+	}
+
+	err := checkBudgetExit(cmd, status, nil)
+
+	require.Error(t, err)
+	var budgetErr *BudgetExitError
+	require.ErrorAs(t, err, &budgetErr, "error should be *BudgetExitError")
+	assert.Equal(t, 2, budgetErr.ExitCode)
+	assert.Contains(t, budgetErr.Reason, "budget threshold exceeded")
+}
+
+// Test checkBudgetExit returns nil when no budget status.
+func TestCheckBudgetExit_NilStatus(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	err := checkBudgetExit(cmd, nil, nil)
+
+	assert.NoError(t, err, "nil status should return nil")
+}
+
+// Test checkBudgetExit returns nil when exit is disabled.
+func TestCheckBudgetExit_ExitDisabled(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	status := &engine.BudgetStatus{
+		Budget: config.BudgetConfig{
+			Amount:          1000.0,
+			Currency:        "USD",
+			ExitOnThreshold: false, // Disabled
+			ExitCode:        2,
+		},
+		Alerts: []engine.ThresholdStatus{
+			{Threshold: 80.0, Status: engine.ThresholdStatusExceeded},
+		},
+	}
+
+	err := checkBudgetExit(cmd, status, nil)
+
+	assert.NoError(t, err, "disabled exit should return nil")
+}
+
+// Test checkBudgetExit returns nil when no thresholds exceeded.
+func TestCheckBudgetExit_NoExceeded(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	status := &engine.BudgetStatus{
+		Budget: config.BudgetConfig{
+			Amount:          1000.0,
+			Currency:        "USD",
+			ExitOnThreshold: true,
+			ExitCode:        2,
+		},
+		Alerts: []engine.ThresholdStatus{
+			{Threshold: 80.0, Status: engine.ThresholdStatusOK},
+		},
+	}
+
+	err := checkBudgetExit(cmd, status, nil)
+
+	assert.NoError(t, err, "no exceeded thresholds should return nil")
+}
+
+// T020a/T027a: Test checkBudgetExit returns exit code 1 for evaluation errors (FR-009).
+func TestCheckBudgetExit_EvaluationError(t *testing.T) {
+	cmd := &cobra.Command{}
+	var errBuf bytes.Buffer
+	cmd.SetErr(&errBuf)
+
+	// Evaluation error should return exit code 1 regardless of configuration
+	evalErr := engine.ErrCurrencyMismatch
+
+	err := checkBudgetExit(cmd, nil, evalErr)
+
+	require.Error(t, err)
+	var budgetErr *BudgetExitError
+	require.ErrorAs(t, err, &budgetErr, "error should be *BudgetExitError")
+	assert.Equal(t, engine.ExitCodeBudgetEvaluationError, budgetErr.ExitCode)
+	assert.Equal(t, 1, budgetErr.ExitCode, "evaluation error should return exit code 1")
+	assert.Contains(t, budgetErr.Reason, "budget evaluation failed")
+}
+
+// T040: ExitReason indicates warning-only mode.
+func TestBudgetStatus_ExitReason_WarningOnly(t *testing.T) {
+	status := &engine.BudgetStatus{
+		Budget: config.BudgetConfig{
+			Amount:          1000.0,
+			Currency:        "USD",
+			ExitOnThreshold: true,
+			ExitCode:        0, // Warning-only mode
+		},
+		Alerts: []engine.ThresholdStatus{
+			{Threshold: 100.0, Status: engine.ThresholdStatusExceeded},
+		},
+	}
+
+	reason := status.ExitReason()
+	assert.Contains(t, reason, "warning only")
+	assert.Contains(t, reason, "exit code 0")
+}
+
+// T041: Unit test for --exit-on-threshold flag parsing.
+func TestCostCmd_ExitOnThresholdFlag(t *testing.T) {
+	// Create a fresh cost command
+	cmd := newCostCmd()
+
+	// Parse the --exit-on-threshold flag
+	err := cmd.ParseFlags([]string{"--exit-on-threshold"})
 	require.NoError(t, err)
-	assert.Empty(t, buf.String())
+
+	// Verify the flag was parsed correctly
+	exitOnThreshold, err := cmd.Flags().GetBool("exit-on-threshold")
+	require.NoError(t, err)
+	assert.True(t, exitOnThreshold, "--exit-on-threshold should be true when set")
+
+	// Verify the flag was marked as changed
+	assert.True(t, cmd.Flags().Changed("exit-on-threshold"))
 }
 
-func TestRenderPlainBudget(t *testing.T) {
-	tests := []struct {
-		name     string
-		status   *engine.BudgetStatus
-		contains []string
-	}{
-		{
-			name: "basic budget status",
-			status: &engine.BudgetStatus{
-				Budget: config.BudgetConfig{
-					Amount:   1000.0,
-					Currency: "USD",
-					Period:   "monthly",
-				},
-				CurrentSpend: 550.0,
-				Percentage:   55.0,
-				Currency:     "USD",
-			},
-			contains: []string{
-				"BUDGET STATUS",
-				"Budget: $1000.00/monthly",
-				"Current Spend: $550.00 (55.0%)",
-				"OK - Within budget",
-			},
-		},
-		{
-			name: "over budget with alerts",
-			status: &engine.BudgetStatus{
-				Budget: config.BudgetConfig{
-					Amount:   1000.0,
-					Currency: "USD",
-					Period:   "monthly",
-				},
-				CurrentSpend: 850.0,
-				Percentage:   85.0,
-				Currency:     "USD",
-				Alerts: []engine.ThresholdStatus{
-					{Threshold: 80.0, Type: config.AlertTypeActual, Status: engine.ThresholdStatusExceeded},
-				},
-			},
-			contains: []string{
-				"BUDGET STATUS",
-				"Budget: $1000.00/monthly",
-				"Current Spend: $850.00 (85.0%)",
-				"WARNING - Exceeds 80% threshold",
-			},
-		},
-		{
-			name: "with forecasted spend",
-			status: &engine.BudgetStatus{
-				Budget: config.BudgetConfig{
-					Amount:   1000.0,
-					Currency: "USD",
-					Period:   "monthly",
-				},
-				CurrentSpend:       450.0,
-				Percentage:         45.0,
-				ForecastedSpend:    930.0,
-				ForecastPercentage: 93.0,
-				Currency:           "USD",
-			},
-			contains: []string{
-				"Forecasted: $930.00 (93.0%)",
-			},
-		},
-		{
-			name: "different currency - EUR",
-			status: &engine.BudgetStatus{
-				Budget: config.BudgetConfig{
-					Amount:   500.0,
-					Currency: "EUR",
-					Period:   "monthly",
-				},
-				CurrentSpend: 250.0,
-				Percentage:   50.0,
-				Currency:     "EUR",
-			},
-			contains: []string{
-				"Budget: €500.00/monthly",
-				"Current Spend: €250.00 (50.0%)",
-			},
-		},
-		{
-			name: "approaching threshold",
-			status: &engine.BudgetStatus{
-				Budget: config.BudgetConfig{
-					Amount:   1000.0,
-					Currency: "USD",
-					Period:   "monthly",
-				},
-				CurrentSpend: 770.0,
-				Percentage:   77.0,
-				Currency:     "USD",
-				Alerts: []engine.ThresholdStatus{
-					{Threshold: 80.0, Type: config.AlertTypeActual, Status: engine.ThresholdStatusApproaching},
-				},
-			},
-			contains: []string{
-				"APPROACHING - Near budget threshold",
-			},
-		},
-	}
+// T041b: Unit test for --exit-on-threshold=false flag parsing.
+func TestCostCmd_ExitOnThresholdFlagFalse(t *testing.T) {
+	cmd := newCostCmd()
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			err := renderPlainBudget(&buf, tc.status)
-			require.NoError(t, err)
+	err := cmd.ParseFlags([]string{"--exit-on-threshold=false"})
+	require.NoError(t, err)
 
-			output := buf.String()
-			for _, expected := range tc.contains {
-				assert.Contains(t, output, expected, "expected output to contain: %s", expected)
-			}
-		})
-	}
+	exitOnThreshold, err := cmd.Flags().GetBool("exit-on-threshold")
+	require.NoError(t, err)
+	assert.False(t, exitOnThreshold, "--exit-on-threshold=false should be false")
 }
 
-func TestRenderStyledBudget(t *testing.T) {
-	// Note: renderStyledBudget includes ANSI escape codes, so we test that it
-	// produces output with expected content (stripping color codes for comparison)
+// T042: Unit test for --exit-code flag parsing.
+func TestCostCmd_ExitCodeFlag(t *testing.T) {
+	cmd := newCostCmd()
 
-	tests := []struct {
-		name     string
-		status   *engine.BudgetStatus
-		contains []string
-	}{
-		{
-			name: "basic styled output",
-			status: &engine.BudgetStatus{
-				Budget: config.BudgetConfig{
-					Amount:   1000.0,
-					Currency: "USD",
-					Period:   "monthly",
-				},
-				CurrentSpend: 550.0,
-				Percentage:   55.0,
-				Currency:     "USD",
-			},
-			contains: []string{
-				"BUDGET STATUS",
-				"Budget:",
-				"1,000.00", // Uses thousand separators
-				"monthly",
-				"Current Spend:",
-				"550.00",
-				"55",
-			},
-		},
-		{
-			name: "over budget with warning",
-			status: &engine.BudgetStatus{
-				Budget: config.BudgetConfig{
-					Amount:   1000.0,
-					Currency: "USD",
-					Period:   "monthly",
-				},
-				CurrentSpend: 850.0,
-				Percentage:   85.0,
-				Currency:     "USD",
-				Alerts: []engine.ThresholdStatus{
-					{Threshold: 80.0, Type: config.AlertTypeActual, Status: engine.ThresholdStatusExceeded},
-				},
-			},
-			contains: []string{
-				"WARNING",
-				"80",
-				"threshold",
-			},
-		},
-	}
+	// Parse the --exit-code flag with value 42
+	err := cmd.ParseFlags([]string{"--exit-code=42"})
+	require.NoError(t, err)
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			err := renderStyledBudget(&buf, tc.status)
-			require.NoError(t, err)
+	// Verify the flag was parsed correctly
+	exitCode, err := cmd.Flags().GetInt("exit-code")
+	require.NoError(t, err)
+	assert.Equal(t, 42, exitCode, "--exit-code should be 42")
 
-			// Strip ANSI codes for content verification
-			output := stripANSI(buf.String())
-			for _, expected := range tc.contains {
-				assert.Contains(t, output, expected, "expected styled output to contain: %s", expected)
-			}
-		})
-	}
+	// Verify the flag was marked as changed
+	assert.True(t, cmd.Flags().Changed("exit-code"))
 }
 
-func TestRenderProgressBar(t *testing.T) {
-	tests := []struct {
-		name       string
-		percentage float64
-		width      int
-		wantFilled int // Approximate filled characters
-	}{
-		{
-			name:       "50% filled",
-			percentage: 50.0,
-			width:      20,
-			wantFilled: 10,
-		},
-		{
-			name:       "0% empty",
-			percentage: 0.0,
-			width:      20,
-			wantFilled: 0,
-		},
-		{
-			name:       "100% full",
-			percentage: 100.0,
-			width:      20,
-			wantFilled: 20,
-		},
-		{
-			name:       "over 100% capped",
-			percentage: 150.0,
-			width:      20,
-			wantFilled: 20, // Should cap at 100%
-		},
-	}
+// T042b: Unit test for --exit-code flag default value.
+func TestCostCmd_ExitCodeFlagDefault(t *testing.T) {
+	cmd := newCostCmd()
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			status := &engine.BudgetStatus{
-				Percentage: tc.percentage,
-			}
-			bar := renderProgressBar(status, tc.width)
+	// Don't set any flags - check default via PersistentFlags
+	exitCode, err := cmd.PersistentFlags().GetInt("exit-code")
+	require.NoError(t, err)
+	assert.Equal(t, 1, exitCode, "default --exit-code should be 1")
 
-			// Strip ANSI codes and count filled characters
-			stripped := stripANSI(bar)
-			filledCount := strings.Count(stripped, progressFilledChar)
-			assert.Equal(t, tc.wantFilled, filledCount, "expected %d filled chars", tc.wantFilled)
-		})
-	}
+	// Flag should NOT be changed when not explicitly set
+	assert.False(t, cmd.PersistentFlags().Changed("exit-code"))
 }
 
-func TestRenderAlertMessages(t *testing.T) {
-	tests := []struct {
-		name     string
-		alerts   []engine.ThresholdStatus
-		contains []string
-		empty    bool
-	}{
-		{
-			name:   "no alerts",
-			alerts: []engine.ThresholdStatus{},
-			empty:  true,
-		},
-		{
-			name: "all OK alerts",
-			alerts: []engine.ThresholdStatus{
-				{Threshold: 80.0, Status: engine.ThresholdStatusOK},
+// T043: Unit test for CLI flags overriding environment variables.
+func TestCostCmd_CLIFlagsOverrideEnv(t *testing.T) {
+	// Set environment variables
+	t.Setenv("FINFOCUS_BUDGET_EXIT_ON_THRESHOLD", "false")
+	t.Setenv("FINFOCUS_BUDGET_EXIT_CODE", "5")
+
+	// Save and restore global config
+	prev := config.GetGlobalConfig()
+	t.Cleanup(func() { config.SetGlobalConfig(prev) })
+
+	// Initialize config from env (simulating what happens in real CLI)
+	cfg := &config.Config{
+		Cost: config.CostConfig{
+			Budgets: config.BudgetConfig{
+				ExitOnThreshold: false, // From env
+				ExitCode:        5,     // From env
 			},
-			empty: true,
 		},
-		{
-			name: "exceeded alert",
-			alerts: []engine.ThresholdStatus{
-				{Threshold: 80.0, Type: config.AlertTypeActual, Status: engine.ThresholdStatusExceeded},
+	}
+	config.SetGlobalConfig(cfg)
+
+	// Create cost command and parse CLI flags that override env
+	cmd := newCostCmd()
+	err := cmd.ParseFlags([]string{"--exit-on-threshold", "--exit-code=99"})
+	require.NoError(t, err)
+
+	// Simulate PersistentPreRunE execution
+	preRunE := cmd.PersistentPreRunE
+	require.NotNil(t, preRunE, "PersistentPreRunE should be set")
+	err = preRunE(cmd, []string{})
+	require.NoError(t, err)
+
+	// Verify CLI flags overrode the env values
+	globalCfg := config.GetGlobalConfig()
+	require.NotNil(t, globalCfg)
+	assert.True(t, globalCfg.Cost.Budgets.ExitOnThreshold, "CLI flag should override env to true")
+	assert.Equal(t, 99, globalCfg.Cost.Budgets.ExitCode, "CLI flag should override env to 99")
+}
+
+// T044: Unit test for CLI flags overriding config file values.
+func TestCostCmd_CLIFlagsOverrideConfig(t *testing.T) {
+	// Save and restore global config
+	prev := config.GetGlobalConfig()
+	t.Cleanup(func() { config.SetGlobalConfig(prev) })
+
+	// Simulate config loaded from file
+	cfg := &config.Config{
+		Cost: config.CostConfig{
+			Budgets: config.BudgetConfig{
+				Amount:          1000.0,
+				Currency:        "USD",
+				ExitOnThreshold: false, // From config file
+				ExitCode:        3,     // From config file
 			},
-			contains: []string{"WARNING", "80", "threshold"},
 		},
-		{
-			name: "approaching alert",
-			alerts: []engine.ThresholdStatus{
-				{Threshold: 80.0, Type: config.AlertTypeActual, Status: engine.ThresholdStatusApproaching},
+	}
+	config.SetGlobalConfig(cfg)
+
+	// Create cost command and parse CLI flags
+	cmd := newCostCmd()
+	err := cmd.ParseFlags([]string{"--exit-on-threshold=true", "--exit-code=7"})
+	require.NoError(t, err)
+
+	// Execute PersistentPreRunE
+	err = cmd.PersistentPreRunE(cmd, []string{})
+	require.NoError(t, err)
+
+	// Verify CLI flags overrode the config file values
+	globalCfg := config.GetGlobalConfig()
+	require.NotNil(t, globalCfg)
+	assert.True(t, globalCfg.Cost.Budgets.ExitOnThreshold, "CLI flag should override config to true")
+	assert.Equal(t, 7, globalCfg.Cost.Budgets.ExitCode, "CLI flag should override config to 7")
+
+	// Verify other config values were preserved
+	assert.Equal(t, 1000.0, globalCfg.Cost.Budgets.Amount, "budget amount should be preserved")
+	assert.Equal(t, "USD", globalCfg.Cost.Budgets.Currency, "currency should be preserved")
+}
+
+// T045: Integration test for CLI flag overrides - only changed flags are applied.
+func TestCostCmd_OnlyChangedFlagsApplied(t *testing.T) {
+	// Save and restore global config
+	prev := config.GetGlobalConfig()
+	t.Cleanup(func() { config.SetGlobalConfig(prev) })
+
+	// Simulate config with specific values
+	cfg := &config.Config{
+		Cost: config.CostConfig{
+			Budgets: config.BudgetConfig{
+				ExitOnThreshold: true,
+				ExitCode:        42,
 			},
-			contains: []string{"APPROACHING", "80", "threshold"},
-		},
-		{
-			name: "forecasted alert",
-			alerts: []engine.ThresholdStatus{
-				{Threshold: 100.0, Type: config.AlertTypeForecasted, Status: engine.ThresholdStatusExceeded},
-			},
-			contains: []string{"WARNING", "forecasted", "100"},
 		},
 	}
+	config.SetGlobalConfig(cfg)
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			status := &engine.BudgetStatus{Alerts: tc.alerts}
-			result := renderAlertMessages(status)
+	// Create cost command but only set --exit-code flag
+	cmd := newCostCmd()
+	err := cmd.ParseFlags([]string{"--exit-code=99"})
+	require.NoError(t, err)
 
-			if tc.empty {
-				assert.Empty(t, result)
-				return
-			}
+	// Execute PersistentPreRunE
+	err = cmd.PersistentPreRunE(cmd, []string{})
+	require.NoError(t, err)
 
-			stripped := stripANSI(result)
-			for _, expected := range tc.contains {
-				assert.Contains(t, stripped, expected)
-			}
-		})
-	}
+	// Verify only the changed flag was applied
+	globalCfg := config.GetGlobalConfig()
+	require.NotNil(t, globalCfg)
+	assert.True(t, globalCfg.Cost.Budgets.ExitOnThreshold, "unchanged flag should preserve config value")
+	assert.Equal(t, 99, globalCfg.Cost.Budgets.ExitCode, "changed flag should override config value")
 }
 
-func TestGetStatusMessage(t *testing.T) {
-	tests := []struct {
-		name     string
-		status   *engine.BudgetStatus
-		expected string
-	}{
-		{
-			name:     "OK status",
-			status:   &engine.BudgetStatus{},
-			expected: "OK - Within budget",
-		},
-		{
-			name: "exceeded threshold",
-			status: &engine.BudgetStatus{
-				Alerts: []engine.ThresholdStatus{
-					{Threshold: 50.0, Status: engine.ThresholdStatusExceeded},
-					{Threshold: 80.0, Status: engine.ThresholdStatusExceeded},
-				},
-			},
-			expected: "WARNING - Exceeds 80% threshold",
-		},
-		{
-			name: "approaching threshold",
-			status: &engine.BudgetStatus{
-				Alerts: []engine.ThresholdStatus{
-					{Threshold: 80.0, Status: engine.ThresholdStatusApproaching},
-				},
-			},
-			expected: "APPROACHING - Near budget threshold",
-		},
-	}
+// T045b: Test that PersistentPreRunE handles nil global config gracefully.
+func TestCostCmd_NilGlobalConfig(t *testing.T) {
+	// Save and restore global config
+	prev := config.GetGlobalConfig()
+	t.Cleanup(func() { config.SetGlobalConfig(prev) })
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, getStatusMessage(tc.status))
-		})
-	}
-}
+	// Ensure no global config is set
+	config.SetGlobalConfig(nil)
 
-func TestCurrencySymbol(t *testing.T) {
-	tests := []struct {
-		currency string
-		expected string
-	}{
-		{"USD", "$"},
-		{"EUR", "€"},
-		{"GBP", "£"},
-		{"JPY", "¥"},
-		{"CAD", "C$"},
-		{"AUD", "A$"},
-		{"CHF", "CHF "},
-		{"XYZ", "XYZ "}, // Unknown currency
-	}
+	cmd := newCostCmd()
+	err := cmd.ParseFlags([]string{"--exit-on-threshold", "--exit-code=5"})
+	require.NoError(t, err)
 
-	for _, tc := range tests {
-		t.Run(tc.currency, func(t *testing.T) {
-			assert.Equal(t, tc.expected, currencySymbol(tc.currency))
-		})
-	}
-}
-
-func TestCalculateBoxWidth(t *testing.T) {
-	tests := []struct {
-		name      string
-		termWidth int
-		expected  int
-	}{
-		{"narrow terminal", 30, minBoxWidth},
-		{"normal terminal", 80, defaultBoxWidth},
-		{"wide terminal", 200, defaultBoxWidth},
-		{"very narrow", 20, minBoxWidth},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := calculateBoxWidth(tc.termWidth)
-			assert.Equal(t, tc.expected, result)
-		})
-	}
-}
-
-func TestCalculateProgressBarWidth(t *testing.T) {
-	tests := []struct {
-		name     string
-		boxWidth int
-		min      int
-		max      int
-	}{
-		{"narrow box", minBoxWidth, minProgressBarWidth, progressBarWidth},
-		{"normal box", defaultBoxWidth, minProgressBarWidth, progressBarWidth},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := calculateProgressBarWidth(tc.boxWidth)
-			assert.GreaterOrEqual(t, result, tc.min)
-			assert.LessOrEqual(t, result, tc.max)
-		})
-	}
-}
-
-func TestIsWriterTerminal(t *testing.T) {
-	// Testing with a bytes.Buffer should return false (not a TTY)
-	var buf bytes.Buffer
-	assert.False(t, isWriterTerminal(&buf))
-
-	// Note: We can't easily test true case without a real terminal
-}
-
-// stripANSI removes ANSI escape codes from a string for content comparison.
-func stripANSI(s string) string {
-	// Simple approach: remove escape sequences between \x1b[ and m
-	result := s
-	for {
-		start := strings.Index(result, "\x1b[")
-		if start == -1 {
-			break
-		}
-		end := strings.Index(result[start:], "m")
-		if end == -1 {
-			break
-		}
-		result = result[:start] + result[start+end+1:]
-	}
-	return result
+	// PersistentPreRunE should not panic or error with nil config
+	err = cmd.PersistentPreRunE(cmd, []string{})
+	assert.NoError(t, err, "should handle nil global config gracefully")
 }

--- a/internal/cli/cost_projected.go
+++ b/internal/cli/cost_projected.go
@@ -158,6 +158,18 @@ func executeCostProjected(cmd *cobra.Command, params costProjectedParams) error 
 	for _, r := range resultWithErrors.Results {
 		totalCost += r.Monthly
 	}
+
+	currency, mixedCurrencies := extractCurrencyFromResults(resultWithErrors.Results)
 	audit.logSuccess(ctx, len(resultWithErrors.Results), totalCost)
+
+	// Evaluate and render budget status (T025: Call checkBudgetExit after renderBudgetIfConfigured)
+	// Render budget status only when currencies are consistent
+	if !mixedCurrencies {
+		budgetStatus, budgetErr := renderBudgetIfConfigured(cmd, totalCost, currency)
+		if exitErr := checkBudgetExit(cmd, budgetStatus, budgetErr); exitErr != nil {
+			return exitErr
+		}
+	}
+
 	return nil
 }

--- a/internal/cli/cost_recommendations.go
+++ b/internal/cli/cost_recommendations.go
@@ -538,7 +538,7 @@ func renderRecommendationsSummary(w io.Writer, recommendations []engine.Recommen
 	totalSavings := 0.0
 	countByAction := make(map[string]int)
 	savingsByAction := make(map[string]float64)
-	currency := "USD"
+	currency := defaultCurrency
 
 	for _, rec := range recommendations {
 		totalSavings += rec.EstimatedSavings
@@ -825,7 +825,7 @@ func buildJSONSummary(recommendations []engine.Recommendation) jsonSummary {
 	countByAction := make(map[string]int)
 	savingsByAction := make(map[string]float64)
 	totalSavings := 0.0
-	currency := "USD"
+	currency := defaultCurrency
 
 	for _, rec := range recommendations {
 		countByAction[rec.Type]++

--- a/internal/cli/cost_recommendations_testhelpers.go
+++ b/internal/cli/cost_recommendations_testhelpers.go
@@ -78,7 +78,7 @@ func RenderRecommendationsTableVerboseForTest(w io.Writer, recs []TestableRecomm
 	result := &engine.RecommendationsResult{
 		Recommendations: engineRecs,
 		TotalSavings:    calculateTotalSavingsForTest(engineRecs),
-		Currency:        "USD",
+		Currency:        defaultCurrency,
 	}
 	return renderRecommendationsTableWithVerbose(w, result, verbose)
 }
@@ -112,7 +112,7 @@ func RenderRecommendationsJSONForTest(w io.Writer, recs []TestableRecommendation
 	result := &engine.RecommendationsResult{
 		Recommendations: engineRecs,
 		TotalSavings:    calculateTotalSavingsForTest(engineRecs),
-		Currency:        "USD",
+		Currency:        defaultCurrency,
 	}
 	return renderRecommendationsJSON(w, result, nil)
 }
@@ -123,7 +123,7 @@ func RenderRecommendationsNDJSONForTest(w io.Writer, recs []TestableRecommendati
 	result := &engine.RecommendationsResult{
 		Recommendations: engineRecs,
 		TotalSavings:    calculateTotalSavingsForTest(engineRecs),
-		Currency:        "USD",
+		Currency:        defaultCurrency,
 	}
 	return renderRecommendationsNDJSON(w, result, nil)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -676,6 +676,8 @@ func (c *Config) SetPluginConfig(pluginName string, config map[string]interface{
 }
 
 // applyEnvOverrides applies environment variable overrides.
+//
+//nolint:gocognit // Complexity is inherent to handling multiple env overrides
 func (c *Config) applyEnvOverrides() {
 	// Compatibility layer for legacy PULUMICOST_ variables
 	if os.Getenv("FINFOCUS_COMPAT") == "1" || os.Getenv("FINFOCUS_COMPAT") == "true" {
@@ -726,6 +728,18 @@ func (c *Config) applyEnvOverrides() {
 				Str("value", maxSize).
 				Err(err).
 				Msg("failed to parse cache max size, using default")
+		}
+	}
+
+	// Budget exit configuration overrides (Issue #219)
+	if exitOnThreshold := os.Getenv("FINFOCUS_BUDGET_EXIT_ON_THRESHOLD"); exitOnThreshold != "" {
+		if e, err := strconv.ParseBool(exitOnThreshold); err == nil {
+			c.Cost.Budgets.ExitOnThreshold = e
+		}
+	}
+	if exitCode := os.Getenv("FINFOCUS_BUDGET_EXIT_CODE"); exitCode != "" {
+		if code, err := strconv.Atoi(exitCode); err == nil {
+			c.Cost.Budgets.ExitCode = code
 		}
 	}
 

--- a/internal/config/integration.go
+++ b/internal/config/integration.go
@@ -35,6 +35,16 @@ func ResetGlobalConfigForTest() {
 	globalConfigInit = false
 }
 
+// SetGlobalConfig sets the global configuration for testing purposes.
+// If cfg is nil, it resets the global config state.
+func SetGlobalConfig(cfg *Config) {
+	globalConfigMu.Lock()
+	defer globalConfigMu.Unlock()
+
+	GlobalConfig = cfg
+	globalConfigInit = cfg != nil
+}
+
 // GetGlobalConfig returns the global configuration, initializing it if needed.
 func GetGlobalConfig() *Config {
 	InitGlobalConfig()

--- a/specs/124-budget-exit-codes/checklists/requirements.md
+++ b/specs/124-budget-exit-codes/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Budget Threshold Exit Codes
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed validation
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- Dependency on Issue #217 (MVP budget alerts) is documented in Assumptions

--- a/specs/124-budget-exit-codes/data-model.md
+++ b/specs/124-budget-exit-codes/data-model.md
@@ -1,0 +1,182 @@
+# Data Model: Budget Threshold Exit Codes
+
+**Feature Branch**: `124-budget-exit-codes`
+**Date**: 2026-01-24
+
+## Entity Changes
+
+### BudgetConfig (Extended)
+
+**Location**: `internal/config/budget.go`
+
+**Current Structure**:
+
+```go
+type BudgetConfig struct {
+    Amount   float64       `yaml:"amount"           json:"amount"`
+    Currency string        `yaml:"currency"         json:"currency"`
+    Period   string        `yaml:"period,omitempty" json:"period,omitempty"`
+    Alerts   []AlertConfig `yaml:"alerts,omitempty" json:"alerts,omitempty"`
+}
+```
+
+**New Fields**:
+
+| Field             | Type   | YAML Key            | Default | Validation      |
+|-------------------|--------|---------------------|---------|-----------------|
+| `ExitOnThreshold` | `bool` | `exit_on_threshold` | `false` | None (boolean)  |
+| `ExitCode`        | `int`  | `exit_code`         | `1`     | Must be 0-255   |
+
+**Extended Structure**:
+
+```go
+type BudgetConfig struct {
+    Amount          float64       `yaml:"amount"                      json:"amount"`
+    Currency        string        `yaml:"currency"                    json:"currency"`
+    Period          string        `yaml:"period,omitempty"            json:"period,omitempty"`
+    Alerts          []AlertConfig `yaml:"alerts,omitempty"            json:"alerts,omitempty"`
+    ExitOnThreshold bool          `yaml:"exit_on_threshold,omitempty" json:"exit_on_threshold,omitempty"`
+    ExitCode        int           `yaml:"exit_code,omitempty"         json:"exit_code,omitempty"`
+}
+```
+
+**New Methods**:
+
+```go
+// GetExitCode returns the configured exit code, defaulting to 1 if not set.
+func (b BudgetConfig) GetExitCode() int
+
+// ShouldExitOnThreshold returns true if exit behavior is enabled.
+func (b BudgetConfig) ShouldExitOnThreshold() bool
+```
+
+**Validation Rules**:
+
+1. `exit_code` must be in range 0-255 (inclusive)
+2. Negative exit codes are rejected with `ErrExitCodeOutOfRange`
+3. Exit codes > 255 are rejected with `ErrExitCodeOutOfRange`
+4. Validation only runs when `exit_on_threshold: true`
+
+### BudgetStatus (Extended)
+
+**Location**: `internal/engine/budget_cli.go`
+
+**Current Structure**:
+
+```go
+type BudgetStatus struct {
+    Budget             BudgetConfig
+    CurrentSpend       float64
+    Percentage         float64
+    ForecastedSpend    float64
+    ForecastPercentage float64
+    Alerts             []ThresholdStatus
+    Currency           string
+}
+```
+
+**New Methods** (no new fields):
+
+```go
+// ShouldExit determines if the CLI should exit with non-zero code.
+// Returns true if:
+//   - Budget has ExitOnThreshold enabled, AND
+//   - Any alert threshold has been exceeded (EXCEEDED status)
+func (s *BudgetStatus) ShouldExit() bool
+
+// GetExitCode returns the exit code to use when ShouldExit() is true.
+// Returns 0 if ShouldExit() would return false.
+// Returns Budget.GetExitCode() otherwise.
+func (s *BudgetStatus) GetExitCode() int
+
+// ExitReason returns a human-readable explanation for the exit code.
+// Used for --debug logging and error messages.
+func (s *BudgetStatus) ExitReason() string
+```
+
+## New Error Types
+
+**Location**: `internal/config/budget.go`
+
+```go
+var (
+    // ErrExitCodeOutOfRange is returned when exit_code is not in 0-255 range.
+    ErrExitCodeOutOfRange = errors.New("exit_code must be between 0 and 255")
+)
+```
+
+## Configuration Examples
+
+### YAML Config File
+
+```yaml
+# ~/.finfocus/config.yaml
+cost:
+  budgets:
+    amount: 100
+    currency: USD
+    alerts:
+      - threshold: 80
+        type: actual
+      - threshold: 100
+        type: actual
+    exit_on_threshold: true
+    exit_code: 2
+```
+
+### Environment Variables
+
+| Variable                            | Type   | Description                                |
+|-------------------------------------|--------|--------------------------------------------|
+| `FINFOCUS_BUDGET_EXIT_ON_THRESHOLD` | string | "true", "1" enables; "false", "0" disables |
+| `FINFOCUS_BUDGET_EXIT_CODE`         | string | Integer value 0-255                        |
+
+### CLI Flags
+
+| Flag                  | Type | Description                       |
+|-----------------------|------|-----------------------------------|
+| `--exit-on-threshold` | bool | Enable exit on threshold exceeded |
+| `--exit-code`         | int  | Exit code to use (default: 1)     |
+
+## State Transitions
+
+Exit code evaluation is stateless—it reads current configuration and budget status, then determines exit behavior:
+
+```text
+[BudgetStatus] → ShouldExit() → true/false
+                      │
+                      ├── ExitOnThreshold: false → false
+                      ├── ExitOnThreshold: true, No alerts exceeded → false
+                      └── ExitOnThreshold: true, Alert exceeded → true
+                                │
+                                └── GetExitCode() → 0-255
+```
+
+## Precedence Rules
+
+Configuration values are merged with the following precedence (highest to lowest):
+
+1. **CLI Flags**: `--exit-on-threshold`, `--exit-code`
+2. **Environment Variables**: `FINFOCUS_BUDGET_EXIT_ON_THRESHOLD`, `FINFOCUS_BUDGET_EXIT_CODE`
+3. **Config File**: `cost.budgets.exit_on_threshold`, `cost.budgets.exit_code`
+4. **Defaults**: `exit_on_threshold: false`, `exit_code: 1`
+
+## Relationships
+
+```text
+Config
+  └── CostConfig
+        └── BudgetConfig
+              ├── Amount, Currency, Period
+              ├── Alerts[]
+              ├── ExitOnThreshold (NEW)
+              └── ExitCode (NEW)
+
+Engine
+  └── BudgetStatus
+        ├── Budget (BudgetConfig)
+        ├── Alerts[] (ThresholdStatus)
+        ├── ShouldExit() (NEW method)
+        ├── GetExitCode() (NEW method)
+        └── ExitReason() (NEW method)
+```

--- a/specs/124-budget-exit-codes/plan.md
+++ b/specs/124-budget-exit-codes/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: Budget Threshold Exit Codes
+
+**Branch**: `124-budget-exit-codes` | **Date**: 2026-01-24 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/124-budget-exit-codes/spec.md`
+
+## Summary
+
+Add configurable exit codes when budget thresholds are exceeded, enabling CI/CD pipeline integration for automated cost governance. The implementation extends `BudgetConfig` with `exit_on_threshold` and `exit_code` fields, adds environment variable and CLI flag support, and integrates exit code evaluation into the cost command post-render flow.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.5
+**Primary Dependencies**: github.com/spf13/cobra (CLI), github.com/rs/zerolog (logging), github.com/rshade/finfocus-spec (proto definitions)
+**Storage**: YAML config file (~/.finfocus/config.yaml)
+**Testing**: go test with testify (require/assert), 80% minimum coverage
+**Target Platform**: Linux (amd64, arm64), macOS (amd64, arm64), Windows (amd64)
+**Project Type**: Single CLI application
+**Performance Goals**: Exit code evaluation adds negligible overhead (<1ms)
+**Constraints**: Exit codes must be 0-255 (Unix standard), output must render before exit
+**Scale/Scope**: Feature-scoped change affecting 3-4 packages (config, engine, cli)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Verify compliance with FinFocus Core Constitution (`.specify/memory/constitution.md`):
+
+- [x] **Plugin-First Architecture**: This is core orchestration logic (exit behavior), not a data source—appropriate for core.
+- [x] **Test-Driven Development**: Tests planned for config parsing, environment variable precedence, exit code evaluation, and CLI integration (80%+ coverage).
+- [x] **Cross-Platform Compatibility**: Exit codes 0-255 are universal across Linux, macOS, Windows.
+- [x] **Documentation Synchronization**: README and docs/ updates included in implementation scope.
+- [x] **Protocol Stability**: No protocol changes—this is CLI-only behavior.
+- [x] **Implementation Completeness**: Feature will be fully implemented with no stubs or TODOs.
+- [x] **Quality Gates**: All CI checks (tests, lint, security) will pass before merge.
+- [x] **Multi-Repo Coordination**: No cross-repo changes required—feature is core-only.
+
+**Violations Requiring Justification**: None
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/124-budget-exit-codes/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (N/A - no API contracts)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+internal/
+├── config/
+│   └── budget.go        # Add ExitOnThreshold, ExitCode fields to BudgetConfig
+├── engine/
+│   └── budget_cli.go    # Add ShouldExit() and GetExitCode() methods to BudgetStatus
+└── cli/
+    ├── cost.go            # Add --exit-on-threshold, --exit-code flags to parent command
+    ├── cost_budget.go     # Add checkBudgetExit() helper function
+    ├── cost_projected.go  # Call exit logic after render
+    └── cost_actual.go     # Call exit logic after render
+
+test/
+├── unit/
+│   └── config/          # Exit code config parsing tests
+├── integration/
+│   └── budget_exit_test.go  # CI/CD simulation tests
+└── fixtures/
+    └── configs/         # Test config files with exit settings
+```
+
+**Structure Decision**: Single CLI application pattern. Changes are localized to config (data model), engine (exit logic), and cli (flag handling + exit invocation).
+
+## Complexity Tracking
+
+> **No violations requiring justification**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|--------------------------------------|
+| None      | N/A        | N/A                                  |

--- a/specs/124-budget-exit-codes/quickstart.md
+++ b/specs/124-budget-exit-codes/quickstart.md
@@ -1,0 +1,167 @@
+# Quickstart: Budget Threshold Exit Codes
+
+**Feature Branch**: `124-budget-exit-codes`
+**Date**: 2026-01-24
+
+## Overview
+
+This feature enables CI/CD pipelines to detect budget threshold violations through exit codes, without parsing command output.
+
+## Quick Setup
+
+### 1. Configure Budget with Exit Behavior
+
+Add to `~/.finfocus/config.yaml`:
+
+```yaml
+cost:
+  budgets:
+    amount: 100
+    currency: USD
+    alerts:
+      - threshold: 80
+        type: actual
+      - threshold: 100
+        type: actual
+    exit_on_threshold: true
+    exit_code: 2
+```
+
+### 2. Run Cost Command
+
+```bash
+finfocus cost projected --pulumi-json plan.json
+echo "Exit code: $?"
+```
+
+### 3. Expected Behavior
+
+| Scenario                    | Exit Code      |
+|-----------------------------|----------------|
+| Cost under all thresholds   | 0              |
+| Cost exceeds 80% threshold  | 2 (configured) |
+| Cost exceeds 100% threshold | 2 (configured) |
+| No budget configured        | 0              |
+| Error during evaluation     | 1              |
+
+## Environment Variable Configuration
+
+Override config file settings per-environment:
+
+```bash
+# Enable exit behavior for CI
+export FINFOCUS_BUDGET_EXIT_ON_THRESHOLD=true
+export FINFOCUS_BUDGET_EXIT_CODE=2
+
+finfocus cost projected --pulumi-json plan.json
+```
+
+## CLI Flag Override
+
+Override at runtime for one-off checks:
+
+```bash
+# Force exit behavior even if not in config
+finfocus cost projected --pulumi-json plan.json --exit-on-threshold --exit-code 3
+```
+
+## CI/CD Integration Example
+
+### GitHub Actions
+
+```yaml
+jobs:
+  cost-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Pulumi Preview
+        run: pulumi preview --json > plan.json
+
+      - name: Check Cost Budget
+        run: |
+          finfocus cost projected --pulumi-json plan.json --exit-on-threshold
+        continue-on-error: false  # Fail pipeline if budget exceeded
+```
+
+### GitLab CI
+
+```yaml
+cost-check:
+  script:
+    - pulumi preview --json > plan.json
+    - finfocus cost projected --pulumi-json plan.json --exit-on-threshold
+  allow_failure: false
+```
+
+### Jenkins
+
+```groovy
+pipeline {
+    stages {
+        stage('Cost Check') {
+            steps {
+                sh 'pulumi preview --json > plan.json'
+                sh 'finfocus cost projected --pulumi-json plan.json --exit-on-threshold'
+            }
+        }
+    }
+}
+```
+
+## Debugging
+
+Enable debug output to see exit code reasoning:
+
+```bash
+finfocus cost projected --pulumi-json plan.json --exit-on-threshold --debug
+```
+
+Sample debug output:
+
+```text
+DBG exit code evaluation component=cli reason="threshold 80% exceeded" exit_code=2
+```
+
+## Common Patterns
+
+### Warning-Only (No Pipeline Failure)
+
+Set `exit_code: 0` to log warnings without failing:
+
+```yaml
+cost:
+  budgets:
+    amount: 100
+    currency: USD
+    exit_on_threshold: true
+    exit_code: 0  # Logs threshold exceeded but exits 0
+```
+
+### Different Codes for Different Thresholds
+
+Currently, all thresholds use the same exit code. For differentiated behavior, use multiple runs or external scripting:
+
+```bash
+# Check 100% threshold
+if finfocus cost projected --pulumi-json plan.json --exit-on-threshold; then
+  echo "Budget OK"
+else
+  echo "Budget EXCEEDED"
+  exit 2
+fi
+```
+
+## Validation
+
+Test your configuration:
+
+```bash
+# Verify config is valid
+finfocus config show
+
+# Test with a known high-cost plan
+finfocus cost projected --pulumi-json high-cost-plan.json --debug
+echo "Exit code: $?"
+```

--- a/specs/124-budget-exit-codes/research.md
+++ b/specs/124-budget-exit-codes/research.md
@@ -1,0 +1,182 @@
+# Research: Budget Threshold Exit Codes
+
+**Feature Branch**: `124-budget-exit-codes`
+**Date**: 2026-01-24
+
+## Research Summary
+
+All technical unknowns from the Technical Context have been resolved through codebase analysis.
+
+## Decisions
+
+### 1. Configuration Structure Location
+
+**Decision**: Extend existing `BudgetConfig` struct in `internal/config/budget.go`
+
+**Rationale**: The `BudgetConfig` struct already contains all budget-related settings (Amount, Currency, Period, Alerts). Adding `ExitOnThreshold` and `ExitCode` fields keeps all budget configuration cohesive.
+
+**Alternatives Considered**:
+
+- Separate `ExitConfig` struct: Rejected—fragments budget configuration unnecessarily
+- Top-level config fields: Rejected—exit codes are budget-specific, not global
+
+### 2. Environment Variable Naming
+
+**Decision**: Use `FINFOCUS_BUDGET_EXIT_ON_THRESHOLD` and `FINFOCUS_BUDGET_EXIT_CODE`
+
+**Rationale**: Follows established pattern (`FINFOCUS_*` prefix) and maintains consistency with existing env vars like `FINFOCUS_CACHE_ENABLED`, `FINFOCUS_LOG_LEVEL`.
+
+**Alternatives Considered**:
+
+- `FINFOCUS_EXIT_*`: Rejected—too generic, not budget-specific
+- `FINFOCUS_COST_EXIT_*`: Rejected—budget is the specific subsystem, not cost
+
+### 3. Exit Logic Location
+
+**Decision**: Add `ShouldExit()` and `GetExitCode()` methods to `BudgetStatus` in `internal/engine/budget_cli.go`
+
+**Rationale**: `BudgetStatus` already contains threshold evaluation results (`HasExceededAlerts()`). Adding exit determination here keeps the logic cohesive and testable.
+
+**Alternatives Considered**:
+
+- Separate exit evaluation function: Rejected—duplicates threshold checking logic
+- CLI-only implementation: Rejected—logic should be testable in isolation
+
+### 4. CLI Integration Point
+
+**Decision**: Call exit logic after `renderBudgetIfConfigured()` in cost commands
+
+**Rationale**: The existing `renderBudgetIfConfigured()` function in `cost_budget.go` evaluates the budget and renders status. Exit code evaluation naturally follows after output is complete.
+
+**Alternatives Considered**:
+
+- PersistentPostRunE hook: Rejected—budget context not available at that level
+- Inside renderBudgetIfConfigured: Rejected—mixing concerns (render vs exit)
+
+### 5. CLI Flag Registration
+
+**Decision**: Add flags to parent `cost` command in `cost.go`, not individual subcommands
+
+**Rationale**: Exit behavior applies to both `cost projected` and `cost actual`. Adding to parent command avoids duplication and ensures consistent flag handling.
+
+**Alternatives Considered**:
+
+- Per-subcommand flags: Rejected—duplication, inconsistent behavior risk
+- Root command flags: Rejected—exit codes are cost-specific, not global
+
+### 6. Exit Code Range Validation
+
+**Decision**: Validate exit codes 0-255 in `BudgetConfig.Validate()`
+
+**Rationale**: Unix exit codes are limited to 0-255. Validation at config level provides early feedback and prevents runtime surprises.
+
+**Alternatives Considered**:
+
+- No validation (let OS clamp): Rejected—silent behavior change is confusing
+- Allow negative values: Rejected—no valid use case, increases error surface
+
+### 7. Configuration Precedence
+
+**Decision**: CLI flags > Environment Variables > Config File > Defaults
+
+**Rationale**: Standard precedence pattern used throughout FinFocus (see `applyEnvironmentOverrides()`). Most specific (runtime) overrides least specific (defaults).
+
+**Alternatives Considered**:
+
+- Env vars override CLI flags: Rejected—counterintuitive, breaks standard patterns
+- Config file overrides env vars: Rejected—breaks 12-factor app principles
+
+### 8. Default Exit Code Value
+
+**Decision**: Default exit code is 1 when `exit_on_threshold: true`
+
+**Rationale**: Exit code 1 is the standard Unix convention for general errors/failures. Code 0 is reserved for success.
+
+**Alternatives Considered**:
+
+- Default to 0: Rejected—defeats purpose of exit_on_threshold
+- Default to 2: Rejected—no standard meaning, would confuse users
+
+### 9. Exit Code 0 Behavior
+
+**Decision**: Allow explicit `exit_code: 0` to disable exit even with `exit_on_threshold: true`
+
+**Rationale**: Provides an escape hatch for users who want threshold logging/alerts without pipeline failure. Edge case documented in spec.
+
+**Alternatives Considered**:
+
+- Reject exit_code 0: Rejected—limits user flexibility unnecessarily
+- Ignore exit_on_threshold if code is 0: Rejected—implicit behavior is confusing
+
+## Existing Code Patterns to Follow
+
+### Environment Variable Override Pattern
+
+From `internal/config/config.go`:
+
+```go
+func applyEnvironmentOverrides(cfg *Config) {
+    if enabled := os.Getenv("FINFOCUS_CACHE_ENABLED"); enabled != "" {
+        cfg.Cost.Cache.Enabled = enabled == "true" || enabled == "1"
+    }
+    if ttl := os.Getenv("FINFOCUS_CACHE_TTL_SECONDS"); ttl != "" {
+        if v, err := strconv.Atoi(ttl); err == nil {
+            cfg.Cost.Cache.TTLSeconds = v
+        }
+    }
+}
+```
+
+### Budget Status Methods Pattern
+
+From `internal/engine/budget_cli.go`:
+
+```go
+func (s *BudgetStatus) HasExceededAlerts() bool {
+    for _, alert := range s.Alerts {
+        if alert.Status == ThresholdStatusExceeded {
+            return true
+        }
+    }
+    return false
+}
+```
+
+### Config Validation Pattern
+
+From `internal/config/budget.go`:
+
+```go
+func (b BudgetConfig) Validate() error {
+    if b.Amount < 0 {
+        return ErrBudgetAmountNegative
+    }
+    // ... additional validations
+    return nil
+}
+```
+
+## Files to Modify
+
+| File                              | Change                                                         |
+|-----------------------------------|----------------------------------------------------------------|
+| `internal/config/budget.go`       | Add `ExitOnThreshold`, `ExitCode` fields to `BudgetConfig`     |
+| `internal/config/budget.go`       | Add validation for exit code range (0-255)                     |
+| `internal/config/config.go`       | Add env var overrides in `applyEnvironmentOverrides()`         |
+| `internal/engine/budget_cli.go`   | Add `ShouldExit()`, `GetExitCode()` methods to `BudgetStatus`  |
+| `internal/cli/cost.go`            | Add `--exit-on-threshold`, `--exit-code` flags                 |
+| `internal/cli/cost_projected.go`  | Call exit logic after render                                   |
+| `internal/cli/cost_actual.go`     | Call exit logic after render                                   |
+
+## New Files to Create
+
+| File                                   | Purpose                                            |
+|----------------------------------------|----------------------------------------------------|
+| `internal/config/budget_test.go`       | Tests for new exit code config fields              |
+| `internal/engine/budget_cli_test.go`   | Tests for ShouldExit/GetExitCode (extend existing) |
+| `test/integration/budget_exit_test.go` | CI/CD simulation integration tests                 |
+
+## Dependencies Confirmed
+
+- **Issue #217 (MVP Budget Alerts)**: The `BudgetStatus.HasExceededAlerts()` method exists and works correctly. Exit code feature can build on this.
+- **No cross-repo changes**: Feature is entirely within finfocus-core.

--- a/specs/124-budget-exit-codes/spec.md
+++ b/specs/124-budget-exit-codes/spec.md
@@ -1,0 +1,124 @@
+# Feature Specification: Budget Threshold Exit Codes
+
+**Feature Branch**: `124-budget-exit-codes`
+**Created**: 2026-01-24
+**Status**: Draft
+**Input**: User description: "Add configurable exit codes when budget thresholds are exceeded, enabling CI/CD pipeline integration for automated cost governance."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - CI/CD Pipeline Fails on Budget Exceeded (Priority: P1)
+
+A CI/CD operator configures their pipeline to fail when cost estimates exceed the configured budget, preventing deployments that would bust the budget.
+
+**Why this priority**: This is the core value proposition—enabling automated cost governance in CI/CD pipelines. Without this, there's no machine-readable signal for pipelines to act on.
+
+**Independent Test**: Can be fully tested by running `finfocus cost projected` with a Pulumi plan that exceeds budget, verifying the command exits with a non-zero code, and confirming the exit code value matches configuration.
+
+**Acceptance Scenarios**:
+
+1. **Given** a budget of $100 is configured with `exit_on_threshold: true`, **When** the projected cost is $150, **Then** the command exits with exit code 1 (default).
+2. **Given** a budget of $100 is configured with `exit_on_threshold: true` and `exit_code: 2`, **When** the projected cost is $150, **Then** the command exits with exit code 2.
+3. **Given** a budget of $100 is configured with `exit_on_threshold: true`, **When** the projected cost is $80, **Then** the command exits with exit code 0 (no threshold exceeded).
+4. **Given** no budget is configured, **When** the cost command runs, **Then** the command exits with exit code 0 regardless of cost.
+
+---
+
+### User Story 2 - Environment-Based Exit Code Configuration (Priority: P2)
+
+A platform engineer sets different exit behaviors for different environments using environment variables, allowing production to be strict while development is lenient.
+
+**Why this priority**: Multi-environment support is essential for real-world CI/CD adoption where different environments have different policies.
+
+**Independent Test**: Can be tested by setting environment variables and verifying exit code behavior matches the environment configuration without any config file.
+
+**Acceptance Scenarios**:
+
+1. **Given** `FINFOCUS_BUDGET_EXIT_ON_THRESHOLD=true` is set, **When** budget is exceeded, **Then** the command exits with non-zero code.
+2. **Given** `FINFOCUS_BUDGET_EXIT_ON_THRESHOLD=false` is set (overriding config file with `exit_on_threshold: true`), **When** budget is exceeded, **Then** the command exits with code 0.
+3. **Given** `FINFOCUS_BUDGET_EXIT_CODE=3` is set, **When** budget is exceeded with exit enabled, **Then** the command exits with code 3.
+4. **Given** both environment variable and config file specify exit code, **When** budget is exceeded, **Then** environment variable takes precedence.
+
+---
+
+### User Story 3 - Warning Threshold Exit Behavior (Priority: P2)
+
+A FinOps manager configures warning thresholds (e.g., 80%) to trigger non-zero exit codes, enabling early warning in pipelines before budget is fully consumed.
+
+**Why this priority**: Early warning prevents surprises and allows teams to take action before hitting hard budget limits.
+
+**Independent Test**: Can be tested by configuring an 80% warning threshold, running cost command with spend at 85%, and verifying exit code behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a budget of $100 with 80% warning alert and `exit_on_threshold: true`, **When** projected cost is $85, **Then** the command exits with configured exit code.
+2. **Given** a budget of $100 with 80% warning alert and `exit_on_threshold: true`, **When** projected cost is $70, **Then** the command exits with code 0 (below warning threshold).
+3. **Given** multiple thresholds (50%, 80%, 100%) with `exit_on_threshold: true`, **When** any threshold is exceeded, **Then** the command exits with the configured exit code.
+
+---
+
+### User Story 4 - CLI Flag Overrides (Priority: P3)
+
+An operator overrides the configured exit behavior at runtime using CLI flags for one-off checks or testing.
+
+**Why this priority**: Runtime flexibility is valuable but less common than persistent configuration.
+
+**Independent Test**: Can be tested by passing CLI flags and verifying they override config file settings for that invocation.
+
+**Acceptance Scenarios**:
+
+1. **Given** config file has `exit_on_threshold: false`, **When** `--exit-on-threshold` flag is passed, **Then** the command exits with non-zero code on budget exceeded.
+2. **Given** config file has `exit_code: 1`, **When** `--exit-code 5` flag is passed, **Then** the command exits with code 5 on budget exceeded.
+3. **Given** environment variable `FINFOCUS_BUDGET_EXIT_CODE=3` is set, **When** `--exit-code 7` flag is passed, **Then** CLI flag takes precedence and command exits with code 7.
+
+---
+
+### Edge Cases
+
+- What happens when exit code is set to 0 explicitly? (Allowed—disables exit behavior even with `exit_on_threshold: true`)
+- What happens when exit code is set to a negative number? (Rejected as invalid during configuration validation)
+- What happens when exit code exceeds 255 (maximum Unix exit code)? (Clamped to 255 or rejected during validation)
+- What happens when both `exit_on_threshold: false` and `--exit-on-threshold` flag are used? (CLI flag wins per precedence rules)
+- What happens when budget evaluation fails due to currency mismatch? (Exit with code 1 for error, not configured exit code)
+- What happens when the cost calculation itself encounters errors? (Continue to output, evaluate budget if possible, then exit with appropriate code)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST support `exit_on_threshold` configuration option (boolean) to enable non-zero exit codes when budget thresholds are exceeded.
+- **FR-002**: System MUST support `exit_code` configuration option (integer) to customize the exit code value, defaulting to 1.
+- **FR-003**: System MUST evaluate budget thresholds after rendering cost output, ensuring users always see the cost data before the process exits.
+- **FR-004**: System MUST support environment variable overrides: `FINFOCUS_BUDGET_EXIT_ON_THRESHOLD` and `FINFOCUS_BUDGET_EXIT_CODE`.
+- **FR-005**: System MUST apply configuration precedence: CLI flags > environment variables > config file > defaults.
+- **FR-006**: System MUST exit with code 0 when no budget is configured, regardless of cost.
+- **FR-007**: System MUST exit with code 0 when cost is below all configured thresholds.
+- **FR-008**: System MUST exit with the configured exit code when any threshold is exceeded (warning, budget, or forecast).
+- **FR-009**: System MUST exit with code 1 when an error occurs during budget evaluation (distinct from threshold exceeded).
+- **FR-010**: System MUST validate exit codes are within valid range (0-255) and reject invalid configurations.
+- **FR-011**: System MUST support CLI flags `--exit-on-threshold` and `--exit-code` for runtime override.
+- **FR-012**: System MUST log the exit code reason when `--debug` is enabled for troubleshooting.
+
+### Key Entities *(include if feature involves data)*
+
+- **Exit Code Configuration**: Settings controlling when and how the CLI returns non-zero exit codes. Contains `exit_on_threshold` (boolean), `exit_code` (integer 0-255).
+- **Budget Evaluation Result**: Extended result from budget evaluation that includes exit code decision. Contains `ThresholdExceeded` (boolean), `ShouldExit` (boolean), `ExitCode` (integer), `Reason` (string for debugging).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: CI/CD pipelines can detect budget threshold violations without parsing command output (exit code alone is sufficient).
+- **SC-002**: Users can configure exit behavior through any of three methods (config file, environment variable, CLI flag) with consistent results.
+- **SC-003**: Cost output is always displayed before exit, ensuring users never lose visibility into cost data due to exit behavior.
+- **SC-004**: Exit code configuration errors are reported clearly with actionable messages identifying the invalid setting.
+- **SC-005**: All existing cost command behavior remains unchanged when exit behavior is not configured (zero breaking changes for existing users).
+- **SC-006**: Exit behavior integrates seamlessly with existing budget status rendering (budget status box appears before exit).
+
+## Assumptions
+
+- **A-001**: The existing budget configuration structure (`BudgetConfig` in `config/budget.go`) will be extended with new fields rather than creating a separate configuration structure.
+- **A-002**: Exit code behavior applies to both `cost projected` and `cost actual` commands equally.
+- **A-003**: The exit code for error conditions (code 1) is not configurable—only threshold-exceeded exit codes are configurable.
+- **A-004**: Exit codes are evaluated after all output is rendered, including budget status display.
+- **A-005**: The feature depends on Issue #217 (MVP budget alerts) being implemented, as exit behavior relies on threshold evaluation.

--- a/specs/124-budget-exit-codes/tasks.md
+++ b/specs/124-budget-exit-codes/tasks.md
@@ -1,0 +1,262 @@
+# Tasks: Budget Threshold Exit Codes
+
+**Input**: Design documents from `/specs/124-budget-exit-codes/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Tests**: Per Constitution Principle II (Test-Driven Development), tests are MANDATORY and must be written BEFORE implementation. All code changes must maintain minimum 80% test coverage (95% for critical paths).
+
+**Completeness**: Per Constitution Principle VI (Implementation Completeness), all tasks MUST be fully implemented. Stub functions, placeholders, and TODO comments are strictly forbidden.
+
+**Documentation**: Per Constitution Principle IV, documentation (README, docs/) MUST be updated concurrently with implementation to prevent drift.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Go project**: `internal/` for packages, `test/` for tests
+- Paths shown below match the finfocus repository structure
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Branch preparation and structure verification
+
+- [ ] T001 Verify branch `124-budget-exit-codes` is checked out and up-to-date with main
+- [ ] T002 [P] Verify all dependencies are installed (`go mod download`)
+- [ ] T003 [P] Run existing tests to establish baseline (`make test`)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core configuration and error types that ALL user stories depend on
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+### Tests for Foundational (MANDATORY - TDD Required) ⚠️
+
+- [ ] T004 [P] Unit test for `ErrExitCodeOutOfRange` error type in `internal/config/budget_test.go`
+- [ ] T005 [P] Unit test for `BudgetConfig.GetExitCode()` method in `internal/config/budget_test.go`
+- [ ] T006 [P] Unit test for `BudgetConfig.ShouldExitOnThreshold()` method in `internal/config/budget_test.go`
+- [ ] T007 [P] Unit test for exit code validation (0-255 range) in `internal/config/budget_test.go`
+
+### Implementation for Foundational
+
+- [ ] T008 Add `ErrExitCodeOutOfRange` error variable in `internal/config/budget.go`
+- [ ] T009 Add `ExitOnThreshold` and `ExitCode` fields to `BudgetConfig` struct in `internal/config/budget.go`
+- [ ] T010 Implement `GetExitCode()` method (returns 1 if not set) in `internal/config/budget.go`
+- [ ] T011 Implement `ShouldExitOnThreshold()` method in `internal/config/budget.go`
+- [ ] T012 Add exit code range validation (0-255) to `BudgetConfig.Validate()` in `internal/config/budget.go`
+
+**Checkpoint**: Foundation ready - BudgetConfig can store and validate exit settings
+
+---
+
+## Phase 3: User Story 1 - CI/CD Pipeline Fails on Budget Exceeded (Priority: P1) 🎯 MVP
+
+**Goal**: When budget threshold is exceeded with `exit_on_threshold: true`, CLI exits with configured code
+
+**Independent Test**: Configure `exit_on_threshold: true` in config, run `cost projected` with high-cost plan, verify exit code matches configured value
+
+### Tests for User Story 1 (MANDATORY - TDD Required) ⚠️
+
+> **CONSTITUTION REQUIREMENT: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T013 [P] [US1] Unit test for `BudgetStatus.ShouldExit()` returns false when disabled in `internal/engine/budget_cli_test.go`
+- [ ] T014 [P] [US1] Unit test for `BudgetStatus.ShouldExit()` returns false when no thresholds exceeded in `internal/engine/budget_cli_test.go`
+- [ ] T015 [P] [US1] Unit test for `BudgetStatus.ShouldExit()` returns true when enabled AND threshold exceeded in `internal/engine/budget_cli_test.go`
+- [ ] T016 [P] [US1] Unit test for `BudgetStatus.GetExitCode()` returns 0 when should not exit in `internal/engine/budget_cli_test.go`
+- [ ] T017 [P] [US1] Unit test for `BudgetStatus.GetExitCode()` returns configured code when should exit in `internal/engine/budget_cli_test.go`
+- [ ] T018 [P] [US1] Unit test for `BudgetStatus.ExitReason()` returns empty string when no exit in `internal/engine/budget_cli_test.go`
+- [ ] T019 [P] [US1] Unit test for `BudgetStatus.ExitReason()` returns descriptive message on exit in `internal/engine/budget_cli_test.go`
+- [ ] T020 [US1] Integration test for config file with `exit_on_threshold: true` in `test/integration/budget_exit_test.go`
+- [ ] T020a [US1] Unit test for exit code 1 when budget evaluation error occurs (FR-009) in `internal/engine/budget_cli_test.go`
+
+### Implementation for User Story 1
+
+- [ ] T021 [US1] Implement `BudgetStatus.ShouldExit()` method in `internal/engine/budget_cli.go`
+- [ ] T022 [US1] Implement `BudgetStatus.GetExitCode()` method in `internal/engine/budget_cli.go`
+- [ ] T023 [US1] Implement `BudgetStatus.ExitReason()` method in `internal/engine/budget_cli.go`
+- [ ] T024 [US1] Add `checkBudgetExit()` helper function in `internal/cli/cost_budget.go`
+- [ ] T025 [US1] Call `checkBudgetExit()` after `renderBudgetIfConfigured()` in `internal/cli/cost_projected.go`
+- [ ] T026 [US1] Call `checkBudgetExit()` after `renderBudgetIfConfigured()` in `internal/cli/cost_actual.go`
+- [ ] T027 [US1] Add debug logging for exit code evaluation in `internal/cli/cost_budget.go`
+- [ ] T027a [US1] Handle budget evaluation errors with exit code 1 (FR-009) in `internal/cli/cost_budget.go`
+
+**Checkpoint**: MVP complete - exit codes work from config file
+
+---
+
+## Phase 4: User Story 2 - Environment-Based Exit Code Configuration (Priority: P2)
+
+**Goal**: DevOps teams can configure exit behavior via environment variables without modifying config files
+
+**Independent Test**: Set `FINFOCUS_BUDGET_EXIT_ON_THRESHOLD=true` and `FINFOCUS_BUDGET_EXIT_CODE=3`, run `cost projected`, verify exit code is 3
+
+### Tests for User Story 2 (MANDATORY - TDD Required) ⚠️
+
+- [ ] T028 [P] [US2] Unit test for `FINFOCUS_BUDGET_EXIT_ON_THRESHOLD=true` enables exit in `internal/config/config_test.go`
+- [ ] T029 [P] [US2] Unit test for `FINFOCUS_BUDGET_EXIT_ON_THRESHOLD=1` enables exit in `internal/config/config_test.go`
+- [ ] T030 [P] [US2] Unit test for `FINFOCUS_BUDGET_EXIT_ON_THRESHOLD=false` disables exit in `internal/config/config_test.go`
+- [ ] T031 [P] [US2] Unit test for `FINFOCUS_BUDGET_EXIT_CODE=42` sets exit code in `internal/config/config_test.go`
+- [ ] T032 [P] [US2] Unit test for env var overriding config file value in `internal/config/config_test.go`
+- [ ] T033 [US2] Integration test for environment variable configuration in `test/integration/budget_exit_test.go`
+
+### Implementation for User Story 2
+
+- [ ] T034 [US2] Add `FINFOCUS_BUDGET_EXIT_ON_THRESHOLD` handling in `applyEnvironmentOverrides()` in `internal/config/config.go`
+- [ ] T035 [US2] Add `FINFOCUS_BUDGET_EXIT_CODE` handling in `applyEnvironmentOverrides()` in `internal/config/config.go`
+
+**Checkpoint**: Environment variable configuration works
+
+---
+
+## Phase 5: User Story 3 - Warning Threshold Exit Behavior (Priority: P2)
+
+**Goal**: Explicit `exit_code: 0` provides warning logs without pipeline failure
+
+**Independent Test**: Configure `exit_on_threshold: true` and `exit_code: 0`, trigger threshold, verify exit code is 0 with logged warning
+
+### Tests for User Story 3 (MANDATORY - TDD Required) ⚠️
+
+- [ ] T036 [P] [US3] Unit test for `exit_code: 0` with `exit_on_threshold: true` returns exit 0 in `internal/engine/budget_cli_test.go`
+- [ ] T037 [P] [US3] Unit test for warning log when `exit_code: 0` and threshold exceeded in `internal/cli/cost_budget_test.go`
+- [ ] T038 [US3] Integration test for warning-only mode in `test/integration/budget_exit_test.go`
+
+### Implementation for User Story 3
+
+- [ ] T039 [US3] Add warning log output when `exit_code: 0` and threshold exceeded in `internal/cli/cost_budget.go`
+- [ ] T040 [US3] Update `ExitReason()` to indicate warning-only mode in `internal/engine/budget_cli.go`
+
+**Checkpoint**: Warning-only mode works without failing pipelines
+
+---
+
+## Phase 6: User Story 4 - CLI Flag Overrides (Priority: P3)
+
+**Goal**: Operators can override exit behavior for single runs without changing config or environment
+
+**Independent Test**: Run `cost projected --exit-on-threshold --exit-code 5 --pulumi-json plan.json`, verify exit code is 5 when threshold exceeded
+
+### Tests for User Story 4 (MANDATORY - TDD Required) ⚠️
+
+- [ ] T041 [P] [US4] Unit test for `--exit-on-threshold` flag parsing in `internal/cli/cost_test.go`
+- [ ] T042 [P] [US4] Unit test for `--exit-code` flag parsing in `internal/cli/cost_test.go`
+- [ ] T043 [P] [US4] Unit test for CLI flags overriding environment variables in `internal/cli/cost_test.go`
+- [ ] T044 [P] [US4] Unit test for CLI flags overriding config file values in `internal/cli/cost_test.go`
+- [ ] T045 [US4] Integration test for CLI flag overrides in `test/integration/budget_exit_test.go`
+
+### Implementation for User Story 4
+
+- [ ] T046 [US4] Add `--exit-on-threshold` persistent flag to `cost` command in `internal/cli/cost.go`
+- [ ] T047 [US4] Add `--exit-code` persistent flag to `cost` command in `internal/cli/cost.go`
+- [ ] T048 [US4] Apply CLI flag values to BudgetConfig in `cost_projected.go` before evaluation
+- [ ] T049 [US4] Apply CLI flag values to BudgetConfig in `cost_actual.go` before evaluation
+
+**Checkpoint**: Full configuration precedence (CLI > Env > Config > Default) works
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, edge cases, and final validation
+
+- [ ] T050 [P] Update docs/reference/cli.md with new `--exit-on-threshold` and `--exit-code` flags
+- [ ] T051 [P] Update docs/reference/configuration.md with new `exit_on_threshold` and `exit_code` fields
+- [ ] T052 [P] Update docs/deployment/ci-cd-integration.md with exit code usage examples
+- [ ] T053 [P] Add edge case test for exit code 255 in `internal/config/budget_test.go`
+- [ ] T054 [P] Add edge case test for invalid exit code 256 in `internal/config/budget_test.go`
+- [ ] T055 [P] Add edge case test for negative exit code -1 in `internal/config/budget_test.go`
+- [ ] T056 Verify 80% minimum test coverage for modified files
+- [ ] T057 Run `make lint` and fix any issues
+- [ ] T058 Run `make test` and verify all tests pass
+- [ ] T059 Validate quickstart.md examples manually
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-6)**: All depend on Foundational phase completion
+  - User stories can then proceed in priority order (P1 → P2 → P2 → P3)
+  - US1 (MVP) must complete before US2-4 for incremental delivery
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) - No dependencies on other stories - **MVP**
+- **User Story 2 (P2)**: Can start after US1 complete - Extends config loading
+- **User Story 3 (P2)**: Can start after US1 complete - Extends exit behavior
+- **User Story 4 (P3)**: Can start after US2 complete - Needs env var layer for precedence testing
+
+### Within Each Phase
+
+- Tests MUST be written and FAIL before implementation
+- Config changes before engine changes
+- Engine changes before CLI changes
+- Core implementation before integration
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- All Setup tasks marked [P] can run in parallel
+- All Foundational tests marked [P] can run in parallel
+- All tests within a user story marked [P] can run in parallel
+- Documentation updates in Phase 7 marked [P] can run in parallel
+
+---
+
+## Parallel Example: Foundational Phase Tests
+
+```bash
+# Launch all foundational tests together:
+Task: "Unit test for ErrExitCodeOutOfRange error type"
+Task: "Unit test for BudgetConfig.GetExitCode() method"
+Task: "Unit test for BudgetConfig.ShouldExitOnThreshold() method"
+Task: "Unit test for exit code validation (0-255 range)"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL - blocks all stories)
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Test exit codes work from config file
+5. Merge to main if ready - MVP delivered!
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add User Story 1 → Test independently → MVP delivered!
+3. Add User Story 2 → Environment variable support
+4. Add User Story 3 → Warning-only mode
+5. Add User Story 4 → CLI flag overrides
+6. Complete Phase 7 → Documentation and edge cases
+7. Each story adds value without breaking previous stories
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Verify tests fail before implementing
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Exit codes must be 0-255 (Unix standard)
+- Configuration precedence: CLI flags > Environment Variables > Config File > Defaults


### PR DESCRIPTION
## Summary

Enable CI/CD pipelines to detect budget threshold violations via configurable exit codes (0-255) when cost thresholds are exceeded. Configuration supports layered precedence: CLI flags override environment variables, which override config file settings, which override defaults.

Key functionality:

- `exit_on_threshold` (bool) enables exit on threshold violation
- `exit_code` (int, 0-255) specifies the exit code to return
- Warning-only mode (exit_code: 0) logs warnings without failing pipelines
- Budget evaluation errors always return exit code 1 (FR-009)

## Test plan

- [x] `make lint` passes with zero issues
- [x] `make test` passes
- [x] All 9 budget exit tests pass
- [x] CLI flag parsing tests verify precedence chain
- [x] Edge case tests for exit codes 0, 255, 256, -1

## Changes

### New files

- `internal/cli/cost_budget_test.go` - CLI budget exit tests

### Modified files

- `internal/config/budget.go` - Added `ExitOnThreshold` and `ExitCode` fields with validation
- `internal/config/budget_test.go` - Added exit code validation tests
- `internal/config/config.go` - Added env var overrides for budget exit
- `internal/config/config_test.go` - Added env var override tests
- `internal/config/integration.go` - Added `SetGlobalConfig()` for tests
- `internal/engine/budget_cli.go` - Added `ShouldExit()`, `GetExitCode()`, `ExitReason()` methods and `ExitCodeBudgetEvaluationError` constant
- `internal/engine/budget_cli_test.go` - Added BudgetStatus exit tests
- `internal/cli/root.go` - Added `--exit-on-threshold` and `--exit-code` persistent flags on cost command
- `internal/cli/cost_budget.go` - Added `BudgetExitError` type and `checkBudgetExit()` helper
- `internal/cli/cost_projected.go` - Integrated budget exit checking
- `internal/cli/cost_actual.go` - Integrated budget exit checking

Closes #219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable budget exit behavior via CLI flags and matching env/config (enable exit on threshold, specify exit code), including a warning-only mode.

* **Improvements**
  * Budget evaluation now influences CLI exit and reporting.
  * Consistent default currency fallback across CLI outputs to avoid mixed-currency surprises.

* **Documentation**
  * Updated Active Technologies and ROADMAP to reflect completed pagination/NDJSON and budgeting items.

* **Tests**
  * Extensive unit and CLI tests for exit semantics, flag/config precedence, parsing, and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->