### PR TITLE
refactor: add ConvertToProto and ConvertValueToString helpers for gRPC plugin communication

### DIFF
--- a/.claude/agents/golang-code-reviewer.md
+++ b/.claude/agents/golang-code-reviewer.md
@@ -6,19 +6,19 @@ model: sonnet
 
 # Golang Code Reviewer Agent
 
-You are a senior Go engineer with 8+ years of experience and deep expertise in Go 1.25.5+ best practices, Pulumi SDK development, and maintaining high-quality codebases. You have a proven track record of contributions to pulumi/pulumi and understand the intricacies of infrastructure-as-code patterns.
+You are a senior Go engineer with 8+ years of experience and deep expertise in Go 1.25.6+ best practices, Pulumi SDK development, and maintaining high-quality codebases. You have a proven track record of contributions to pulumi/pulumi and understand the intricacies of infrastructure-as-code patterns.
 
 When reviewing code, you will:
 
 **Code Analysis Approach:**
 - Perform comprehensive line-by-line analysis of all provided code
 - Identify potential bugs, race conditions, memory leaks, and performance issues
-- Check for proper error handling patterns using Go 1.25.5+ idioms
+- Check for proper error handling patterns using Go 1.25.6+ idioms
 - Verify correct use of context.Context for cancellation and timeouts
 - Ensure proper resource cleanup with defer statements
 - Validate goroutine safety and concurrent access patterns
 
-**Go 1.25.5+ Best Practices:**
+**Go 1.25.6+ Best Practices:**
 - Enforce use of structured logging with slog package
 - Recommend clear() for slice/map cleanup where appropriate
 - Suggest range-over-func patterns for iterators when beneficial

--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -48,10 +48,10 @@ recent changes focusing on:
    - Cost calculation logic accuracy
    - CLI UX and error messaging quality
 
-7. **Go Version Idioms (Go 1.25.5+)**
-   - Use Go Go 1.25.5+ language features and standard library improvements
+7. **Go Version Idioms (Go 1.25.6+)**
+   - Use Go Go 1.25.6+ language features and standard library improvements
    - Leverage modern Go patterns and best practices
-   - Ensure compatibility with Go Go 1.25.5+ runtime behavior
+   - Ensure compatibility with Go Go 1.25.6+ runtime behavior
    - Utilize updated standard library APIs and optimizations
 
 ### Context for Review

--- a/.github/instructions/ai-agent-files.instructions.md
+++ b/.github/instructions/ai-agent-files.instructions.md
@@ -53,5 +53,5 @@ This repository contains AI agent instruction files that provide guidance for di
 
 - **Never commit changes** without user approval (CLAUDE.md restriction)
 - **Always run tests and linting** before completion
-- **Follow Go 1.25.5+ standards** and best practices
+- **Follow Go 1.25.6+ standards** and best practices
 - **Maintain high test coverage** (80%+ target)

--- a/.github/instructions/go-files.instructions.md
+++ b/.github/instructions/go-files.instructions.md
@@ -4,13 +4,13 @@ applyTo: '**/*.go'
 
 # Go Code Instructions
 
-This repository uses Go 1.25.5+ with specific coding standards and best practices.
+This repository uses Go 1.25.6+ with specific coding standards and best practices.
 
 ## Go Version Requirements:
 
-- **Minimum version**: Go 1.25.5
-- **Target version**: Go 1.25.5
-- **Compatibility**: Ensure code works with Go 1.25.5 features
+- **Minimum version**: Go 1.25.6
+- **Target version**: Go 1.25.6
+- **Compatibility**: Ensure code works with Go 1.25.6 features
 
 ## Code Quality Standards:
 

--- a/.github/instructions/go-module.instructions.md
+++ b/.github/instructions/go-module.instructions.md
@@ -8,8 +8,8 @@ The go.mod file manages Go module dependencies and version requirements.
 
 ## Go Version Management:
 
-- **Current version**: Go 1.25.5
-- **Compatibility**: Ensure all dependencies support Go 1.25.5
+- **Current version**: Go 1.25.6
+- **Compatibility**: Ensure all dependencies support Go 1.25.6
 - **Updates**: Update version consistently across all documentation
 
 ## Dependency Management:

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -12,7 +12,7 @@ This directory contains GitHub Actions workflows for CI/CD, automated code revie
 
 **ci.yml** - Complete CI/CD pipeline triggered on PRs and main branch pushes:
 
-- **Test Job**: Go 1.25.5 setup, unit tests with race detection, coverage reporting (20% minimum threshold)
+- **Test Job**: Go 1.25.6 setup, unit tests with race detection, coverage reporting (20% minimum threshold)
 - **Lint Job**: golangci-lint with project-specific configuration, security scanning with gosec
 - **Security Job**: govulncheck for dependency vulnerability scanning
 - **Validation Job**: gofmt formatting checks, go mod tidy verification, go vet static analysis
@@ -185,7 +185,7 @@ gh auth status
 
 **Go Setup**:
 
-- ✅ **Standard**: `actions/setup-go@v5` with `go-version: '1.25.5'` and `cache: true`
+- ✅ **Standard**: `actions/setup-go@v5` with `go-version: '1.25.6'` and `cache: true`
 - **Consistency**: All workflows should use identical Go version and caching
 
 **Checkout**:

--- a/.github/workflows/cross-repo-integration.yml
+++ b/.github/workflows/cross-repo-integration.yml
@@ -1,9 +1,18 @@
+# TEMPORARILY DISABLED - Schedule trigger disabled pending architectural fix
+# See enhancement issue for proper implementation using registry-based plugin install.
+#
+# Current Problem: Building plugin from source fails because generated data files
+# (CCF instance specs) are gitignored and not available in CI.
+#
+# Correct Approach: Use `finfocus plugin install aws-public` to download the
+# published plugin binary from GitHub releases instead of building from source.
+
 name: Cross-Repository Integration
 
 on:
-  schedule:
-    # Run at 2 AM UTC every day
-    - cron: '0 2 * * *'
+  # schedule:
+  #   # Run at 2 AM UTC every day - TEMPORARILY DISABLED
+  #   - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
       core_ref:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ layout: "docs"
 
 ### Go Formatting and Imports
 
-- Go 1.25.5+; use tabs for indentation and run `gofmt` on Go files.
+- Go 1.25.6+; use tabs for indentation and run `gofmt` on Go files.
 - Imports grouped as: standard library, third-party, internal packages.
 - `goimports`/`golines` enforced via `golangci-lint`; keep lines tidy.
 - Avoid `init()` and global variables (lint rule).
@@ -139,7 +139,7 @@ Use `require.*` for setup failures and nil checks, `assert.*` for value comparis
 
 ### Current Stack
 
-- Go 1.25.5 with `github.com/Masterminds/semver/v3` and finfocus plugin SDK.
+- Go 1.25.6 with `github.com/Masterminds/semver/v3` and finfocus plugin SDK.
 - charmbracelet/lipgloss v1.0.0 and golang.org/x/term v0.37.0.
 - Plugin directory: `~/.finfocus/plugins/<plugin-name>/<version>/`.
 
@@ -149,9 +149,9 @@ Use `require.*` for setup failures and nil checks, `assert.*` for value comparis
 
 ### Active Technologies
 
-- Go 1.25.5 + finfocus-spec SDK, Cobra CLI, zerolog, gRPC, pluginsdk (001-plugin-init-recorder)
+- Go 1.25.6 + finfocus-spec SDK, Cobra CLI, zerolog, gRPC, pluginsdk (001-plugin-init-recorder)
 - Local filesystem for fixture downloads and recorded request output (001-plugin-init-recorder)
 
 ### Recent Changes
 
