### PR TITLE
fix(cli): thread passphrase via subprocess env, not process-wide os.S…

### DIFF
--- a/internal/cli/overview.go
+++ b/internal/cli/overview.go
@@ -268,7 +268,9 @@ func loadPlainOverviewData(
 	}
 
 	// Auto-detect mode: state-first loading with optional change detection and prompt.
-	stateResources, manifestTime, projectDir, stackName, stateErr := loadStateForOverview(ctx, params)
+	// In plain (non-TUI) mode the passphrase is not prompted; PULUMI_CONFIG_PASSPHRASE
+	// is expected to already be set in the caller's environment.
+	stateResources, manifestTime, projectDir, stackName, stateErr := loadStateForOverview(ctx, params, "")
 	if stateErr != nil {
 		return nil, nil, "", false, stateErr
 	}
@@ -306,7 +308,7 @@ func loadPlainOverviewData(
 	// Non-TTY without --yes: shouldRunPreview remains false → state-only.
 
 	if shouldRunPreview {
-		planSteps, planErr := loadPlanForOverview(ctx, params, projectDir, stackName)
+		planSteps, planErr := loadPlanForOverview(ctx, params, projectDir, stackName, "")
 		if planErr != nil {
 			return nil, nil, stackName, false, planErr
 		}
@@ -343,9 +345,10 @@ func loadOverviewFromFiles(
 
 // exportStateFromProject auto-detects the Pulumi project, runs `pulumi stack export`,
 // parses the result, and returns the state resources plus metadata.
+// passphrase is injected into the subprocess environment only (never os.Setenv).
 // It is shared by loadOverviewFromAutoDetect and loadStateForOverview.
 func exportStateFromProject(
-	ctx context.Context, stack string,
+	ctx context.Context, stack, passphrase string,
 ) ([]engine.StateResource, string, string, string, error) {
 	projectDir, resolvedStack, err := detectPulumiProject(ctx, stack)
 	if err != nil {
@@ -358,6 +361,7 @@ func exportStateFromProject(
 	exportData, exportErr := pulumidetect.StackExport(ctx, pulumidetect.ExportOptions{
 		ProjectDir: projectDir,
 		Stack:      resolvedStack,
+		Passphrase: passphrase,
 	})
 	if exportErr != nil {
 		return nil, "", "", "", fmt.Errorf("running pulumi stack export: %w", exportErr)
@@ -372,17 +376,19 @@ func exportStateFromProject(
 
 // loadOverviewFromAutoDetect discovers the Pulumi project/stack and runs
 // both `pulumi stack export` and `pulumi preview --json` to gather data.
+// In the plain (non-TUI) mode no passphrase is prompted; PULUMI_CONFIG_PASSPHRASE
+// is expected to be set in the caller's environment already.
 func loadOverviewFromAutoDetect(
 	ctx context.Context, params overviewParams,
 ) ([]engine.StateResource, []engine.PlanStep, string, error) {
-	stateResources, _, projectDir, resolvedStack, err := exportStateFromProject(ctx, params.stack)
+	stateResources, _, projectDir, resolvedStack, err := exportStateFromProject(ctx, params.stack, "")
 	if err != nil {
 		return nil, nil, "", err
 	}
 
 	// Resolve plan: from file if --pulumi-json provided, otherwise auto-detect
 	ptPreview := logging.StartPhase(ctx, "pulumi", "overview", "preview")
-	planSteps, planErr := resolveOverviewPlan(ctx, params.pulumiJSON, projectDir, resolvedStack)
+	planSteps, planErr := resolveOverviewPlan(ctx, params.pulumiJSON, projectDir, resolvedStack, "")
 	ptPreview.Done(ctx)
 	if planErr != nil {
 		return nil, nil, "", planErr
@@ -392,8 +398,9 @@ func loadOverviewFromAutoDetect(
 }
 
 // resolveOverviewPlan loads plan steps from a file or runs pulumi preview.
+// passphrase is injected into the subprocess environment only (never os.Setenv).
 func resolveOverviewPlan(
-	ctx context.Context, pulumiJSON, projectDir, stack string,
+	ctx context.Context, pulumiJSON, projectDir, stack, passphrase string,
 ) ([]engine.PlanStep, error) {
 	log := logging.FromContext(ctx)
 
@@ -410,6 +417,7 @@ func resolveOverviewPlan(
 	previewData, err := pulumidetect.Preview(ctx, pulumidetect.PreviewOptions{
 		ProjectDir: projectDir,
 		Stack:      stack,
+		Passphrase: passphrase,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("running pulumi preview: %w", err)
@@ -804,19 +812,17 @@ func overviewInitAndEnrich(
 	log := logging.FromContext(enrichCtx)
 
 	// Pre-check: detect if stack uses passphrase encryption before loading.
+	// The returned passphrase is threaded to Pulumi subprocess calls via
+	// ExportOptions/PreviewOptions.Passphrase and never mutates the process-wide environment.
 	pw, passphraseErr := checkAndPromptPassphrase(enrichCtx, p, params, passphraseChan)
 	if passphraseErr != nil {
 		p.Send(tui.OverviewInitErrorMsg{Err: passphraseErr})
 		return
 	}
-	if applyErr := applyPassphraseEnv(pw); applyErr != nil {
-		p.Send(tui.OverviewInitErrorMsg{Err: applyErr})
-		return
-	}
 
 	// Phase 1: Load Pulumi state only (fast — no preview yet).
 	p.Send(tui.OverviewPhaseMsg{Index: phaseLoadStackState, Phase: "Loading stack state..."})
-	stateResources, manifestTime, projectDir, stackName, stateErr := loadStateForOverview(enrichCtx, params)
+	stateResources, manifestTime, projectDir, stackName, stateErr := loadStateForOverview(enrichCtx, params, pw)
 	if stateErr != nil {
 		p.Send(tui.OverviewInitErrorMsg{Err: fmt.Errorf("resolve overview data: %w", stateErr)})
 		return
@@ -861,7 +867,7 @@ func overviewInitAndEnrich(
 		rows = engine.NewRowsFromState(enrichCtx, stateResources)
 	} else {
 		// Preview path: load plan steps and merge with state.
-		planSteps, planErr := loadPlanForOverview(enrichCtx, params, projectDir, stackName)
+		planSteps, planErr := loadPlanForOverview(enrichCtx, params, projectDir, stackName, pw)
 		if planErr != nil {
 			p.Send(tui.OverviewInitErrorMsg{Err: planErr})
 			return
@@ -914,8 +920,9 @@ func overviewInitAndEnrich(
 		capturedParams := params
 		capturedProjectDir := projectDir
 		capturedStackName := stackName
+		capturedPW := pw
 		previewCmd = func() tea.Msg {
-			return runBackgroundPreview(enrichCtx, capturedParams, capturedProjectDir, capturedStackName)
+			return runBackgroundPreview(enrichCtx, capturedParams, capturedProjectDir, capturedStackName, capturedPW)
 		}
 	}
 
@@ -935,9 +942,10 @@ func overviewInitAndEnrich(
 }
 
 // loadStateForOverview loads Pulumi state only (without preview/plan).
+// passphrase is injected into subprocess env only (never os.Setenv).
 // Returns stateResources, manifestTime, projectDir, stackName, and any error.
 func loadStateForOverview(
-	ctx context.Context, params overviewParams,
+	ctx context.Context, params overviewParams, passphrase string,
 ) ([]engine.StateResource, string, string, string, error) {
 	if params.pulumiState != "" {
 		// Use explicit file path — no manifest time or project dir available.
@@ -954,31 +962,34 @@ func loadStateForOverview(
 	}
 
 	// Auto-detect project and run pulumi stack export.
-	return exportStateFromProject(ctx, params.stack)
+	return exportStateFromProject(ctx, params.stack, passphrase)
 }
 
 // loadPlanForOverview loads plan steps from a file or runs pulumi preview.
+// passphrase is injected into subprocess env only (never os.Setenv).
 // This is the preview-path helper used by overviewInitAndEnrich.
 func loadPlanForOverview(
-	ctx context.Context, params overviewParams, projectDir, stack string,
+	ctx context.Context, params overviewParams, projectDir, stack, passphrase string,
 ) ([]engine.PlanStep, error) {
-	return resolveOverviewPlan(ctx, params.pulumiJSON, projectDir, stack)
+	return resolveOverviewPlan(ctx, params.pulumiJSON, projectDir, stack, passphrase)
 }
 
 // runBackgroundPreview runs pulumi preview in the background and returns an
 // OverviewChangesReadyMsg with the resulting status map. It is used as a
 // tea.Cmd payload for the on-demand 'p' key handler.
+// passphrase is injected into subprocess env only (never os.Setenv).
 // If preview fails, it returns an empty OverviewChangesReadyMsg so the TUI
 // remains usable in state-only mode.
 func runBackgroundPreview(
 	ctx context.Context,
 	params overviewParams,
 	projectDir, stack string,
+	passphrase string,
 ) tui.OverviewChangesReadyMsg {
 	l := logging.FromContext(ctx)
 	previewStart := time.Now()
 
-	planSteps, err := resolveOverviewPlan(ctx, params.pulumiJSON, projectDir, stack)
+	planSteps, err := resolveOverviewPlan(ctx, params.pulumiJSON, projectDir, stack, passphrase)
 	if err != nil {
 		l.Warn().
 			Ctx(ctx).
@@ -1005,19 +1016,6 @@ func runBackgroundPreview(
 	}
 }
 
-// applyPassphraseEnv sets PULUMI_CONFIG_PASSPHRASE when pw is non-empty.
-// Callers obtain pw from checkAndPromptPassphrase and call this function so that
-// os.Setenv is never invoked from inside a background goroutine.
-func applyPassphraseEnv(pw string) error {
-	if pw == "" {
-		return nil
-	}
-	if err := os.Setenv("PULUMI_CONFIG_PASSPHRASE", pw); err != nil {
-		return fmt.Errorf("setting PULUMI_CONFIG_PASSPHRASE: %w", err)
-	}
-	return nil
-}
-
 // shortErrMsg returns a short (≤60 char) representation of err suitable for
 // embedding in a TUI status bar. Returns "" when err is nil.
 func shortErrMsg(err error) string {
@@ -1039,8 +1037,8 @@ func shortErrMsg(err error) string {
 // the passphrase (or the context is cancelled).
 //
 // Returns the passphrase string (non-empty when the user entered one) and any error.
-// The caller is responsible for calling os.Setenv with the returned passphrase so that
-// os.Setenv is never called from a background goroutine.
+// The returned passphrase is threaded to Pulumi subprocess calls via
+// ExportOptions/PreviewOptions.Passphrase and never mutates the process-wide environment.
 //
 // If passphrase auto-detection is not possible (e.g. using --pulumi-state files instead
 // of auto-detect, or if the stack YAML cannot be read), the check is silently skipped

--- a/internal/engine/overview_render.go
+++ b/internal/engine/overview_render.go
@@ -182,7 +182,10 @@ func RenderOverviewAsTable(w io.Writer, rows []OverviewRow, stackCtx StackContex
 
 	// State-only footnote written after flush so tabwriter alignment does not affect it.
 	if stackCtx.IsStateOnly {
-		footnote := "* projected at current state (730h/mo) — rerun with --yes to include pending changes"
+		footnote := fmt.Sprintf(
+			"* projected at current state (%dh/mo) — rerun with --yes to include pending changes",
+			HoursPerMonth,
+		)
 		if _, err := fmt.Fprintln(w, footnote); err != nil {
 			return fmt.Errorf("writing state-only footnote: %w", err)
 		}

--- a/internal/pulumi/changedetect_test.go
+++ b/internal/pulumi/changedetect_test.go
@@ -152,7 +152,9 @@ func TestDetectChanges_StatErrorSkipsFile(t *testing.T) {
 	// so this exercises the stat-error skip branch inside DetectChanges.
 	brokenTarget := filepath.Join(tmpDir, "nonexistent-target.ts")
 	brokenLink := filepath.Join(tmpDir, "broken.ts")
-	require.NoError(t, os.Symlink(brokenTarget, brokenLink))
+	if err := os.Symlink(brokenTarget, brokenLink); err != nil {
+		t.Skipf("symlinks not available on this platform/environment: %v", err)
+	}
 
 	// Detection should skip the broken symlink and continue; index.ts is newer so
 	// HasLikelyChanges must be true.

--- a/internal/pulumi/pulumi.go
+++ b/internal/pulumi/pulumi.go
@@ -25,6 +25,7 @@ type PreviewOptions struct {
 	ProjectDir string        // Directory containing Pulumi.yaml.
 	Stack      string        // Specific stack name (empty = current).
 	Timeout    time.Duration // Max execution time (default: 5 minutes).
+	Passphrase string        // PULUMI_CONFIG_PASSPHRASE injected into subprocess env only.
 }
 
 // ExportOptions configures a Pulumi stack export command execution.
@@ -32,6 +33,7 @@ type ExportOptions struct {
 	ProjectDir string        // Directory containing Pulumi.yaml.
 	Stack      string        // Specific stack name (empty = current).
 	Timeout    time.Duration // Max execution time (default: 60 seconds).
+	Passphrase string        // PULUMI_CONFIG_PASSPHRASE injected into subprocess env only.
 }
 
 // StackInfo represents a single stack from pulumi stack ls --json.
@@ -42,18 +44,28 @@ type StackInfo struct {
 }
 
 // CommandRunner executes an external command and returns its stdout, stderr, and error.
+// extraEnv entries (e.g. "KEY=value") are appended to the subprocess environment only;
+// they do not mutate the parent process environment.
 // This interface enables testing without spawning real subprocesses.
 type CommandRunner interface {
-	Run(ctx context.Context, dir string, name string, args ...string) (stdout []byte, stderr []byte, err error)
+	Run(
+		ctx context.Context,
+		dir string,
+		name string,
+		extraEnv []string,
+		args ...string,
+	) (stdout []byte, stderr []byte, err error)
 }
 
 // execRunner is the default CommandRunner that uses exec.CommandContext.
 type execRunner struct{}
 
-func (r *execRunner) Run(ctx context.Context, dir string, name string, args ...string) ([]byte, []byte, error) {
+func (r *execRunner) Run(
+	ctx context.Context, dir string, name string, extraEnv []string, args ...string,
+) ([]byte, []byte, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
-	cmd.Env = os.Environ()
+	cmd.Env = append(os.Environ(), extraEnv...)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -129,7 +141,7 @@ func GetCurrentStack(ctx context.Context, projectDir string) (string, error) {
 		Str("project_dir", projectDir).
 		Msg("listing Pulumi stacks")
 
-	stdout, stderr, err := Runner.Run(ctx, projectDir, "pulumi", "stack", "ls", "--json")
+	stdout, stderr, err := Runner.Run(ctx, projectDir, "pulumi", nil, "stack", "ls", "--json")
 	if err != nil {
 		return "", fmt.Errorf("running pulumi stack ls: %w: %s", err, strings.TrimSpace(string(stderr)))
 	}
@@ -162,6 +174,7 @@ type pulumiCmdConfig struct {
 	timeout        time.Duration
 	defaultTimeout time.Duration
 	args           []string
+	extraEnv       []string // injected into subprocess env only, never os.Setenv
 	operation      string
 	logMessage     string
 	wrapErr        func(string) error
@@ -219,7 +232,7 @@ func runPulumiCommand(ctx context.Context, cfg pulumiCmdConfig) ([]byte, error) 
 		Str("stack", cfg.stack).
 		Msg(cfg.logMessage)
 
-	stdout, stderr, err := Runner.Run(ctx, cfg.projectDir, "pulumi", args...)
+	stdout, stderr, err := Runner.Run(ctx, cfg.projectDir, "pulumi", cfg.extraEnv, args...)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return nil, fmt.Errorf(
@@ -253,12 +266,17 @@ func runPulumiCommand(ctx context.Context, cfg pulumiCmdConfig) ([]byte, error) 
 // slice. It returns an error if the Pulumi command fails, if the context is canceled, or
 // if the operation exceeds its timeout.
 func Preview(ctx context.Context, opts PreviewOptions) ([]byte, error) {
+	var extraEnv []string
+	if opts.Passphrase != "" {
+		extraEnv = []string{"PULUMI_CONFIG_PASSPHRASE=" + opts.Passphrase}
+	}
 	return runPulumiCommand(ctx, pulumiCmdConfig{
 		projectDir:     opts.ProjectDir,
 		stack:          opts.Stack,
 		timeout:        opts.Timeout,
 		defaultTimeout: DefaultPreviewTimeout,
 		args:           []string{"preview", "--json"},
+		extraEnv:       extraEnv,
 		operation:      "preview",
 		logMessage:     "running pulumi preview --json (this may take a moment)...",
 		wrapErr:        PreviewError,
@@ -274,12 +292,17 @@ func Preview(ctx context.Context, opts PreviewOptions) ([]byte, error) {
 // An error is returned if the Pulumi CLI cannot be found or fails, if the operation times out, or if the
 // provided context is cancelled.
 func StackExport(ctx context.Context, opts ExportOptions) ([]byte, error) {
+	var extraEnv []string
+	if opts.Passphrase != "" {
+		extraEnv = []string{"PULUMI_CONFIG_PASSPHRASE=" + opts.Passphrase}
+	}
 	return runPulumiCommand(ctx, pulumiCmdConfig{
 		projectDir:     opts.ProjectDir,
 		stack:          opts.Stack,
 		timeout:        opts.Timeout,
 		defaultTimeout: DefaultExportTimeout,
 		args:           []string{"stack", "export"},
+		extraEnv:       extraEnv,
 		operation:      "stack export",
 		logMessage:     "running pulumi stack export...",
 		wrapErr:        ExportError,

--- a/internal/pulumi/pulumi_test.go
+++ b/internal/pulumi/pulumi_test.go
@@ -18,15 +18,23 @@ type mockRunner struct {
 	stderr []byte
 	err    error
 	// Captured call arguments for verification.
-	lastDir  string
-	lastName string
-	lastArgs []string
+	lastDir      string
+	lastName     string
+	lastArgs     []string
+	lastExtraEnv []string
 }
 
-func (m *mockRunner) Run(_ context.Context, dir string, name string, args ...string) ([]byte, []byte, error) {
+func (m *mockRunner) Run(
+	_ context.Context,
+	dir string,
+	name string,
+	extraEnv []string,
+	args ...string,
+) ([]byte, []byte, error) {
 	m.lastDir = dir
 	m.lastName = name
 	m.lastArgs = args
+	m.lastExtraEnv = extraEnv
 	return m.stdout, m.stderr, m.err
 }
 
@@ -419,4 +427,56 @@ func TestStackExport_ContextCancellation(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "timed out")
+}
+
+// --- Passphrase env injection tests ---
+
+func TestPreview_WithPassphrase_InjectsEnv(t *testing.T) {
+	t.Setenv("FINFOCUS_LOG_LEVEL", "error")
+	mock := &mockRunner{stdout: []byte(`{"steps":[]}`)}
+	withMockRunner(t, mock)
+
+	_, err := Preview(context.Background(), PreviewOptions{
+		ProjectDir: "/project",
+		Passphrase: "my-secret",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, mock.lastExtraEnv, "PULUMI_CONFIG_PASSPHRASE=my-secret")
+}
+
+func TestPreview_EmptyPassphrase_NoExtraEnv(t *testing.T) {
+	t.Setenv("FINFOCUS_LOG_LEVEL", "error")
+	mock := &mockRunner{stdout: []byte(`{"steps":[]}`)}
+	withMockRunner(t, mock)
+
+	_, err := Preview(context.Background(), PreviewOptions{
+		ProjectDir: "/project",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, mock.lastExtraEnv)
+}
+
+func TestStackExport_WithPassphrase_InjectsEnv(t *testing.T) {
+	t.Setenv("FINFOCUS_LOG_LEVEL", "error")
+	mock := &mockRunner{stdout: []byte(`{"version":3}`)}
+	withMockRunner(t, mock)
+
+	_, err := StackExport(context.Background(), ExportOptions{
+		ProjectDir: "/project",
+		Passphrase: "stack-secret",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, mock.lastExtraEnv, "PULUMI_CONFIG_PASSPHRASE=stack-secret")
+}
+
+func TestStackExport_EmptyPassphrase_NoExtraEnv(t *testing.T) {
+	t.Setenv("FINFOCUS_LOG_LEVEL", "error")
+	mock := &mockRunner{stdout: []byte(`{"version":3}`)}
+	withMockRunner(t, mock)
+
+	_, err := StackExport(context.Background(), ExportOptions{
+		ProjectDir: "/project",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, mock.lastExtraEnv)
 }


### PR DESCRIPTION
…etenv

## Summary

- Removes `applyPassphraseEnv` which called `os.Setenv("PULUMI_CONFIG_PASSPHRASE", ...)`, mutating the process-wide environment — unsafe in concurrent contexts and breaks parallel test isolation.
- Passphrase is now threaded as an explicit parameter from `overviewInitAndEnrich` down to `exportStateFromProject`, `resolveOverviewPlan`, and `runBackgroundPreview`, and injected only into the subprocess `Cmd.Env` via `PreviewOptions.Passphrase` and `ExportOptions.Passphrase`.
- `CommandRunner.Run` interface gains an `extraEnv []string` parameter so env overrides can be forwarded to any subprocess without process-wide side-effects.
- Two companion fixes included: replaces the hardcoded `"730h/mo"` string with the `HoursPerMonth` constant, and guards a symlink test with `t.Skipf` on platforms that do not support symlink creation.

## Test plan

- [x] Two new tests verify passphrase injection: `TestPreview_WithPassphrase_InjectsEnv` and `TestStackExport_WithPassphrase_InjectsEnv`
- [x] Empty-passphrase path asserts no extra env entries are added
- [x] `make test` passes
- [x] `make lint` passes with zero issues

## Changes

### Modified files

- `internal/cli/overview.go` — removed `applyPassphraseEnv`; threaded `pw` to `loadStateForOverview`, `loadPlanForOverview`, and `runBackgroundPreview`
- `internal/pulumi/pulumi.go` — added `Passphrase` field to `PreviewOptions` / `ExportOptions`; updated `CommandRunner.Run` with `extraEnv []string`; injects passphrase into subprocess env only
- `internal/pulumi/pulumi_test.go` — updated mock runner for new interface; added passphrase injection tests
- `internal/engine/overview_render.go` — uses `HoursPerMonth` constant instead of hardcoded `"730h/mo"` string
- `internal/pulumi/changedetect_test.go` — guards symlink creation with `t.Skipf` on platforms without symlink support

Closes #761
Closes #763
Closes #764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved passphrase handling for more reliable subprocess communication

* **Improvements**
  * Made hours per month calculation dynamic

* **Tests**
  * Enhanced symlink test compatibility across different environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->