### PR TITLE
fix(tui): widen Recs column to show N(-M) dismissed format

### DIFF
--- a/internal/tui/overview_model.go
+++ b/internal/tui/overview_model.go
@@ -553,7 +553,7 @@ func (m *OverviewModel) buildOverviewTable() table.Model {
 		{Title: projectedHeader, Width: 12}, //nolint:mnd // Column width.
 		{Title: "Delta", Width: 12},         //nolint:mnd // Column width.
 		{Title: "Drift%", Width: 8},         //nolint:mnd // Column width.
-		{Title: "Recs", Width: 4},           //nolint:mnd // Column width.
+		{Title: "Recs", Width: 9},           //nolint:mnd // Column width.
 	}
 
 	visibleRows := m.getVisibleRows()


### PR DESCRIPTION
## Summary

- The `Recs` column in the overview table was defined with
  `Width: 4`, which clips output when dismissed recommendations
  are present (e.g. `"10(-5)"` is 6 chars, `"100(-20)"` is 9)
- Increased column width to `9` to accommodate the full
  `N(-M)` format without truncation, covering values up to
  `"999(-99)"`

## Test plan

- [x] `make lint` passes with zero issues
- [x] `make test` passes

## Changes

### Modified files

- `internal/tui/overview_model.go` - `Recs` column `Width`
  changed from `4` to `9`; `//nolint:mnd` comment preserved

Closes #766