### PR TITLE
fix(registry): fall back to filesystem discovery for plugin removal

### DIFF
--- a/internal/config/plugins.go
+++ b/internal/config/plugins.go
@@ -78,7 +78,8 @@ func SaveInstalledPlugins(plugins []InstalledPlugin) error {
 		if unmarshalErr := yaml.Unmarshal(existingData, &fullConfig); unmarshalErr != nil {
 			fullConfig = make(map[string]interface{})
 		}
-	} else {
+	}
+	if fullConfig == nil {
 		fullConfig = make(map[string]interface{})
 	}
 


### PR DESCRIPTION
## Summary

- Plugins installed manually (e.g., `make install-recorder`) exist on disk but have no entry in `config.yaml`, causing `plugin remove` to report them as "not installed" despite being visible in `plugin list`
- `Remove()` now resolves the plugin directory before the config check and falls back to scanning `~/.finfocus/plugins/<name>/` for version subdirectories when the config lookup fails
- Config removal is skipped gracefully for filesystem-only plugins, avoiding both spurious warnings and a nil map panic in `SaveInstalledPlugins()` when the config file has no YAML keys

## Test plan

- [x] `make test` passes
- [x] `make lint` passes with zero issues
- [x] New test: filesystem-only plugin removal succeeds
- [x] New test: filesystem-only plugin with multiple versions
- [x] New test: config-tracked plugin removal still works (regression)
- [x] Existing remove tests pass (basic, keep-config, aliases, non-existent, progress, CLI, multi-version)

## Changes

### Modified files

- `internal/registry/installer.go` - Reorder `pluginDir` resolution before config check, add filesystem fallback with `inConfig` flag, add `discoverPluginFromFilesystem()` helper method
- `internal/config/plugins.go` - Fix nil map panic in `SaveInstalledPlugins()` when config file contains only comments
- `test/integration/plugin/remove_test.go` - Add three new test cases for filesystem-only removal and config-tracked regression

Closes #592