### PR TITLE
fix(ingest): pass cloud resource IDs and ARNs to plugins for actual cost

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,7 +44,7 @@ jobs:
     name: Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
@@ -283,7 +283,7 @@ jobs:
     name: Build (${{ matrix.os }}-${{ matrix.goarch }})
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -362,10 +362,116 @@ jobs:
           path: benchmark-results.txt
           retention-days: 30
 
+  # Post-test AWS resource cleanup
+  aws-cleanup:
+    name: AWS E2E Cleanup
+    runs-on: ubuntu-latest
+    needs: [integration, e2e, analyzer-e2e]
+    if: always()
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_E2E_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Clean up E2E AWS resources
+        shell: bash
+        run: |
+          set +e  # Don't fail on individual cleanup errors
+
+          cleanup_region() {
+            local REGION="$1"
+            echo "=== Cleaning up region: ${REGION} ==="
+
+            # 1. Terminate EC2 instances tagged with e2e-test-*
+            mapfile -t INSTANCE_IDS < <(aws ec2 describe-instances \
+              --region "${REGION}" \
+              --filters "Name=tag:Name,Values=e2e-test-*" "Name=instance-state-name,Values=running,stopped,pending" \
+              --query "Reservations[].Instances[].InstanceId" --output text 2>/dev/null | xargs -n1)
+            if [ "${#INSTANCE_IDS[@]}" -gt 0 ]; then
+              echo "Terminating instances in ${REGION}: ${INSTANCE_IDS[*]}"
+              aws ec2 terminate-instances --region "${REGION}" --instance-ids "${INSTANCE_IDS[@]}"
+              aws ec2 wait instance-terminated --region "${REGION}" --instance-ids "${INSTANCE_IDS[@]}" || true
+            fi
+
+            # 2. Delete detached EBS volumes
+            mapfile -t VOLUME_IDS < <(aws ec2 describe-volumes \
+              --region "${REGION}" \
+              --filters "Name=tag:Name,Values=e2e-test-*" "Name=status,Values=available" \
+              --query "Volumes[].VolumeId" --output text 2>/dev/null | xargs -n1)
+            if [ "${#VOLUME_IDS[@]}" -gt 0 ]; then
+              echo "Deleting volumes in ${REGION}: ${VOLUME_IDS[*]}"
+              for VOL in "${VOLUME_IDS[@]}"; do
+                aws ec2 delete-volume --region "${REGION}" --volume-id "${VOL}" || true
+              done
+            fi
+
+            # 3. Delete security groups (non-default)
+            mapfile -t SG_IDS < <(aws ec2 describe-security-groups \
+              --region "${REGION}" \
+              --filters "Name=tag:Name,Values=e2e-test-*" \
+              --query "SecurityGroups[?GroupName!='default'].GroupId" --output text 2>/dev/null | xargs -n1)
+            if [ "${#SG_IDS[@]}" -gt 0 ]; then
+              echo "Deleting security groups in ${REGION}: ${SG_IDS[*]}"
+              for SG in "${SG_IDS[@]}"; do
+                aws ec2 delete-security-group --region "${REGION}" --group-id "${SG}" || true
+              done
+            fi
+
+            # 4. Delete subnets
+            mapfile -t SUBNET_IDS < <(aws ec2 describe-subnets \
+              --region "${REGION}" \
+              --filters "Name=tag:Name,Values=e2e-test-*" \
+              --query "Subnets[].SubnetId" --output text 2>/dev/null | xargs -n1)
+            if [ "${#SUBNET_IDS[@]}" -gt 0 ]; then
+              echo "Deleting subnets in ${REGION}: ${SUBNET_IDS[*]}"
+              for SUBNET in "${SUBNET_IDS[@]}"; do
+                aws ec2 delete-subnet --region "${REGION}" --subnet-id "${SUBNET}" || true
+              done
+            fi
+
+            # 5. Detach and delete internet gateways
+            mapfile -t VPC_IDS < <(aws ec2 describe-vpcs \
+              --region "${REGION}" \
+              --filters "Name=tag:Name,Values=e2e-test-*,test-vpc" \
+              --query "Vpcs[].VpcId" --output text 2>/dev/null | xargs -n1)
+            if [ "${#VPC_IDS[@]}" -gt 0 ]; then
+              for VPC in "${VPC_IDS[@]}"; do
+                mapfile -t IGW_IDS < <(aws ec2 describe-internet-gateways \
+                  --region "${REGION}" \
+                  --filters "Name=attachment.vpc-id,Values=${VPC}" \
+                  --query "InternetGateways[].InternetGatewayId" --output text 2>/dev/null | xargs -n1)
+                if [ "${#IGW_IDS[@]}" -gt 0 ]; then
+                  for IGW in "${IGW_IDS[@]}"; do
+                    echo "Detaching and deleting IGW ${IGW} from VPC ${VPC} in ${REGION}"
+                    aws ec2 detach-internet-gateway --region "${REGION}" --internet-gateway-id "${IGW}" --vpc-id "${VPC}" || true
+                    aws ec2 delete-internet-gateway --region "${REGION}" --internet-gateway-id "${IGW}" || true
+                  done
+                fi
+              done
+            fi
+
+            # 6. Delete VPCs
+            if [ "${#VPC_IDS[@]}" -gt 0 ]; then
+              echo "Deleting VPCs in ${REGION}: ${VPC_IDS[*]}"
+              for VPC in "${VPC_IDS[@]}"; do
+                aws ec2 delete-vpc --region "${REGION}" --vpc-id "${VPC}" || true
+              done
+            fi
+
+            echo "=== Cleanup complete for ${REGION} ==="
+          }
+
+          # Clean up all regions used by E2E tests
+          for REGION in us-east-1 eu-west-1 ap-northeast-1; do
+            cleanup_region "${REGION}"
+          done
+
   notify-failure:
     name: Notify on Failure
     runs-on: ubuntu-latest
