### PR TITLE
Revert "chore(deps): update dependency go to v1.26.0"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0'
+          go-version: '1.25.7'
           cache: true
 
       - name: Build plugin binaries for integration tests
@@ -92,7 +92,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0'
+          go-version: '1.25.7'
           cache: true
 
       - name: Run golangci-lint
@@ -122,7 +122,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0'
+          go-version: '1.25.7'
           cache: true
 
       - name: Install govulncheck
@@ -141,7 +141,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0'
+          go-version: '1.25.7'
           cache: true
 
       - name: Check gofmt
@@ -174,7 +174,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0'
+          go-version: '1.25.7'
           cache: true
 
       - name: Restore fuzz corpus cache
@@ -220,7 +220,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0'
+          go-version: '1.25.7'
           cache: true
 
       - name: Run benchmark smoke tests
@@ -250,7 +250,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0'
+          go-version: '1.25.7'
           cache: true
 
       - name: Build binary

--- a/.github/workflows/claude-review-fix.yml
+++ b/.github/workflows/claude-review-fix.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0'
+          go-version: '1.25.7'
           cache: true
 
       - name: Run Claude Code

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0'
+          go-version: '1.25.7'
 
       # 3. Run GoReleaser
       - name: Run GoReleaser

--- a/.github/workflows/opencode-review-fix.yml
+++ b/.github/workflows/opencode-review-fix.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0'
+          go-version: '1.25.7'
           cache: true
 
       - name: Install OpenCode CLI


### PR DESCRIPTION
Reverts rshade/finfocus#664

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version from 1.26.0 to 1.25.7 across all CI/CD workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->