### PR TITLE
fix(proto): deep copy CostBreakdown to prevent source mutation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ analysis.md
 dist/
 build/
 vendor/
+PR_MESSAGE.md

--- a/internal/proto/adapter.go
+++ b/internal/proto/adapter.go
@@ -267,8 +267,8 @@ func recordActualCostPluginError(
 }
 
 // appendActualCostResults converts each ActualCostResult into a CostResult and appends it to result.Results.
-// The conversion copies Currency to Currency, TotalCost to MonthlyCost, copies CostBreakdown, sets HourlyCost to 0,
-// and deep-copies the Sustainability metrics into a new map. The provided result is mutated in-place.
+// It deep-copies both CostBreakdown and Sustainability metrics into new maps.
+// The provided result is mutated in-place.
 //
 // Parameters:
 //   - result: destination CostResultWithErrors whose Results slice will be extended.
@@ -279,8 +279,12 @@ func appendActualCostResults(result *CostResultWithErrors, actualResults []*Actu
 			Currency:       actual.Currency,
 			MonthlyCost:    actual.TotalCost, // Total cost for the period
 			HourlyCost:     0,
-			CostBreakdown:  actual.CostBreakdown,
+			CostBreakdown:  make(map[string]float64, len(actual.CostBreakdown)),
 			Sustainability: make(map[string]SustainabilityMetric),
+		}
+
+		for k, v := range actual.CostBreakdown {
+			costResult.CostBreakdown[k] = v
 		}
 
 		for k, v := range actual.Sustainability {

--- a/internal/proto/adapter_test.go
+++ b/internal/proto/adapter_test.go
@@ -3065,3 +3065,33 @@ func (m *mockPbcCostSourceServiceClient) GetBudgets(
 ) (*pbc.GetBudgetsResponse, error) {
 	return &pbc.GetBudgetsResponse{}, nil
 }
+
+func TestAppendActualCostResults_DeepCopy(t *testing.T) {
+	// Arrange
+	originalBreakdown := map[string]float64{
+		"Compute": 100.0,
+		"Storage": 50.0,
+	}
+	actualResults := []*ActualCostResult{
+		{
+			Currency:      "USD",
+			TotalCost:     150.0,
+			CostBreakdown: originalBreakdown,
+		},
+	}
+	result := &CostResultWithErrors{
+		Results: []*CostResult{},
+	}
+
+	// Act
+	appendActualCostResults(result, actualResults)
+
+	// Assert
+	assert.Len(t, result.Results, 1)
+
+	// Mutate the result's breakdown
+	result.Results[0].CostBreakdown["Compute"] = 999.0
+
+	// Verify the original was NOT mutated
+	assert.Equal(t, 100.0, originalBreakdown["Compute"], "Original CostBreakdown should not be mutated")
+}


### PR DESCRIPTION
## Summary

- Fixed an issue in `appendActualCostResults` where `CostBreakdown` maps were assigned by reference instead of being deep-copied.
- This prevents side effects where mutating the resulting `CostResult` could inadvertently modify the source `ActualCostResult`.
- Updated documentation for `appendActualCostResults` to accurately reflect that both `CostBreakdown` and `Sustainability` metrics are now deep-copied.

## Test plan

- [x] Completed validation steps
- [x] `make lint` passes with zero issues
- [x] `make test` passes

## Changes

### Modified files

- `internal/proto/adapter.go` - Deep-copy `CostBreakdown` and update doc comment.
- `internal/proto/adapter_test.go` - Add regression test for deep-copying.

Closes #614