-- 001-plugin-init-recorder: Added Go 1.25.5 + finfocus-spec SDK, Cobra CLI, zerolog, gRPC, pluginsdk
+- 001-plugin-init-recorder: Added Go 1.25.6 + finfocus-spec SDK, Cobra CLI, zerolog, gRPC, pluginsdk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **deps:** update go dependencies ([#314](https://github.com/rshade/finfocus/issues/314)) ([c09f298](https://github.com/rshade/finfocus/commit/c09f298281c8b7e18d47fe086dd6fb5d921fd571))
 * **deps:** update module github.com/rshade/finfocus-spec to v0.4.3 ([#211](https://github.com/rshade/finfocus/issues/211)) ([4cb56d9](https://github.com/rshade/finfocus/commit/4cb56d928ab0b5887fd2fc56c182383d9eedfffe))
 * **deps:** update module github.com/spf13/cobra to v1.10.2 ([#240](https://github.com/rshade/finfocus/issues/240)) ([ad3bfd7](https://github.com/rshade/finfocus/commit/ad3bfd7b92d189a912dbae3ae10bbda2067e6bf2))
-* update Go version to 1.25.5 and improve plugin integration tests ([#244](https://github.com/rshade/finfocus/issues/244)) ([4f383df](https://github.com/rshade/finfocus/commit/4f383df0df1e1d4d3d23259adef8eb29d6ea41e9))
+* update Go version to 1.25.6 and improve plugin integration tests ([#244](https://github.com/rshade/finfocus/issues/244)) ([4f383df](https://github.com/rshade/finfocus/commit/4f383df0df1e1d4d3d23259adef8eb29d6ea41e9))
 
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ make lint    # Run linting
 
 ## Go Version
 
-**Project Go Version**: 1.25.5 (see `go.mod`)
+**Project Go Version**: 1.25.6 (see `go.mod`)
 
 **CRITICAL**: Before claiming any Go version "doesn't exist" or suggesting version
 changes, verify on <https://go.dev/dl/> first.
@@ -333,7 +333,7 @@ Triggered on pull requests and pushes to main branch:
 
 **Test Job:**
 
-- Go 1.25.5 setup with caching
+- Go 1.25.6 setup with caching
 - Unit tests with race detection and coverage reporting
 - Coverage threshold check (minimum 61%)
 - Artifacts uploaded for coverage reports
@@ -975,7 +975,7 @@ CodeRabbit now:
 5. **Integrates with existing CI/CD** tools and workflows
 
 ## Active Technologies
-- Go 1.25.5 + github.com/spf13/cobra (CLI), github.com/rs/zerolog (logging), github.com/rshade/finfocus-spec v0.5.3+ (proto definitions/SDK), google.golang.org/grpc, github.com/stretchr/testify; YAML config file (~/.finfocus/config.yaml)
+- Go 1.25.6 + github.com/spf13/cobra (CLI), github.com/rs/zerolog (logging), github.com/rshade/finfocus-spec v0.5.3+ (proto definitions/SDK), google.golang.org/grpc, github.com/stretchr/testify; YAML config file (~/.finfocus/config.yaml)
 
 ## Recent Changes
 
@@ -988,12 +988,12 @@ Based on recent development sessions, consider adding:
 - **Version Consistency**: When updating Go versions, update both `go.mod` and ALL markdown files simultaneously
 - **Search Pattern**: Use `grep "Go.*1\." --include="*.md"` to find all version references in documentation
 - **Files to Check**: go.mod, all .md files in docs/, specs/, examples/, and root-level documentation
-- **Docker Images**: Update Docker base images (e.g., `golang:1.24` → `golang:1.25.5`) in documentation examples
+- **Docker Images**: Update Docker base images (e.g., `golang:1.24` → `golang:1.25.6`) in documentation examples
 
 ### Systematic Version Updates
 
 - **Process**: 1) Update go.mod first, 2) Find all references with grep, 3) Update each file systematically, 4) Verify with final grep search
-- **Common Patterns**: Update both specific versions (1.24.10 → 1.25.5) and minimum requirements (Go 1.24+ → Go 1.25.5+)
+- **Common Patterns**: Update both specific versions (1.24.10 → 1.25.6) and minimum requirements (Go 1.24+ → Go 1.25.6+)
 - **CI Workflows**: Update GitHub Actions go-version parameters in documentation examples
 
 This ensures complete version consistency across the entire codebase and documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ submit a pull request directly.
 
 | Tool             | Version    | Purpose             |
 | ---------------- | ---------- | ------------------- |
-| Go               | 1.25.5+    | Core development    |
+| Go               | 1.25.6+    | Core development    |
 | golangci-lint    | v2.6.2     | Go linting          |
 | markdownlint-cli | v0.45.0    | Markdown linting    |
 | Git              | Latest     | Version control     |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,29 +3,29 @@
 Auto-generated from all feature plans. Last updated: 2026-01-12
 
 ## Active Technologies
-- Go 1.25.5 + `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (Config), `github.com/rshade/finfocus-spec` (renamed from `finfocus-spec`) (113-rebrand-to-finfocus)
+- Go 1.25.6 + `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (Config), `github.com/rshade/finfocus-spec` (renamed from `finfocus-spec`) (113-rebrand-to-finfocus)
 - Filesystem (`~/.finfocus/config.yaml`, `~/.finfocus/plugins/`) (113-rebrand-to-finfocus)
 - Filesystem (Plugin directories) (115-v021-dx-improvements)
 - Markdown (GFM), Mermaid (for diagrams) + Jekyll (for site generation), mermaid.js (for rendering diagrams) (118-e2e-plugin-docs)
-- Go 1.25.5 + `github.com/charmbracelet/lipgloss`, `golang.org/x/term`, `github.com/spf13/viper` (existing config), `github.com/spf13/cobra` (existing CLI) (001-cli-budget-alerts)
+- Go 1.25.6 + `github.com/charmbracelet/lipgloss`, `golang.org/x/term`, `github.com/spf13/viper` (existing config), `github.com/spf13/cobra` (existing CLI) (001-cli-budget-alerts)
 - Local filesystem (`~/.finfocus/config.yaml`) (001-cli-budget-alerts)
 
-- Markdown, Go 1.25.5 (for code verification) + Jekyll (for docs site), GitHub Pages (010-sync-docs-codebase)
+- Markdown, Go 1.25.6 (for code verification) + Jekyll (for docs site), GitHub Pages (010-sync-docs-codebase)
 - Git repository (docs folder) (010-sync-docs-codebase)
 - Pulumi Analyzer integration (finfocus analyzer serve)
 - Plugin management commands (finfocus plugin init/install/update/remove)
 - GitHub Actions, `gh` CLI, OpenCode CLI/API (019-nightly-failure-analysis)
-- Go 1.25.5 + `github.com/stretchr/testify` (assertions), `net/http/httptest` (mocking) (021-plugin-integration-tests)
+- Go 1.25.6 + `github.com/stretchr/testify` (assertions), `net/http/httptest` (mocking) (021-plugin-integration-tests)
 - Filesystem (mocked via `t.TempDir()`) (021-plugin-integration-tests)
-- Go 1.25.5 + `github.com/spf13/cobra` (CLI), `github.com/spf13/pflag` (023-add-cli-filter-flag)
+- Go 1.25.6 + `github.com/spf13/cobra` (CLI), `github.com/spf13/pflag` (023-add-cli-filter-flag)
 - Pure Go (no external dependencies for filter logic) (023-add-cli-filter-flag)
-- Go 1.25.5 + `github.com/Masterminds/semver/v3` (001-latest-plugin-version)
+- Go 1.25.6 + `github.com/Masterminds/semver/v3` (001-latest-plugin-version)
 - Filesystem (`~/.finfocus/plugins/`) (001-latest-plugin-version)
-- Go 1.25.5 + github.com/rshade/finfocus-spec v0.4.14, github.com/Masterminds/semver/v3 (112-plugin-info-discovery)
+- Go 1.25.6 + github.com/rshade/finfocus-spec v0.4.14, github.com/Masterminds/semver/v3 (112-plugin-info-discovery)
 
 - Local Pulumi state (ephemeral), no persistent DB (Stateless operation). (008-e2e-cost-testing, 009-analyzer-plugin, 112-plugin-info-discovery)
 
-- Go 1.25.5
+- Go 1.25.6
 - `github.com/rshade/finfocus-spec`
 - `google.golang.org/grpc` (002-implement-supports-handler)
 
@@ -66,7 +66,7 @@ finfocus analyzer serve
 
 ## Code Style
 
-Go 1.25.5: Follow standard conventions
+Go 1.25.6: Follow standard conventions
 
 ## Documentation Standards
 
@@ -194,7 +194,7 @@ import (
 - **Property Extraction**: Core (`adapter.go`) relies on populated `Inputs` to extract SKU and Region. If `Inputs` are empty (due to ingest issues), pricing lookup fails.
 
 ## Recent Changes
-- 001-cli-budget-alerts: Added Go 1.25.5 + `github.com/charmbracelet/lipgloss`, `golang.org/x/term`, `github.com/spf13/viper` (existing config), `github.com/spf13/cobra` (existing CLI)
+- 001-cli-budget-alerts: Added Go 1.25.6 + `github.com/charmbracelet/lipgloss`, `golang.org/x/term`, `github.com/spf13/viper` (existing config), `github.com/spf13/cobra` (existing CLI)
 - 118-e2e-plugin-docs: Added Markdown (GFM), Mermaid (for diagrams) + Jekyll (for site generation), mermaid.js (for rendering diagrams)
 
 
@@ -210,12 +210,12 @@ Based on recent development sessions, consider adding:
 - **Version Consistency**: When updating Go versions, update both `go.mod` and ALL markdown files simultaneously
 - **Search Pattern**: Use `grep "Go.*1\." --include="*.md"` to find all version references in documentation
 - **Files to Check**: go.mod, all .md files in docs/, specs/, examples/, and root-level documentation
-- **Docker Images**: Update Docker base images (e.g., `golang:1.24` → `golang:1.25.5`) in documentation examples
+- **Docker Images**: Update Docker base images (e.g., `golang:1.24` → `golang:1.25.6`) in documentation examples
 
 ### Systematic Version Updates
 
 - **Process**: 1) Update go.mod first, 2) Find all references with grep, 3) Update each file systematically, 4) Verify with final grep search
-- **Common Patterns**: Update both specific versions (1.24.10 → 1.25.5) and minimum requirements (Go 1.24+ → Go 1.25.5+)
+- **Common Patterns**: Update both specific versions (1.24.10 → 1.25.6) and minimum requirements (Go 1.24+ → Go 1.25.6+)
 - **CI Workflows**: Update GitHub Actions go-version parameters in documentation examples
 
 This ensures complete version consistency across the entire codebase and documentation.

--- a/docker/README.md
+++ b/docker/README.md
@@ -70,7 +70,7 @@ docker run --rm \
 ## Image Details
 
 - **Base Image**: Alpine Linux (latest)
-- **Go Version**: 1.25.5 (golang:1.25.5-alpine)
+- **Go Version**: 1.25.6 (golang:1.25.6-alpine)
 - **User**: Non-root user `finfocus` (UID: 1001, GID: 1001)
 - **Working Directory**: `/home/finfocus`
 - **Plugin Directory**: `/home/finfocus/.finfocus/plugins`

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -73,7 +73,7 @@ docker run --rm \
 ## Image Details
 
 - **Base Image**: Alpine Linux (latest)
-- **Go Version**: 1.25.5 (golang:1.25.5-alpine)
+- **Go Version**: 1.25.6 (golang:1.25.6-alpine)
 - **User**: Non-root user `finfocus` (UID: 1001, GID: 1001)
 - **Working Directory**: `/home/finfocus`
 - **Plugin Directory**: `/home/finfocus/.finfocus/plugins`

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,7 +9,7 @@ Detailed steps to install FinFocus on your system.
 ## Prerequisites
 
 - Pulumi CLI installed
-- Go 1.25.5+ (if building from source)
+- Go 1.25.6+ (if building from source)
 - Git (if building from source)
 - 5-10 minutes
 

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -42,7 +42,7 @@ For actual costs (with plugins), you need:
 - **Azure:** Azure credentials or service principal
 - **GCP:** GCP service account
 
-### Optional: Go 1.25.5+ (for building from source)
+### Optional: Go 1.25.6+ (for building from source)
 
 ```bash
 # Check if installed

--- a/docs/guides/developer-guide.md
+++ b/docs/guides/developer-guide.md
@@ -23,7 +23,7 @@ building plugins or contributing to the core project.
 
 ### Prerequisites
 
-- Go 1.25.5+ (for core development)
+- Go 1.25.6+ (for core development)
 - Git
 - Make
 - Node.js 18+ (for documentation tools)
@@ -662,7 +662,7 @@ Users install plugins to: `~/.finfocus/plugins/<name>/<version>/`
 ### Docker Deployment
 
 ```dockerfile
-FROM golang:1.25.5 as builder
+FROM golang:1.25.6 as builder
 WORKDIR /app
 COPY . .
 RUN make build

--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -44,7 +44,7 @@ FinFocus is a command-line tool that calculates cloud infrastructure costs from 
 ### Prerequisites
 
 - **Pulumi CLI** installed and working
-- **Go 1.25.5+** (if building from source)
+- **Go 1.25.6+** (if building from source)
 - **Cloud credentials** configured (AWS, Azure, GCP, etc.)
 
 ### Option 1: Download Binary (Recommended)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -259,7 +259,7 @@ docker run --rm finfocus --version
 
 ### Prerequisites for Building
 
-- **Go**: Version 1.25.5 or later
+- **Go**: Version 1.25.6 or later
   - Install from: https://golang.org/dl/
 - **Git**: For cloning the repository
 - **Make**: For using build scripts (optional)

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -267,7 +267,7 @@ export AWS_REGION="us-west-2"
 
 #### Prerequisites
 
-- **Go**: Version 1.25.5 or later
+- **Go**: Version 1.25.6 or later
 - **Protocol Buffers**: For gRPC service definitions
 - **finfocus-spec**: Protocol definitions repository
 
@@ -507,7 +507,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.6'
 
       - name: Build binaries
         run: |

--- a/docs/plugins/vantage/setup.md
+++ b/docs/plugins/vantage/setup.md
@@ -32,7 +32,7 @@ Before installing the Vantage plugin, ensure you have:
 
 ### System Requirements
 
-- Go 1.25.5 or later
+- Go 1.25.6 or later
 - `make` (for building from source)
 - Docker (optional, for running mock tests)
 

--- a/docs/support/contributing.md
+++ b/docs/support/contributing.md
@@ -65,7 +65,7 @@ submit a pull request directly.
 
 | Tool             | Version    | Purpose             |
 | ---------------- | ---------- | ------------------- |
-| Go               | 1.25.5+    | Core development    |
+| Go               | 1.25.6+    | Core development    |
 | golangci-lint    | v2.6.2     | Go linting          |
 | markdownlint-cli | v0.45.0    | Markdown linting    |
 | Git              | Latest     | Version control     |

--- a/docs/testing/e2e-guide.md
+++ b/docs/testing/e2e-guide.md
@@ -25,7 +25,7 @@ the complete cost calculation pipeline using actual AWS services.
 
 Before running end-to-end tests, ensure your environment meets the following requirements:
 
-- **Go 1.25.5+**: Required for building the core and plugins.
+- **Go 1.25.6+**: Required for building the core and plugins.
 - **AWS Credentials**: A valid AWS account with read permissions (for Cost Explorer) and resource creation permissions
   (for infrastructure tests).
 - **FinFocus Core**: Installed locally.

--- a/examples/plugins/aws-example/README.md
+++ b/examples/plugins/aws-example/README.md
@@ -33,7 +33,7 @@ This is a reference implementation of a FinFocus plugin for AWS cost calculation
 
 ### Prerequisites
 
-- Go 1.25.5+
+- Go 1.25.6+
 - FinFocus Core development environment
 
 ### Build the Plugin

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rshade/finfocus
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
@@ -53,7 +53,7 @@ require (
 	github.com/prometheus/common v0.67.4 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/rshade/finfocus-spec v0.5.4
+	github.com/rshade/finfocus-spec v0.5.5
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
-github.com/rshade/finfocus-spec v0.5.4 h1:2nNQ7/SMjB1k2zdugnmM6NWBELDXV1J1Nk7Dj6cZFcg=
-github.com/rshade/finfocus-spec v0.5.4/go.mod h1:jw6VTyUqzwgK96llyAfESkgigHNrSKHD7W5IT6u0AH8=
+github.com/rshade/finfocus-spec v0.5.5 h1:gfHarUyJCWJVv3+hHUKif3RT/PfAcu6He2D45X3VBOY=
+github.com/rshade/finfocus-spec v0.5.5/go.mod h1:mFUOpKQ4+WK3lVcubQpxVQfnlHIFpYW7TH5aSt1+IaQ=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=

--- a/specs/001-cli-budget-alerts/plan.md
+++ b/specs/001-cli-budget-alerts/plan.md
@@ -9,7 +9,7 @@ Implement budget configuration support and threshold alert display in the finfoc
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5  
+**Language/Version**: Go 1.25.6  
 **Primary Dependencies**: `github.com/charmbracelet/lipgloss`, `golang.org/x/term`, `github.com/spf13/viper` (existing config), `github.com/spf13/cobra` (existing CLI)  
 **Storage**: Local filesystem (`~/.finfocus/config.yaml`)  
 **Testing**: `github.com/stretchr/testify` (assertions), `go test`  

--- a/specs/001-multi-region-e2e/plan.md
+++ b/specs/001-multi-region-e2e/plan.md
@@ -9,7 +9,7 @@ Implement multi-region E2E testing infrastructure to validate both projected and
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: testify v1.11.1, Pulumi Automation API v3.210.0+, existing E2E test framework (`test/e2e/`)
 **Storage**: Local filesystem (Pulumi state files, test fixtures in `test/e2e/fixtures/`)
 **Testing**: `go test` with `-tags e2e` build constraint, testify assertions

--- a/specs/001-multi-region-e2e/quickstart.md
+++ b/specs/001-multi-region-e2e/quickstart.md
@@ -2,7 +2,7 @@
 
 **Audience**: Developers implementing or running multi-region E2E tests
 **Time to Complete**: 15-20 minutes
-**Prerequisites**: Go 1.25.5, FinFocus built locally, AWS credentials configured
+**Prerequisites**: Go 1.25.6, FinFocus built locally, AWS credentials configured
 
 ## Overview
 

--- a/specs/001-multi-region-e2e/research.md
+++ b/specs/001-multi-region-e2e/research.md
@@ -196,7 +196,7 @@ func TestMain(m *testing.M) {
 
 ## Technology Stack Summary
 
-- **Go** (1.25.5): Test implementation language
+- **Go** (1.25.6): Test implementation language
 - **testify** (v1.11.1): Assertion and require helpers
 - **Pulumi SDK** (v3.210.0+): Automation API for resource deployment
 - **AWS SDK Go v2** (latest): (Indirect) Plugin uses for actual costs

--- a/specs/001-plugin-init-recorder/plan.md
+++ b/specs/001-plugin-init-recorder/plan.md
@@ -9,7 +9,7 @@ Deliver a recorder-compatible plugin initialization flow that fetches canonical 
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5  
+**Language/Version**: Go 1.25.6  
 **Primary Dependencies**: finfocus-spec SDK, Cobra CLI, zerolog, gRPC, pluginsdk  
 **Storage**: Local filesystem for fixture downloads and recorded request output  
 **Testing**: go test, testify/assert + require, make test, make lint  

--- a/specs/002-implement-supports-handler/plan.md
+++ b/specs/002-implement-supports-handler/plan.md
@@ -9,7 +9,7 @@ This plan outlines the implementation of a `Supports` gRPC handler in the `plugi
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: `github.com/rshade/finfocus-spec v0.1.0`, `google.golang.org/grpc v1.77.0`
 **Storage**: N/A
 **Testing**: Go `testing` package with `stretchr/testify`

--- a/specs/003-proto-error-aggregation/plan.md
+++ b/specs/003-proto-error-aggregation/plan.md
@@ -11,7 +11,7 @@ Implement error aggregation for `GetProjectedCost` and `GetActualCost` in the pr
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: gRPC, zerolog (new), finfocus-spec proto SDK
 **Storage**: N/A (in-memory error aggregation)
 **Testing**: go test with race detection, 80% coverage minimum

--- a/specs/004-zerolog-tracing/plan.md
+++ b/specs/004-zerolog-tracing/plan.md
@@ -12,7 +12,7 @@ configurable log levels, JSON/console output formats, and a `--debug` CLI flag.
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: github.com/rs/zerolog v1.34.0, github.com/oklog/ulid/v2 (for trace IDs)
 **Storage**: N/A (logs to stderr/file, no persistence)
 **Testing**: go test with -race flag, testify assertions

--- a/specs/005-pluginsdk-interceptors/plan.md
+++ b/specs/005-pluginsdk-interceptors/plan.md
@@ -14,7 +14,7 @@ as the first in the chain.
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: google.golang.org/grpc v1.74.2, github.com/rs/zerolog
 **Storage**: N/A (stateless configuration)
 **Testing**: go test with race detection

--- a/specs/005-pluginsdk-interceptors/quickstart.md
+++ b/specs/005-pluginsdk-interceptors/quickstart.md
@@ -10,7 +10,7 @@ when serving a FinFocus plugin.
 
 ## Prerequisites
 
-- Go 1.25.5+
+- Go 1.25.6+
 - `github.com/rshade/finfocus-spec/sdk/go/pluginsdk` v0.2.0+
 
 ## Basic Usage

--- a/specs/005-pluginsdk-interceptors/research.md
+++ b/specs/005-pluginsdk-interceptors/research.md
@@ -134,7 +134,7 @@ Criteria is easily met.
 
 All NEEDS CLARIFICATION items from Technical Context have been resolved:
 
-- ✅ Language/Version: Go 1.25.5 (from go.mod)
+- ✅ Language/Version: Go 1.25.6 (from go.mod)
 - ✅ Dependencies: gRPC v1.74.2, zerolog (from go.mod)
 - ✅ Testing: go test with race detection (from constitution)
 - ✅ Platform: Linux, macOS, Windows (from constitution)

--- a/specs/006-plugin-install/plan.md
+++ b/specs/006-plugin-install/plan.md
@@ -9,7 +9,7 @@ Implement a comprehensive plugin installation system enabling users to install, 
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: archive/tar, archive/zip, compress/gzip, net/http, github.com/spf13/cobra, gopkg.in/yaml.v3
 **Storage**: File system (~/.finfocus/plugins/, ~/.finfocus/config.yaml)
 **Testing**: go test with race detection, 80% minimum coverage

--- a/specs/007-engine-test-coverage/benchmark-baseline.md
+++ b/specs/007-engine-test-coverage/benchmark-baseline.md
@@ -2,7 +2,7 @@
 
 **Date**: 2025-12-02
 **System**: Intel Core i7-6600U @ 2.60GHz, Linux
-**Go Version**: 1.25.5
+**Go Version**: 1.25.6
 
 ## Summary
 

--- a/specs/007-engine-test-coverage/plan.md
+++ b/specs/007-engine-test-coverage/plan.md
@@ -13,7 +13,7 @@ benchmarks to 1K, 10K, 100K resource scales.
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: testing (stdlib), github.com/stretchr/testify
 **Storage**: N/A (testing framework, no persistence)
 **Testing**: `go test` with `-coverprofile`, `-race`, `-bench`

--- a/specs/007-engine-test-coverage/spec.md
+++ b/specs/007-engine-test-coverage/spec.md
@@ -166,7 +166,7 @@ As a quality engineer, I need integration tests that verify engine components wo
 
 ### Assumptions
 
-- Go 1.25.5 is the target runtime environment
+- Go 1.25.6 is the target runtime environment
 - Test coverage is measured using standard `go tool cover` tooling
 - Benchmark baselines will be established during initial test implementation
 - Mock plugin implementations from `test/mocks/plugin/` will be used for integration testing

--- a/specs/008-e2e-cost-testing/plan.md
+++ b/specs/008-e2e-cost-testing/plan.md
@@ -15,7 +15,7 @@ Implement an End-to-End (E2E) testing framework for FinFocus using the Pulumi Au
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**:
 
 - `github.com/pulumi/pulumi-aws/sdk/v7` (AWS Provider v7)

--- a/specs/008-e2e-cost-testing/quickstart.md
+++ b/specs/008-e2e-cost-testing/quickstart.md
@@ -4,7 +4,7 @@ This guide explains how to run the End-to-End (E2E) cost validation tests for Fi
 
 ## Prerequisites
 
-1. **Go 1.25.5+** installed.
+1. **Go 1.25.6+** installed.
 2. **Pulumi CLI** installed.
 3. **AWS Credentials** configured in your environment:
    - `AWS_ACCESS_KEY_ID`

--- a/specs/009-analyzer-plugin/plan.md
+++ b/specs/009-analyzer-plugin/plan.md
@@ -18,7 +18,7 @@ Implement the Pulumi Analyzer plugin interface (`pulumirpc.Analyzer`) to enable 
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**:
 
 - `google.golang.org/grpc v1.77.0` - gRPC server implementation

--- a/specs/009-analyzer-plugin/tasks.md
+++ b/specs/009-analyzer-plugin/tasks.md
@@ -168,7 +168,7 @@ still finishes with warnings.
 - [x] T063.5 Create integration test for SC-003 latency requirement in `test/integration/analyzer_test.go` to verify <2s latency on small stacks.
 - [x] T064 Run full test suite: `make test`
 - [x] T065 Run linting: `make lint`
-- [x] T065.5 Run `govulncheck ./...` to verify no high/critical vulnerabilities (stdlib vulns noted, need Go 1.25.5)
+- [x] T065.5 Run `govulncheck ./...` to verify no high/critical vulnerabilities (stdlib vulns noted, need Go 1.25.6)
 - [x] T066 Verify coverage meets 80% threshold for analyzer package (achieved 92.7%)
 - [x] T066.5 Verify 80% docstring coverage for `internal/analyzer` package (all exported symbols documented)
 

--- a/specs/010-sync-docs-codebase/plan.md
+++ b/specs/010-sync-docs-codebase/plan.md
@@ -11,7 +11,7 @@
 
 ## Technical Context
 
-**Language/Version**: Markdown, Go 1.25.5 (for code verification)
+**Language/Version**: Markdown, Go 1.25.6 (for code verification)
 **Primary Dependencies**: Jekyll (for docs site), GitHub Pages
 **Storage**: Git repository (docs folder)
 **Testing**: `make docs-lint` (markdown-link-check, markdownlint)

--- a/specs/011-shared-tui-package/plan.md
+++ b/specs/011-shared-tui-package/plan.md
@@ -11,7 +11,7 @@ Create a shared internal TUI package at `internal/tui/` providing common Bubble 
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5 (aligned with project go.mod)  
+**Language/Version**: Go 1.25.6 (aligned with project go.mod)  
 **Primary Dependencies**: github.com/charmbracelet/bubbletea v1.2.4, github.com/charmbracelet/bubbles v0.20.0, github.com/charmbracelet/lipgloss v1.0.0, golang.org/x/term v0.27.0, golang.org/x/text v0.21.0  
 **Storage**: N/A (UI rendering package)  
 **Testing**: Go testing framework with table-driven tests  

--- a/specs/011-shared-tui-package/research.md
+++ b/specs/011-shared-tui-package/research.md
@@ -14,7 +14,7 @@
 
 - Bubble Tea provides excellent model-view-update architecture for CLI TUIs
 - Lip Gloss offers consistent styling with ANSI color support
-- Versions chosen for stability and compatibility with Go 1.25.5
+- Versions chosen for stability and compatibility with Go 1.25.6
 - Charm libraries are actively maintained and widely adopted in Go CLI ecosystem
 
 **Alternatives Considered**:

--- a/specs/012-analyzer-e2e-tests/plan.md
+++ b/specs/012-analyzer-e2e-tests/plan.md
@@ -9,7 +9,7 @@ Add end-to-end tests that verify the FinFocus Analyzer plugin works correctly wi
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: testing (stdlib), github.com/stretchr/testify, github.com/oklog/ulid/v2
 **Storage**: Local Pulumi state (`file://` backend), temp directories for test fixtures
 **Testing**: Go test with `-tags e2e` build constraint

--- a/specs/012-analyzer-e2e-tests/quickstart.md
+++ b/specs/012-analyzer-e2e-tests/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-1. **Go 1.25.5+** installed
+1. **Go 1.25.6+** installed
 2. **Pulumi CLI** installed (`pulumi version` should work)
 3. **finfocus binary** built (`make build`)
 4. **AWS credentials** configured (via environment or AWS CLI)

--- a/specs/012-analyzer-e2e-tests/spec.md
+++ b/specs/012-analyzer-e2e-tests/spec.md
@@ -148,7 +148,7 @@ As a CI/CD pipeline maintainer, I need the E2E tests to run reliably in CI witho
 - Built `finfocus` binary with analyzer functionality.
 - `aws-public` plugin for accurate pricing data.
 - Existing E2E test framework in `test/e2e/`.
-- Go 1.25.5+ for test execution.
+- Go 1.25.6+ for test execution.
 
 ## Out of Scope
 

--- a/specs/014-pluginsdk-env-adoption/plan.md
+++ b/specs/014-pluginsdk-env-adoption/plan.md
@@ -11,7 +11,7 @@ Migrate finfocus-core to use standardized pluginsdk/env.go constants for environ
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5  
+**Language/Version**: Go 1.25.6  
 **Primary Dependencies**: pluginsdk from finfocus-spec v0.4.5+ (github.com/rshade/finfocus-spec/sdk/go/pluginsdk)  
 **Storage**: N/A (environment variable configuration)  
 **Testing**: Go unit tests, integration tests  

--- a/specs/015-integrate-logging/plan.md
+++ b/specs/015-integrate-logging/plan.md
@@ -13,7 +13,7 @@ and adds audit capabilities.
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: zerolog v1.34.0 (already integrated), cobra v1.10.1, yaml.v3
 **Storage**: File system (`~/.finfocus/config.yaml`, log files)
 **Testing**: go test with testify, race detection required

--- a/specs/017-remove-port-env/plan.md
+++ b/specs/017-remove-port-env/plan.md
@@ -9,7 +9,7 @@ Remove the legacy `PORT` environment variable from plugin process spawning in `i
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: github.com/rshade/finfocus-spec v0.4.1 (pluginsdk), google.golang.org/grpc v1.77.0
 **Storage**: N/A
 **Testing**: go test (stdlib), github.com/stretchr/testify

--- a/specs/018-recorder-plugin/plan.md
+++ b/specs/018-recorder-plugin/plan.md
@@ -11,7 +11,7 @@ Implement a reference "Recorder" plugin within finfocus-core that captures all g
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**:
 
 - `github.com/rshade/finfocus-spec v0.4.6+` (pluginsdk, protobuf definitions)

--- a/specs/018-recorder-plugin/quickstart.md
+++ b/specs/018-recorder-plugin/quickstart.md
@@ -6,7 +6,7 @@ This guide shows how to build, install, and use the Recorder plugin to inspect g
 
 ## Prerequisites
 
-- Go 1.25.5+
+- Go 1.25.6+
 - finfocus-core built (`make build`)
 - A Pulumi plan JSON file (optional, for testing)
 

--- a/specs/020-cost-filter-tests/plan.md
+++ b/specs/020-cost-filter-tests/plan.md
@@ -17,7 +17,7 @@ Implement comprehensive integration tests for the `--filter` flag across `cost p
   the iteration process.
 -->
 
-**Language/Version**: Go 1.25.5 (from AGENTS.md and go.mod)
+**Language/Version**: Go 1.25.6 (from AGENTS.md and go.mod)
 **Primary Dependencies**: Existing CLI infrastructure (`internal/cli/`, `internal/engine/`), test helpers (`test/integration/helpers/`)
 **Storage**: N/A (CLI tool processing JSON files)
 **Testing**: Go testing framework with testify assertions (existing pattern in test/integration/cli/)

--- a/specs/020-cost-filter-tests/quickstart.md
+++ b/specs/020-cost-filter-tests/quickstart.md
@@ -9,7 +9,7 @@ This guide helps you understand and run the integration tests for the `--filter`
 
 ## Prerequisites
 
-- Go 1.25.5+ installed
+- Go 1.25.6+ installed
 - Project built: `make build`
 - Test fixtures available in `test/fixtures/plans/`
 

--- a/specs/020-cost-filter-tests/tasks.md
+++ b/specs/020-cost-filter-tests/tasks.md
@@ -27,7 +27,7 @@ description: 'Task list for integration tests for --filter flag'
 **Purpose**: Ensure development environment is ready for test implementation
 
 - [x] T001 Verify existing test infrastructure works in test/integration/helpers/cli_helper.go
-- [x] T002 Confirm Go 1.25.5 and testify dependencies are available
+- [x] T002 Confirm Go 1.25.6 and testify dependencies are available
 - [x] T003 Test existing integration test execution with `make test`
 
 ---

--- a/specs/021-plugin-integration-tests/plan.md
+++ b/specs/021-plugin-integration-tests/plan.md
@@ -9,7 +9,7 @@ Implement a comprehensive integration test suite for the `plugin init`, `install
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: `github.com/stretchr/testify` (assertions), `net/http/httptest` (mocking)
 **Storage**: Filesystem (mocked via `t.TempDir()`)
 **Testing**: Go standard `testing` package + `testify`

--- a/specs/021-plugin-integration-tests/quickstart.md
+++ b/specs/021-plugin-integration-tests/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Go 1.25.5 or later
+- Go 1.25.6 or later
 - Make (optional, but recommended)
 
 ## Running the Tests

--- a/specs/023-add-cli-filter-flag/plan.md
+++ b/specs/023-add-cli-filter-flag/plan.md
@@ -11,7 +11,7 @@ This feature adds the missing `--filter` flag to the `finfocus actual-cost` comm
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: `github.com/spf13/cobra` (CLI), `github.com/spf13/pflag`
 **Storage**: N/A (CLI logic)
 **Testing**: `test/integration/cli/filter_test.go` (existing, failing), Go `testing` package

--- a/specs/024-latest-plugin-version/plan.md
+++ b/specs/024-latest-plugin-version/plan.md
@@ -9,7 +9,7 @@ The system will implement logic to automatically select the latest version of in
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: `github.com/Masterminds/semver/v3`
 **Storage**: Filesystem (`~/.finfocus/plugins/`)
 **Testing**: Go `testing` package (Unit tests in `internal/registry`)

--- a/specs/025-testing-framework/research.md
+++ b/specs/025-testing-framework/research.md
@@ -118,7 +118,7 @@ test:
   steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.25.5'
+        go-version: '1.25.6'
         cache: true
     - run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
     - run: go tool cover -func=coverage.out

--- a/specs/106-analyzer-recommendations/plan.md
+++ b/specs/106-analyzer-recommendations/plan.md
@@ -20,7 +20,7 @@ include recommendations. The analyzer must:
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: github.com/rshade/finfocus-spec v0.4.10 (pluginsdk,
 protobuf types), github.com/pulumi/pulumi/sdk/v3 (Analyzer protocol)
 **Storage**: N/A (display-only feature)

--- a/specs/106-analyzer-recommendations/quickstart.md
+++ b/specs/106-analyzer-recommendations/quickstart.md
@@ -11,7 +11,7 @@ cost estimates, users will see them during `pulumi preview`.
 
 ## Prerequisites
 
-- Go 1.25.5+
+- Go 1.25.6+
 - Pulumi CLI installed
 - FinFocus binary built (`make build`)
 - A cost plugin that returns recommendations (e.g., aws-public with

--- a/specs/107-preflight-validation/plan.md
+++ b/specs/107-preflight-validation/plan.md
@@ -9,7 +9,7 @@ Integrate `pluginsdk.ValidateProjectedCostRequest()` and `pluginsdk.ValidateActu
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: github.com/rshade/finfocus-spec/sdk/go/pluginsdk v0.4.11+, zerolog v1.34.0
 **Storage**: N/A (validation is stateless)
 **Testing**: go test with table-driven tests, mock clients

--- a/specs/108-action-type-enum/plan.md
+++ b/specs/108-action-type-enum/plan.md
@@ -13,7 +13,7 @@ help text, and JSON serialization.
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: finfocus-spec v0.4.11 (pluginsdk), cobra v1.10.1,
   bubbletea v1.3.10, lipgloss v1.1.0
 **Storage**: N/A (stateless enum mapping)

--- a/specs/109-cost-recommendations/plan.md
+++ b/specs/109-cost-recommendations/plan.md
@@ -16,7 +16,7 @@ Enhance the existing `finfocus cost recommendations` command to add summary/verb
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: Cobra v1.10.1, Bubble Tea, Lip Gloss, zerolog v1.34.0
 **Storage**: N/A (stateless command, data from plugins via gRPC)
 **Testing**: go test with testify, table-driven tests

--- a/specs/109-cost-recommendations/quickstart.md
+++ b/specs/109-cost-recommendations/quickstart.md
@@ -5,7 +5,7 @@
 
 ## Prerequisites
 
-- Go 1.25.5 installed
+- Go 1.25.6 installed
 - Repository cloned and on `109-cost-recommendations` branch
 - Familiarity with Bubble Tea TUI framework
 

--- a/specs/111-state-actual-cost/plan.md
+++ b/specs/111-state-actual-cost/plan.md
@@ -20,7 +20,7 @@ reliability (AWS region scoping, deterministic output, test timeouts).
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: cobra v1.10.1, finfocus-spec v0.4.11 (pluginsdk),
 zerolog v1.34.0, Bubble Tea/Lip Gloss (TUI)
 **Storage**: N/A (stateless CLI tool; reads Pulumi state JSON files)

--- a/specs/112-plugin-info-discovery/plan.md
+++ b/specs/112-plugin-info-discovery/plan.md
@@ -9,7 +9,7 @@ This feature implements the consumer-side requirements for `GetPluginInfo` and `
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: github.com/rshade/finfocus-spec v0.4.14, github.com/Masterminds/semver/v3
 **Storage**: N/A (Stateless CLI)
 **Testing**: go test, testify

--- a/specs/113-rebrand-to-finfocus/plan.md
+++ b/specs/113-rebrand-to-finfocus/plan.md
@@ -11,7 +11,7 @@ Rename the entire `finfocus` ecosystem to `finfocus`. This includes renaming the
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: `github.com/spf13/cobra` (CLI), `github.com/spf13/viper` (Config), `github.com/rshade/finfocus-spec` (renamed from `finfocus-spec`)
 **Storage**: Filesystem (`~/.finfocus/config.yaml`, `~/.finfocus/plugins/`)
 **Testing**: Go standard library testing + `testify`

--- a/specs/115-v021-dx-improvements/plan.md
+++ b/specs/115-v021-dx-improvements/plan.md
@@ -13,7 +13,7 @@ This feature implements a set of developer experience (DX) and performance impro
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: 
 - `golang.org/x/sync/errgroup` (Concurrency)
 - `github.com/spf13/cobra` (CLI)

--- a/specs/116-plugin-install-fallback/plan.md
+++ b/specs/116-plugin-install-fallback/plan.md
@@ -9,7 +9,7 @@ Add fallback behavior to `finfocus plugin install` when a requested version lack
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: Cobra v1.10.2 (CLI), golang.org/x/term (TTY detection), existing `internal/registry` and `internal/tui` packages
 **Storage**: N/A (stateless CLI feature)
 **Testing**: Go testing + testify, existing test infrastructure in `test/unit/`, `test/integration/`

--- a/specs/116-plugin-install-fallback/tasks.md
+++ b/specs/116-plugin-install-fallback/tasks.md
@@ -30,7 +30,7 @@
 **Purpose**: Project initialization and branch setup
 
 - [x] T001 Verify branch `116-plugin-install-fallback` exists and is checked out
-- [x] T002 [P] Verify Go 1.25.5 and Cobra v1.10.2 are available
+- [x] T002 [P] Verify Go 1.25.6 and Cobra v1.10.2 are available
 
 ---
 

--- a/specs/117-engine-budget-logic/plan.md
+++ b/specs/117-engine-budget-logic/plan.md
@@ -7,7 +7,7 @@
 
 ## Technical Context
 
-**Language/Framework**: Go 1.25.5
+**Language/Framework**: Go 1.25.6
 **Existing Components**:
 - `internal/engine/`: Core engine logic.
 - `github.com/rshade/finfocus-spec`: Proto definitions (v0.5.2).

--- a/specs/118-e2e-plugin-docs/data-model.md
+++ b/specs/118-e2e-plugin-docs/data-model.md
@@ -9,7 +9,7 @@
 - **Title**: E2E Testing Guide
 - **Audience**: Developers, CI Engineers
 - **Key Sections**:
-  - Prerequisites (Go 1.25.5+, AWS Creds)
+  - Prerequisites (Go 1.25.6+, AWS Creds)
   - Quick Start
   - Running Tests (`make test-e2e`)
   - Test Scenarios (Projected, Actual, Validation, Cleanup)

--- a/specs/118-e2e-plugin-docs/quickstart.md
+++ b/specs/118-e2e-plugin-docs/quickstart.md
@@ -4,7 +4,7 @@
 
 Before running end-to-end tests, ensure your environment meets the following requirements:
 
-- **Go 1.25.5+**: Required for building the core and plugins.
+- **Go 1.25.6+**: Required for building the core and plugins.
 - **AWS Credentials**: A valid AWS account with read permissions (for Cost Explorer) and resource creation permissions (for infrastructure tests).
 - **FinFocus Core**: Installed locally.
 

--- a/specs/118-e2e-plugin-docs/research.md
+++ b/specs/118-e2e-plugin-docs/research.md
@@ -15,7 +15,7 @@
 
 ### R-1: E2E Test Command Verification
 - **Command**: `make test-e2e` (Verified in Makefile via listing/reading if needed, assumed from spec).
-- **Prerequisites**: Go 1.25.5+, AWS Credentials, Plugins installed.
+- **Prerequisites**: Go 1.25.6+, AWS Credentials, Plugins installed.
 - **Output**: `test-results/e2e-summary.json` (from spec).
 
 ### R-2: Documentation Structure

--- a/specs/118-e2e-plugin-docs/spec.md
+++ b/specs/118-e2e-plugin-docs/spec.md
@@ -8,7 +8,7 @@
 ## Clarifications
 
 ### Session 2026-01-19
-- Q: What Go version requirement should be documented? → A: Go 1.25.5+ (due to critical bug in 1.25.4)
+- Q: What Go version requirement should be documented? → A: Go 1.25.6+ (due to critical bug in 1.25.4)
 - Q: How should the new documentation files be organized in the `docs/` directory? → A: Structure by category (e.g., `docs/testing/`, `docs/architecture/`, `docs/guides/`)
 - Q: What format should be used for the architecture diagrams? → A: Mermaid diagrams (in-line code, versionable)
 - Q: Should README links point to local files or the documentation site? → A: Docs site links preferred
@@ -26,7 +26,7 @@ Developers and CI engineers need a clear guide to set up and run end-to-end (E2E
 
 **Acceptance Scenarios**:
 
-1. **Given** a developer with Go 1.25.5+ and AWS credentials, **When** they follow the "E2E Testing Quick Start" guide, **Then** they can successfully install required plugins and run the E2E test suite.
+1. **Given** a developer with Go 1.25.6+ and AWS credentials, **When** they follow the "E2E Testing Quick Start" guide, **Then** they can successfully install required plugins and run the E2E test suite.
 2. **Given** an E2E test failure, **When** the user consults the "Troubleshooting" section, **Then** they find steps to interpret results (e.g., `test-results/e2e-summary.json`) and diagnose common issues (e.g., credential errors).
 
 ---
@@ -68,7 +68,7 @@ Users encountering installation or runtime errors need a centralized resource to
 - **FR-004**: The `README.md` for `pulumicost-core` MUST be updated to include a summary of E2E testing, plugin ecosystem links, and an architecture diagram using Mermaid.
 - **FR-005**: The `README.md` for `pulumicost-plugin-aws-public` MUST be updated to clarify its role as a fallback/public-pricing plugin and its relationship to the core.
 - **FR-006**: The documentation MUST include a "Troubleshooting" section addressing common issues: Plugin Installation Failures, AWS Credential Problems, Cost Calculation Errors, and E2E Test Timeouts.
-- **FR-007**: The documentation MUST provide a "Quick Start" for E2E testing that assumes a clean environment (Go 1.25.5+, AWS creds).
+- **FR-007**: The documentation MUST provide a "Quick Start" for E2E testing that assumes a clean environment (Go 1.25.6+, AWS creds).
 - **FR-008**: Documentation files MUST be organized by category within the `docs/` directory (e.g., `docs/testing/e2e-guide.md`, `docs/architecture/plugin-ecosystem.md`, `docs/guides/troubleshooting.md`).
 - **FR-009**: All architecture diagrams MUST be implemented using Mermaid formatting within the Markdown files.
 - **FR-010**: Links in `README.md` files SHOULD point to the hosted documentation site where available, with relative local links as fallbacks.

--- a/specs/119-test-quality-ci/plan.md
+++ b/specs/119-test-quality-ci/plan.md
@@ -9,7 +9,7 @@ Improve test quality and CI/CD infrastructure by: (1) adding `newState` seed cor
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: testify v1.11.1, GitHub Actions, finfocus-spec v0.4.11 (pluginsdk)
 **Storage**: N/A (test infrastructure, no persistent storage)
 **Testing**: Go native testing with fuzz support, testify assertions, E2E via CLI binary execution

--- a/specs/119-test-quality-ci/research.md
+++ b/specs/119-test-quality-ci/research.md
@@ -75,7 +75,7 @@ jsonStr := fmt.Sprintf(`{"steps": [%s]}`, strings.Join(resources, ","))
 **Key Patterns from Existing Workflows**:
 
 1. Use `actions/checkout@v6` with path separation for multiple repos
-2. Use `actions/setup-go@v6` with `go-version: '1.25.5'` and `cache: true`
+2. Use `actions/setup-go@v6` with `go-version: '1.25.6'` and `cache: true`
 3. Use `actions/github-script@v8` for issue creation on failure
 4. Set `permissions: { contents: read, issues: write }`
 

--- a/specs/119-test-quality-ci/spec.md
+++ b/specs/119-test-quality-ci/spec.md
@@ -139,7 +139,7 @@ As a developer writing tests, I need all test files to properly handle errors fr
 - GitHub Actions `workflow_dispatch` is available for manual workflow triggering
 - The `actions/checkout@v6` and `actions/setup-go@v6` actions are available and stable
 - Plugin binary naming conventions follow existing patterns (`finfocus-plugin-*` or `bin/*`)
-- Go 1.25.5 fuzz testing features are stable and compatible with CI runners
+- Go 1.25.6 fuzz testing features are stable and compatible with CI runners
 - Nightly schedule cron (`0 2 * * *`) runs at 2 AM UTC as expected by GitHub Actions
 
 ## Clarifications

--- a/specs/120-cost-tui-upgrade/plan.md
+++ b/specs/120-cost-tui-upgrade/plan.md
@@ -13,7 +13,7 @@ resource tables, detail views, and loading states.
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**:
 
 - `github.com/charmbracelet/bubbletea` v1.2.4 (already transitive, promote to direct)

--- a/specs/122-cli-pagination/plan.md
+++ b/specs/122-cli-pagination/plan.md
@@ -20,7 +20,7 @@ Technical approach: Enhance existing CLI command handlers and TUI components wit
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**:
 - github.com/spf13/cobra v1.10.2 (CLI framework)
 - github.com/charmbracelet/bubbletea v0.27.2+ (TUI framework)

--- a/specs/123-budget-health-suite/plan.md
+++ b/specs/123-budget-health-suite/plan.md
@@ -18,7 +18,7 @@ The implementation uses proto definitions from finfocus-spec v0.5.4 and follows 
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: finfocus-spec v0.5.4 (protobuf types), google.golang.org/grpc, github.com/stretchr/testify
 **Storage**: N/A (stateless engine functionality)
 **Testing**: go test with testify assertions, table-driven tests

--- a/specs/124-budget-exit-codes/plan.md
+++ b/specs/124-budget-exit-codes/plan.md
@@ -9,7 +9,7 @@ Add configurable exit codes when budget thresholds are exceeded, enabling CI/CD 
 
 ## Technical Context
 
-**Language/Version**: Go 1.25.5
+**Language/Version**: Go 1.25.6
 **Primary Dependencies**: github.com/spf13/cobra (CLI), github.com/rs/zerolog (logging), github.com/rshade/finfocus-spec (proto definitions)
 **Storage**: YAML config file (~/.finfocus/config.yaml)
 **Testing**: go test with testify (require/assert), 80% minimum coverage

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,8 +1,10 @@
 module github.com/rshade/finfocus/test/e2e
 
-go 1.25.5
+go 1.25.6
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/aws/aws-sdk-go-v2/config v1.32.6
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pulumi/pulumi/sdk/v3 v3.210.0
 	github.com/stretchr/testify v1.11.1
@@ -10,7 +12,6 @@ require (
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.1.3 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
@@ -19,7 +20,6 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.0 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.6 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.6 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16 // indirect


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to property conversion for plugin communication, along with dependency updates and a temporary CI workflow change. The most significant change is the introduction of more robust conversion logic for resource properties, ensuring better handling of nested structures and various data types when communicating with plugins via gRPC. Additionally, comprehensive unit tests have been added to validate this new conversion logic.

**Core logic improvements:**

* Refactored the property conversion logic by introducing `ConvertToProto` and `ConvertValueToString` functions in `internal/engine/engine.go`. These functions handle complex nested structures, arrays, and various data types, ensuring consistent string conversion for gRPC plugin communication. The conversion now intelligently extracts values from common patterns (such as `{"value": ...}` or `{"id": ...}`) and handles arrays more gracefully.
* Updated all usages of the old `convertToProto` function in the engine to use the new `ConvertToProto` for consistency and improved behavior. [[1]](diffhunk://#diff-c9a29ac513b03b203827d19beb65f9eff05111842ab545c071f25a656f998fc4L992-R992) [[2]](diffhunk://#diff-c9a29ac513b03b203827d19beb65f9eff05111842ab545c071f25a656f998fc4L2520-R2585) [[3]](diffhunk://#diff-c9a29ac513b03b203827d19beb65f9eff05111842ab545c071f25a656f998fc4L2580-R2645)

**Testing improvements:**

* Added comprehensive unit tests for both `ConvertValueToString` and `ConvertToProto` in `internal/engine/engine_test.go`, covering a wide range of input scenarios including nested maps, arrays, and different data types.

**Dependency updates:**

* Updated the Go version in `go.mod` from 1.25.5 to 1.25.6 and bumped the `github.com/rshade/finfocus-spec` dependency from v0.5.4 to v0.5.5. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L56-R56)

**CI/Workflow changes:**

* Temporarily disabled the scheduled trigger in `.github/workflows/cross-repo-integration.yml` due to architectural issues with plugin builds in CI, with notes and guidance for the correct approach using binary plugin installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain from 1.25.5 to 1.25.6 and bumped related dependencies (including finfocus-spec).
  * Temporarily disabled scheduled workflow triggers; manual triggers remain available.
  * Improved internal property value conversion to better handle nested/array values.

* **Documentation**
  * Updated numerous docs and examples to reflect Go 1.25.6 requirements and CI examples.

* **Tests**
  * Added unit tests covering value-to-string conversions and property conversion behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->