-    needs: [cross-platform-tests, integration, e2e, analyzer-e2e, deep-fuzz, cross-platform-builds, benchmarks]
+    needs: [cross-platform-tests, integration, e2e, analyzer-e2e, deep-fuzz, cross-platform-builds, benchmarks, aws-cleanup]
     if: always() && github.event_name == 'schedule' && failure()
     steps:
       - name: Create failure issue

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1027,6 +1027,8 @@ CodeRabbit now:
   - Bubble Tea v1.3.10 (TUI), Lip Gloss v1.1.0 (styling) (223-cost-estimate)
 - Local JSON file (`~/.finfocus/dismissed.json`) for dismissal state; plugin-side storage delegated to plugins (508-recommendation-dismissal)
 - State Management: N/A (stateless command design) (223-cost-estimate)
+- Go 1.25.7 + Cobra v1.10.2 (CLI), zerolog v1.34.0 (logging), testify v1.11.1 (testing). No new dependencies. (509-pulumi-auto-detect)
+- N/A (stateless CLI invocation) (509-pulumi-auto-detect)
 
 ## Recent Changes
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1343,6 +1343,7 @@ func (e *Engine) getActualCostFromPlugin(
 		ResourceIDs: []string{resource.ID},
 		StartTime:   from.Unix(),
 		EndTime:     to.Unix(),
+		Properties:  resource.Properties,
 	}
 
 	resp, err := client.API.GetActualCost(ctx, req)

