### PR TITLE
fix(logging): add .Ctx(ctx) to log calls in changedetect.go

### DIFF
--- a/internal/pulumi/changedetect.go
+++ b/internal/pulumi/changedetect.go
@@ -51,6 +51,7 @@ func DetectChanges(ctx context.Context, manifestTime string, projectDir string) 
 	lastDeployment, parseErr := time.Parse(time.RFC3339, manifestTime)
 	if parseErr != nil {
 		log.Warn().
+			Ctx(ctx).
 			Str("component", "changedetect").
 			Str("operation", "parse_manifest_time").
 			Str("manifest_time", manifestTime).
@@ -78,6 +79,7 @@ func DetectChanges(ctx context.Context, manifestTime string, projectDir string) 
 		info, statErr := os.Stat(path)
 		if statErr != nil {
 			log.Debug().
+				Ctx(ctx).
 				Str("component", "changedetect").
 				Str("operation", "stat_source_file").
 				Str("file", path).


### PR DESCRIPTION
## Summary

- Two zerolog calls in `DetectChanges` used the component logger (`log := logging.FromContext(ctx)`) but omitted `.Ctx(ctx)` chaining, so `TracingHook` never had a chance to inject `trace_id` into those log lines.
- The warn log for malformed manifest timestamps and the debug log for failed `os.Stat` calls are now correlated with the enclosing request trace, making distributed tracing complete across the change-detection path.

## Test plan

- [x] `go test ./internal/pulumi/...` — all tests pass
- [x] `golangci-lint run ./internal/pulumi/...` — zero issues
- [x] `make lint` passes with zero issues
- [x] `make test` passes

## Changes

### Modified files

- `internal/pulumi/changedetect.go` — added `.Ctx(ctx)` to the `Warn()` call (parse\_manifest\_time path) and the `Debug()` call (stat\_source\_file path)

Closes #765

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging to provide better context during change detection operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->