### PR TITLE
feat(router): support GCP zone normalization in normalizeToRegion

### DIFF
--- a/internal/router/region_test.go
+++ b/internal/router/region_test.go
@@ -41,6 +41,14 @@ func TestExtractResourceRegion(t *testing.T) {
 			want: "eu-west-1",
 		},
 		{
+			name: "GCP zone stripped to region",
+			resource: engine.ResourceDescriptor{
+				Type:       "gcp:compute:Instance",
+				Properties: map[string]interface{}{"availabilityZone": "us-central1-a"},
+			},
+			want: "us-central1",
+		},
+		{
 			name: "location property for Azure",
 			resource: engine.ResourceDescriptor{
 				Type:       "azure:compute:VM",
@@ -88,9 +96,17 @@ func TestNormalizeToRegion(t *testing.T) {
 		input string
 		want  string
 	}{
+		// AWS zones
 		{"us-west-2a", "us-west-2"},
 		{"us-west-2", "us-west-2"},
 		{"eu-central-1c", "eu-central-1"},
+		// GCP zones
+		{"us-central1-a", "us-central1"},
+		{"europe-west1-b", "europe-west1"},
+		{"asia-east2-c", "asia-east2"},
+		// GCP regions (no zone suffix) returned unchanged
+		{"us-central1", "us-central1"},
+		// Azure / other
 		{"eastus", "eastus"},
 		{"", ""},
 	}


### PR DESCRIPTION
## Summary

- GCP zones use a `-<letter>` suffix format (e.g., `us-central1-a`) unlike AWS zones which use a direct letter suffix (`us-west-2a`)
- The existing logic only handled AWS format, causing GCP resources to fail plugin region matching
- Added a second check for the `digit + dash + letter` pattern so both cloud providers normalize correctly

## Test plan

- [x] GCP zones normalize correctly (`us-central1-a` -> `us-central1`, `europe-west1-b` -> `europe-west1`, `asia-east2-c` -> `asia-east2`)
- [x] AWS zones still normalize correctly (`us-west-2a` -> `us-west-2`)
- [x] Non-zone strings returned unchanged (`eastus`, `us-central1`)
- [x] `ExtractResourceRegion` handles GCP zones via `availabilityZone`
- [x] `make test` passes
- [x] `make lint` passes with zero issues

## Changes

### Modified files

- `internal/router/region.go` - Added GCP zone detection branch after existing AWS check in `normalizeToRegion`
- `internal/router/region_test.go` - Added GCP test cases to `TestNormalizeToRegion` and `TestExtractResourceRegion`

Closes #615