--- a/internal/ingest/state_test.go
+++ b/internal/ingest/state_test.go
@@ -39,9 +39,14 @@ const stateWithTimestamps = `{
         "modified": "2024-06-20T14:22:00Z",
         "inputs": {
           "instanceType": "t3.micro",
-          "ami": "ami-12345"
+          "ami": "ami-12345",
+          "tags": {
+            "Name": "web-server",
+            "Environment": "dev"
+          }
         },
         "outputs": {
+          "arn": "arn:aws:ec2:us-east-1:123456789012:instance/i-0abc123def456",
           "publicIp": "54.123.45.67"
         }
       },
@@ -393,4 +398,208 @@ func TestGetCustomResourcesWithContext(t *testing.T) {
 	ctx := context.Background()
 	resources := state.GetCustomResourcesWithContext(ctx)
 	assert.Len(t, resources, 2)
+}
+
+func TestMapStateResource_CloudIdentifiers(t *testing.T) {
+	t.Setenv("FINFOCUS_LOG_LEVEL", "error")
+
+	created := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		resource ingest.StackExportResource
+		validate func(t *testing.T, desc engine.ResourceDescriptor)
+	}{
+		{
+			name: "cloud ID and ARN injected from state",
+			resource: ingest.StackExportResource{
+				URN:    "urn:pulumi:dev::project::aws:ec2/instance:Instance::web",
+				Type:   "aws:ec2/instance:Instance",
+				ID:     "i-0abc123def456",
+				Custom: true,
+				Inputs: map[string]interface{}{
+					"instanceType": "t3.micro",
+				},
+				Outputs: map[string]interface{}{
+					"arn":      "arn:aws:ec2:us-east-1:123456789012:instance/i-0abc123def456",
+					"publicIp": "54.123.45.67",
+				},
+				Created: &created,
+			},
+			validate: func(t *testing.T, desc engine.ResourceDescriptor) {
+				// Cloud ID injected
+				assert.Equal(t, "i-0abc123def456", desc.Properties[ingest.PropertyPulumiCloudID])
+
+				// ARN injected from outputs
+				assert.Equal(t, "arn:aws:ec2:us-east-1:123456789012:instance/i-0abc123def456",
+					desc.Properties[ingest.PropertyPulumiARN])
+
+				// URN preserved
+				assert.Equal(t, "urn:pulumi:dev::project::aws:ec2/instance:Instance::web",
+					desc.Properties[ingest.PropertyPulumiURN])
+
+				// ID field still uses URN for display/correlation
+				assert.Equal(t, "urn:pulumi:dev::project::aws:ec2/instance:Instance::web", desc.ID)
+
+				// Original inputs preserved
+				assert.Equal(t, "t3.micro", desc.Properties["instanceType"])
+			},
+		},
+		{
+			name: "resource without outputs still gets cloud ID",
+			resource: ingest.StackExportResource{
+				URN:    "urn:pulumi:dev::project::aws:s3/bucket:Bucket::data",
+				Type:   "aws:s3/bucket:Bucket",
+				ID:     "my-bucket-12345",
+				Custom: true,
+				Inputs: map[string]interface{}{
+					"bucket": "my-bucket-12345",
+				},
+			},
+			validate: func(t *testing.T, desc engine.ResourceDescriptor) {
+				// Cloud ID injected from state ID
+				assert.Equal(t, "my-bucket-12345", desc.Properties[ingest.PropertyPulumiCloudID])
+
+				// No ARN (no outputs)
+				_, hasARN := desc.Properties[ingest.PropertyPulumiARN]
+				assert.False(t, hasARN)
+
+				// URN still preserved
+				assert.Equal(t, "urn:pulumi:dev::project::aws:s3/bucket:Bucket::data",
+					desc.Properties[ingest.PropertyPulumiURN])
+			},
+		},
+		{
+			name: "resource without cloud ID (empty ID field)",
+			resource: ingest.StackExportResource{
+				URN:    "urn:pulumi:dev::project::aws:ec2/instance:Instance::pending",
+				Type:   "aws:ec2/instance:Instance",
+				ID:     "",
+				Custom: true,
+				Inputs: map[string]interface{}{
+					"instanceType": "t3.micro",
+				},
+			},
+			validate: func(t *testing.T, desc engine.ResourceDescriptor) {
+				// No cloud ID injected (empty)
+				_, hasCloudID := desc.Properties[ingest.PropertyPulumiCloudID]
+				assert.False(t, hasCloudID)
+
+				// URN still preserved
+				assert.Equal(t, "urn:pulumi:dev::project::aws:ec2/instance:Instance::pending",
+					desc.Properties[ingest.PropertyPulumiURN])
+			},
+		},
+		{
+			name: "tags extracted from inputs",
+			resource: ingest.StackExportResource{
+				URN:    "urn:pulumi:dev::project::aws:ec2/instance:Instance::tagged",
+				Type:   "aws:ec2/instance:Instance",
+				ID:     "i-tagged123",
+				Custom: true,
+				Inputs: map[string]interface{}{
+					"instanceType": "t3.micro",
+					"tags": map[string]interface{}{
+						"Name":        "tagged-instance",
+						"Environment": "dev",
+					},
+				},
+			},
+			validate: func(t *testing.T, desc engine.ResourceDescriptor) {
+				// Tags should be present in properties
+				tags, ok := desc.Properties["tags"]
+				require.True(t, ok, "tags should exist in properties")
+
+				tagMap, ok := tags.(map[string]interface{})
+				require.True(t, ok, "tags should be a map")
+				assert.Equal(t, "tagged-instance", tagMap["Name"])
+				assert.Equal(t, "dev", tagMap["Environment"])
+			},
+		},
+		{
+			name: "tagsAll from outputs takes precedence",
+			resource: ingest.StackExportResource{
+				URN:    "urn:pulumi:dev::project::aws:ec2/launchTemplate:LaunchTemplate::nodes",
+				Type:   "aws:ec2/launchTemplate:LaunchTemplate",
+				ID:     "lt-0fedcba987654",
+				Custom: true,
+				Inputs: map[string]interface{}{
+					"tags": map[string]interface{}{
+						"Name": "nodes",
+					},
+				},
+				Outputs: map[string]interface{}{
+					"arn": "arn:aws:ec2:us-west-2:123456789012:launch-template/lt-0fedcba987654",
+					"tagsAll": map[string]interface{}{
+						"Name":      "nodes",
+						"ManagedBy": "pulumi",
+					},
+				},
+			},
+			validate: func(t *testing.T, desc engine.ResourceDescriptor) {
+				// tagsAll should be present (from outputs)
+				tagsAll, ok := desc.Properties["tagsAll"]
+				require.True(t, ok, "tagsAll should exist in properties")
+
+				tagMap, ok := tagsAll.(map[string]interface{})
+				require.True(t, ok, "tagsAll should be a map")
+				assert.Equal(t, "nodes", tagMap["Name"])
+				assert.Equal(t, "pulumi", tagMap["ManagedBy"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desc, err := ingest.MapStateResource(tt.resource)
+			require.NoError(t, err)
+			tt.validate(t, desc)
+		})
+	}
+}
+
+func TestMapStateResource_GoldenEKSState(t *testing.T) {
+	t.Setenv("FINFOCUS_LOG_LEVEL", "error")
+
+	statePath := "../../test/fixtures/state/golden-eks-state.json"
+
+	state, err := ingest.LoadStackExport(statePath)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	assert.Equal(t, 3, state.Version)
+	assert.True(t, state.HasTimestamps())
+
+	customResources := state.GetCustomResources()
+	// Provider + IAM role + EKS cluster + SG + launch template + bastion = 6
+	assert.Len(t, customResources, 6)
+
+	resources, err := ingest.MapStateResources(customResources)
+	require.NoError(t, err)
+	assert.Len(t, resources, 6)
+
+	// Verify EKS cluster has cloud ID and ARN
+	var eksCluster *engine.ResourceDescriptor
+	for i := range resources {
+		if resources[i].Type == "aws:eks/cluster:Cluster" {
+			eksCluster = &resources[i]
+			break
+		}
+	}
+	require.NotNil(t, eksCluster, "should find EKS cluster resource")
+	assert.Equal(t, "main-eks-cluster", eksCluster.Properties[ingest.PropertyPulumiCloudID])
+	assert.Equal(t, "arn:aws:eks:us-west-2:123456789012:cluster/main-eks-cluster",
+		eksCluster.Properties[ingest.PropertyPulumiARN])
+
+	// Verify bastion host is marked as external and has cloud ID
+	var bastion *engine.ResourceDescriptor
+	for i := range resources {
+		if resources[i].Type == "aws:ec2/instance:Instance" {
+			bastion = &resources[i]
+			break
+		}
+	}
+	require.NotNil(t, bastion, "should find bastion instance")
+	assert.Equal(t, "i-0bastion1234abcde", bastion.Properties[ingest.PropertyPulumiCloudID])
+	assert.Equal(t, "true", bastion.Properties[ingest.PropertyPulumiExternal])
 }

--- a/test/fixtures/state/golden-eks-state.json
+++ b/test/fixtures/state/golden-eks-state.json
@@ -1,0 +1,165 @@
+{
+  "version": 3,
+  "deployment": {
+    "manifest": {
+      "time": "2025-06-01T10:00:00.000000000Z",
+      "magic": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+      "version": "v3.130.0"
+    },
+    "resources": [
+      {
+        "urn": "urn:pulumi:prod::eks-cluster::pulumi:pulumi:Stack::eks-cluster-prod",
+        "type": "pulumi:pulumi:Stack",
+        "custom": false
+      },
+      {
+        "urn": "urn:pulumi:prod::eks-cluster::pulumi:providers:aws::default_us-west-2",
+        "type": "pulumi:providers:aws",
+        "custom": true,
+        "id": "provider-aws-usw2",
+        "inputs": {
+          "region": "us-west-2"
+        },
+        "outputs": {
+          "region": "us-west-2"
+        }
+      },
+      {
+        "urn": "urn:pulumi:prod::eks-cluster::aws:iam/role:Role::eks-cluster-role",
+        "type": "aws:iam/role:Role",
+        "custom": true,
+        "id": "eks-cluster-role-abc1234",
+        "external": false,
+        "provider": "urn:pulumi:prod::eks-cluster::pulumi:providers:aws::default_us-west-2",
+        "inputs": {
+          "name": "eks-cluster-role",
+          "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+          "tags": {
+            "Name": "eks-cluster-role",
+            "Environment": "production",
+            "Team": "platform"
+          }
+        },
+        "outputs": {
+          "arn": "arn:aws:iam::123456789012:role/eks-cluster-role-abc1234",
+          "name": "eks-cluster-role-abc1234",
+          "uniqueId": "AROA1234567890EXAMPLE"
+        },
+        "created": "2025-03-15T09:00:00Z",
+        "modified": "2025-03-15T09:00:00Z"
+      },
+      {
+        "urn": "urn:pulumi:prod::eks-cluster::aws:eks/cluster:Cluster::main",
+        "type": "aws:eks/cluster:Cluster",
+        "custom": true,
+        "id": "main-eks-cluster",
+        "external": false,
+        "provider": "urn:pulumi:prod::eks-cluster::pulumi:providers:aws::default_us-west-2",
+        "inputs": {
+          "name": "main-eks-cluster",
+          "roleArn": "arn:aws:iam::123456789012:role/eks-cluster-role-abc1234",
+          "version": "1.29",
+          "tags": {
+            "Name": "main-eks-cluster",
+            "Environment": "production",
+            "Team": "platform"
+          },
+          "vpcConfig": {
+            "subnetIds": ["subnet-0a1b2c3d", "subnet-0e5f6a7b"],
+            "securityGroupIds": ["sg-0abc1234def56789"]
+          }
+        },
+        "outputs": {
+          "arn": "arn:aws:eks:us-west-2:123456789012:cluster/main-eks-cluster",
+          "endpoint": "https://ABC123DEF456.gr7.us-west-2.eks.amazonaws.com",
+          "certificateAuthority": {"data": "LS0tLS1CRUdJTi...FAKE..."},
+          "name": "main-eks-cluster",
+          "platformVersion": "eks.8",
+          "status": "ACTIVE",
+          "vpcConfig": {
+            "clusterSecurityGroupId": "sg-0cluster1234",
+            "vpcId": "vpc-0abc123def456"
+          }
+        },
+        "created": "2025-03-15T09:05:00Z",
+        "modified": "2025-05-20T14:30:00Z"
+      },
+      {
+        "urn": "urn:pulumi:prod::eks-cluster::aws:ec2/securityGroup:SecurityGroup::eks-node-sg",
+        "type": "aws:ec2/securityGroup:SecurityGroup",
+        "custom": true,
+        "id": "sg-0abc1234def56789",
+        "external": false,
+        "provider": "urn:pulumi:prod::eks-cluster::pulumi:providers:aws::default_us-west-2",
+        "inputs": {
+          "name": "eks-node-sg",
+          "description": "Security group for EKS worker nodes",
+          "vpcId": "vpc-0abc123def456",
+          "tags": {
+            "Name": "eks-node-sg",
+            "Environment": "production"
+          }
+        },
+        "outputs": {
+          "arn": "arn:aws:ec2:us-west-2:123456789012:security-group/sg-0abc1234def56789",
+          "id": "sg-0abc1234def56789",
+          "ownerId": "123456789012"
+        },
+        "created": "2025-03-15T09:02:00Z",
+        "modified": "2025-03-15T09:02:00Z"
+      },
+      {
+        "urn": "urn:pulumi:prod::eks-cluster::aws:ec2/launchTemplate:LaunchTemplate::eks-nodes",
+        "type": "aws:ec2/launchTemplate:LaunchTemplate",
+        "custom": true,
+        "id": "lt-0fedcba9876543210",
+        "external": false,
+        "provider": "urn:pulumi:prod::eks-cluster::pulumi:providers:aws::default_us-west-2",
+        "inputs": {
+          "instanceType": "m5.xlarge",
+          "imageId": "ami-0eks1234567890abc",
+          "tags": {
+            "Name": "eks-nodes",
+            "Environment": "production"
+          }
+        },
+        "outputs": {
+          "arn": "arn:aws:ec2:us-west-2:123456789012:launch-template/lt-0fedcba9876543210",
+          "id": "lt-0fedcba9876543210",
+          "latestVersion": 3,
+          "tagsAll": {
+            "Name": "eks-nodes",
+            "Environment": "production",
+            "ManagedBy": "pulumi"
+          }
+        },
+        "created": "2025-03-15T09:10:00Z",
+        "modified": "2025-04-01T11:20:00Z"
+      },
+      {
+        "urn": "urn:pulumi:prod::eks-cluster::aws:ec2/instance:Instance::bastion",
+        "type": "aws:ec2/instance:Instance",
+        "custom": true,
+        "id": "i-0bastion1234abcde",
+        "external": true,
+        "provider": "urn:pulumi:prod::eks-cluster::pulumi:providers:aws::default_us-west-2",
+        "inputs": {
+          "instanceType": "t3.small",
+          "ami": "ami-0bastion12345",
+          "tags": {
+            "Name": "bastion-host",
+            "Environment": "production"
+          }
+        },
+        "outputs": {
+          "arn": "arn:aws:ec2:us-west-2:123456789012:instance/i-0bastion1234abcde",
+          "instanceType": "t3.small",
+          "publicIp": "198.51.100.10",
+          "privateIp": "10.0.1.50"
+        },
+        "created": "2025-01-10T08:00:00Z",
+        "modified": "2025-06-01T10:00:00Z"
+      }
+    ]
+  }
+}


### PR DESCRIPTION

## Summary
- `cost actual --pulumi-state` failed with "missing resource information" because the adapter sent Pulumi URNs instead of cloud-provider IDs (e.g., `i-0abc123`) to plugins
- `MapStateResource()` now injects `pulumi:cloudId`, `pulumi:arn`, `pulumi:urn`, and tags from Pulumi state into ResourceDescriptor Properties
- The adapter resolves these properties into the proto `GetActualCostRequest` fields (`ResourceId`, `Arn`, `Tags`) that plugins expect
- Added `Properties` pass-through from engine to adapter so resource context reaches the gRPC layer

## Validation
- [x] `make test` passes with zero failures
- [x] `make lint` passes with zero issues
- [x] Unit tests for `MapStateResource` cloud identifier injection (5 cases: cloud ID+ARN, no outputs, empty ID, tags from inputs, tagsAll precedence)
- [x] Unit tests for `resolveActualCostIdentifiers` (6 cases)
- [x] Unit tests for `extractResourceTags` (5 cases)
- [x] Integration test against golden EKS state fixture
- [x] End-to-end adapter test with Properties flow

## Files Changed
- `test/fixtures/state/golden-eks-state.json` - Sanitized EKS cluster state with 7 resources (IAM, EKS, EC2, security groups) for testing cloud identifier extraction
- `internal/ingest/state.go` - Enriched `MapStateResource()` to inject cloud ID from `resource.ID`, ARN from outputs, URN, and tags (tagsAll preferred over tags)
- `internal/proto/adapter.go` - Added `Properties` field to `GetActualCostRequest`; added `resolveActualCostIdentifiers()`, `extractResourceTags()`, `extractTagMap()` helpers; updated both `GetActualCostWithErrors()` and `clientAdapter.GetActualCost()` to populate proto ResourceId/Arn/Tags
- `internal/engine/engine.go` - Pass `resource.Properties` through to adapter in `getActualCostFromPlugin()`
- `internal/ingest/state_test.go` - Added cloud identifier and golden EKS state tests; enriched test fixtures with outputs/tags
- `internal/proto/adapter_test.go` - Added tests for identifier resolution, tag extraction, and Properties flow
- `test/integration/actual_cost_test.go` - Added integration test for cloud identifier extraction from golden state

Closes #380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Actual cost calculations now include resource properties (Cloud ID, ARN, URN) for enhanced metadata and resource identification.

* **Chores**
  * Updated nightly CI workflows with improved cleanup procedures and test failure handling.
  * Enhanced documentation for CLI dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->