### PR TITLE
docs(routing): document routing limits in analyzer/policy-pack mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1116,6 +1116,7 @@ CodeRabbit now:
 
 ## Active Technologies
 - Go 1.25.7 + `github.com/charmbracelet/lipgloss` (already imported in file) (597-tui-init-lipgloss)
+- Markdown (documentation-only; no Go code changes) + markdownlint-cli2 v0.18.1 (already installed) (598-analyzer-routing-docs)
 
 - Go 1.25.7 + Bubble Tea (charmbracelet/bubbletea), Lip Gloss
 

--- a/docs/analyzer-integration.md
+++ b/docs/analyzer-integration.md
@@ -81,6 +81,54 @@ Pulumi internal resources (Stack, providers) are handled specially:
 - Cost: $0.00
 - Message: "Internal Pulumi resource (no cloud cost)"
 
+## Isolating Plugins in Analyzer Mode
+
+When finfocus runs as a Pulumi policy pack, routing configuration is not applied.
+The only supported mechanism for controlling which plugins are loaded is `FINFOCUS_HOME`.
+
+When `FINFOCUS_HOME` is set, finfocus uses `$FINFOCUS_HOME/plugins/` as its entire
+plugin root. Any plugin absent from that directory is never loaded.
+
+> **Warning: Directory-level symlinks are not supported**
+> (issue [#750](https://github.com/rshade/finfocus/issues/750))
+>
+> The registry silently skips directory-level symlinks. If you symlink the entire
+> plugin version directory, the plugin will not be found. Use file-level symlinks
+> (symlink the binary itself) until issue #750 is resolved.
+
+### Step-by-step: create an isolated plugin home
+
+**Step 1**: Create real plugin directories (not symlinks):
+
+```bash
+mkdir -p ~/.finfocus/demo/plugins/aws-public/v0.1.5
+```
+
+**Step 2**: Symlink only the plugin binary (file-level):
+
+```bash
+ln -sf ~/.finfocus/plugins/aws-public/v0.1.5/finfocus-plugin-aws-public-us-east-1 \
+    ~/.finfocus/demo/plugins/aws-public/v0.1.5/finfocus-plugin-aws-public-us-east-1
+```
+
+Repeat Step 1 and Step 2 for each plugin you want to include.
+
+**Step 3**: Run `pulumi preview` with the isolated home:
+
+```bash
+FINFOCUS_HOME=~/.finfocus/demo \
+  pulumi preview --policy-pack /path/to/finfocus-policy-pack
+```
+
+Only the plugins present in `~/.finfocus/demo/plugins/` will be loaded. If the
+directory contains no plugins, finfocus returns zero cost data (it does **not**
+fall back to `~/.finfocus`).
+
+### Environment variable precedence
+
+`FINFOCUS_HOME` takes highest precedence over `PULUMI_HOME/finfocus` and `~/.finfocus`.
+See [Configuration Reference](reference/config-schema.md) for the full precedence order.
+
 ## See Also
 
 - [Analyzer Setup Guide](getting-started/analyzer-setup.md)

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -328,6 +328,19 @@ routing:
 3. If fails and `fallback: true` → try local specs (built-in)
 4. If no specs → return "no cost data available"
 
+> **Note: Routing does not apply in analyzer/policy-pack mode**
+>
+> When finfocus runs as a Pulumi policy pack (`pulumi preview --policy-pack`),
+> routing configuration is **not consulted**. All plugins discovered in the plugin
+> directory are loaded and queried for every resource.
+>
+> Additionally, global plugins (those with `supported_providers: ["*"]`) cannot be
+> excluded via routing even in standard CLI mode — they are always included for all
+> resources.
+>
+> To exclude specific plugins when running as a policy pack, use `FINFOCUS_HOME`
+> isolation. See [Isolating plugins in analyzer mode](../analyzer-integration.md#isolating-plugins-in-analyzer-mode).
+
 ## Validation
 
 ### Eager Validation (Before Deployment)
@@ -669,6 +682,10 @@ Results include which plugin provided the data:
 
 ## Changelog
 
+- **v0.3.1**: Documented analyzer/policy-pack mode limitations
+  - Routing configuration is not applied when running as a Pulumi policy pack
+  - Global plugins (`supported_providers: ["*"]`) cannot be excluded via routing
+  - Added `FINFOCUS_HOME` isolation procedure in Analyzer Integration docs
 - **v0.3.0**: Initial multi-plugin routing release
   - Automatic provider-based routing
   - Declarative pattern/feature/priority configuration

--- a/specs/598-analyzer-routing-docs/checklists/requirements.md
+++ b/specs/598-analyzer-routing-docs/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Document Routing Limits in Analyzer Mode
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All checklist items pass. The specification is ready for `/speckit.plan`.

--- a/specs/598-analyzer-routing-docs/plan.md
+++ b/specs/598-analyzer-routing-docs/plan.md
@@ -1,0 +1,180 @@
+# Implementation Plan: Document Routing Limits in Analyzer Mode
+
+**Branch**: `598-analyzer-routing-docs` | **Date**: 2026-02-20 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/598-analyzer-routing-docs/spec.md`
+
+## Summary
+
+Add documentation clarifying that routing configuration is not applied during
+`pulumi preview --policy-pack` (analyzer/policy-pack mode) and that global plugins
+cannot be excluded via routing. Provide an actionable `FINFOCUS_HOME`-based plugin
+isolation procedure for users who need to control which plugins run in analyzer mode.
+
+Two existing files are modified; no new files are created:
+
+1. `docs/guides/routing.md` — add a `> **Note:**` callout after "Common Configuration
+   Patterns", before "Validation", covering the three facts: no routing in analyzer mode,
+   global plugins always fire, and pointer to isolation procedure.
+2. `docs/analyzer-integration.md` — add `## Isolating Plugins in Analyzer Mode` section
+   before `## See Also`, with step-by-step `FINFOCUS_HOME` procedure, file-level symlink
+   instructions, issue #750 warning, and inline bash example.
+
+## Technical Context
+
+**Language/Version**: Markdown (documentation-only; no Go code changes)
+**Primary Dependencies**: markdownlint-cli2 v0.18.1 (already installed)
+**Storage**: N/A
+**Testing**: `make docs-lint` (markdownlint validation)
+**Target Platform**: GitHub Pages / Jekyll static site
+**Performance Goals**: N/A
+**Constraints**: No new files; both modified files must pass `make docs-lint` with zero errors
+**Scale/Scope**: 2 markdown files, ~50–70 lines added total
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Verify compliance with FinFocus Core Constitution (`.specify/memory/constitution.md`):
+
+- [x] **Plugin-First Architecture**: N/A — documentation-only; no code changes.
+- [x] **Test-Driven Development**: N/A — validation is `make docs-lint` (markdownlint).
+  Linting must pass before claiming tasks complete.
+- [x] **Cross-Platform Compatibility**: N/A — documentation is platform-agnostic.
+- [x] **Documentation Integrity**: YES — this feature IS a documentation integrity
+  improvement. Both modified files must remain synchronized with the confirmed behavior
+  described in the issue (finfocus v0.3.1, Pulumi CLI v3.223.0).
+- [x] **Protocol Stability**: N/A — no protocol changes.
+- [x] **Implementation Completeness**: All documentation content must be fully written.
+  No `TODO` markers or placeholder text may remain in the committed changes.
+- [x] **Quality Gates**: `make docs-lint` must pass with zero errors after changes.
+- [x] **Multi-Repo Coordination**: N/A — documentation only affects this repository.
+
+**Violations Requiring Justification**: None.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/598-analyzer-routing-docs/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (complete)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Files Modified
+
+```text
+docs/
+├── guides/
+│   └── routing.md           # ADD: callout after "Common Configuration Patterns"
+└── analyzer-integration.md  # ADD: "Isolating Plugins in Analyzer Mode" section
+```
+
+No new files. No new directories. No source code changes.
+
+## Phase 0: Research
+
+All NEEDS CLARIFICATION items resolved. See `research.md` for full decision log.
+
+**Summary of resolved decisions**:
+
+| # | Decision | Resolution |
+|---|----------|------------|
+| 1 | Callout format in routing.md | `> **Note:**` blockquote; no heading, no ToC update |
+| 2 | Callout placement in routing.md | After line 330 (end of "Common Configuration Patterns"), before "## Validation" |
+| 3 | New section placement in analyzer-integration.md | Before `## See Also` (line 84) |
+| 4 | Issue #750 URL | `https://github.com/rshade/finfocus/issues/750` |
+| 5 | FR-007 shell example | Inline `bash` fenced code block; no new script file |
+| 6 | Symlink warning label | `> **Warning:**` (distinct from `> **Note:**` callout) |
+
+## Phase 1: Design
+
+### routing.md Callout Content
+
+Insert after line 330 (before `## Validation`):
+
+```markdown
+
+> **Note: Routing does not apply in analyzer/policy-pack mode**
+>
+> When finfocus runs as a Pulumi policy pack (`pulumi preview --policy-pack`),
+> routing configuration is **not consulted**. All plugins discovered in the plugin
+> directory are loaded and queried for every resource.
+>
+> Additionally, global plugins (those with `supported_providers: ["*"]`) cannot be
+> excluded via routing even in standard CLI mode — they are always included for all
+> resources.
+>
+> To exclude specific plugins when running as a policy pack, use `FINFOCUS_HOME`
+> isolation. See [Isolating plugins in analyzer mode](../analyzer-integration.md#isolating-plugins-in-analyzer-mode).
+```
+
+### analyzer-integration.md New Section Content
+
+Insert before `## See Also` (before line 84):
+
+```markdown
+## Isolating Plugins in Analyzer Mode
+
+When finfocus runs as a Pulumi policy pack, routing configuration is not applied.
+The only supported mechanism for controlling which plugins are loaded is `FINFOCUS_HOME`.
+
+When `FINFOCUS_HOME` is set, finfocus uses `$FINFOCUS_HOME/plugins/` as its entire
+plugin root. Any plugin absent from that directory is never loaded.
+
+> **Warning: Directory-level symlinks are not supported** (issue [#750](https://github.com/rshade/finfocus/issues/750))
+>
+> The registry silently skips directory-level symlinks. If you symlink the entire
+> plugin version directory, the plugin will not be found. Use file-level symlinks
+> (symlink the binary itself) until issue #750 is resolved.
+
+### Step-by-step: create an isolated plugin home
+
+**Step 1**: Create real plugin directories (not symlinks):
+
+\```bash
+mkdir -p ~/.finfocus/demo/plugins/aws-public/v0.1.5
+\```
+
+**Step 2**: Symlink only the plugin binary (file-level):
+
+\```bash
+ln -sf ~/.finfocus/plugins/aws-public/v0.1.5/finfocus-plugin-aws-public-us-east-1 \
+    ~/.finfocus/demo/plugins/aws-public/v0.1.5/finfocus-plugin-aws-public-us-east-1
+\```
+
+Repeat Step 1 and Step 2 for each plugin you want to include.
+
+**Step 3**: Run `pulumi preview` with the isolated home:
+
+\```bash
+FINFOCUS_HOME=~/.finfocus/demo \
+  pulumi preview --policy-pack /path/to/finfocus-policy-pack
+\```
+
+Only the plugins present in `~/.finfocus/demo/plugins/` will be loaded. If the
+directory contains no plugins, finfocus returns zero cost data (it does **not**
+fall back to `~/.finfocus`).
+
+### Environment variable precedence
+
+`FINFOCUS_HOME` takes highest precedence over `PULUMI_HOME/finfocus` and `~/.finfocus`.
+See [Configuration Reference](reference/config-schema.md) for the full precedence order.
+```
+
+### No data-model.md, contracts/, or quickstart.md
+
+This feature has no data entities, API endpoints, or new CLI commands. These Phase 1
+artifacts are not applicable and are omitted.
+
+## Phase 2: Tasks
+
+See `tasks.md` (generated by `/speckit.tasks`).
+
+## Implementation Order
+
+1. Edit `docs/guides/routing.md` — insert callout (self-contained, no dependencies)
+2. Edit `docs/analyzer-integration.md` — insert new section (self-contained, no dependencies)
+3. Run `make docs-lint` — verify zero errors on both files
+4. Run `make lint` — confirm no regressions in other linting passes

--- a/specs/598-analyzer-routing-docs/research.md
+++ b/specs/598-analyzer-routing-docs/research.md
@@ -1,0 +1,107 @@
+# Research: Document Routing Limits in Analyzer Mode
+
+**Feature**: 598-analyzer-routing-docs
+**Date**: 2026-02-20
+
+## Decision 1: Callout Format in routing.md
+
+**Decision**: Use a `> **Note:**` blockquote (no new heading, no ToC update required).
+
+**Rationale**: The markdownlint config (`docs/.markdownlint-cli2.jsonc`) permits inline
+HTML for select elements but not general `<div class="note">` patterns. A `>` blockquote
+with bold label is the established callout pattern in the existing docs and passes
+markdownlint without configuration changes. Adding a new `##` heading would require a
+ToC update and shift the document structure unnecessarily for what is a two-paragraph
+advisory note.
+
+**Alternatives considered**:
+
+- New `## Limitations in Analyzer Mode` heading — rejected; requires ToC update and
+  adds a top-level section for content that is a side-note, not a primary topic.
+- HTML `<div>` callout — rejected; only specific allowed elements in the lint config.
+
+---
+
+## Decision 2: Callout Placement in routing.md
+
+**Decision**: Insert immediately after line 330 (end of "Common Configuration Patterns"
+section), before line 331 ("## Validation" heading).
+
+**Rationale**: Confirmed via file inspection — line 330 is the last line of the
+"Common Configuration Patterns" section content
+(`4. If no specs → return "no cost data available"`). Inserting here places the callout
+exactly where the issue requests ("after the routing configuration examples") and ensures
+a developer who has just read the configuration patterns encounters the limitation before
+moving on to validation commands.
+
+**Alternatives considered**:
+
+- "Advanced Topics" section (line ~594) — rejected per user clarification (Q1 answer: C).
+- "Troubleshooting" section — rejected; developer may never reach it when looking for
+  configuration guidance.
+
+---
+
+## Decision 3: New Section Placement in analyzer-integration.md
+
+**Decision**: Insert new `## Isolating Plugins in Analyzer Mode` section immediately
+before `## See Also` (currently at line 84).
+
+**Rationale**: The file has no Table of Contents, so no ToC update is required. The
+"See Also" section is the natural terminal section. Inserting before it places the new
+content as the second-to-last section, giving it prominence without disrupting the
+existing technical reference flow (Architecture → How It Works → Key Technical Details
+→ Internal Types → **Isolating Plugins** → See Also).
+
+**Alternatives considered**:
+
+- Append after "See Also" — rejected; "See Also" should always be the final section.
+- Insert between existing sections — rejected; would disrupt the technical reference
+  narrative flow.
+
+---
+
+## Decision 4: Issue #750 Reference Format
+
+**Decision**: Use a full GitHub URL: `https://github.com/rshade/finfocus/issues/750`.
+
+**Rationale**: The repository module path confirms `github.com/rshade/finfocus`. Full
+URLs work correctly on GitHub Pages (rendered HTML) and in plain markdown readers alike.
+Relative `#750` anchors do not resolve in Jekyll-rendered GitHub Pages.
+
+**Alternatives considered**:
+
+- Bare `#750` reference — rejected; does not hyperlink in GitHub Pages output.
+- `[#750](../issues/750)` relative path — rejected; unreliable across GitHub Pages URL
+  structures.
+
+---
+
+## Decision 5: FR-007 Shell Command Example Format
+
+**Decision**: Inline `bash` fenced code block within `analyzer-integration.md`. No new
+script files created. (Per user clarification Q2 answer: A.)
+
+**Rationale**: Keeps scope minimal, consistent with SC-004 (no new files). An inline
+example is fully actionable and avoids repo clutter for a pattern users will customize.
+
+**Alternatives considered**:
+
+- `scripts/run-analyzer-preview.sh` — rejected per user clarification.
+
+---
+
+## Decision 6: Symlink Warning Severity
+
+**Decision**: Use `> **Warning:**` label (not `> **Note:**`) for the directory-level
+symlink breakage warning within the isolation procedure.
+
+**Rationale**: The broken-symlink behavior (issue #750) causes silent failures — the
+registry loads no plugins without error. A "Warning" label is more appropriate than a
+"Note" to signal that following the wrong approach has non-obvious consequences. This
+distinction is purely semantic and does not affect markdownlint compliance.
+
+**Alternatives considered**:
+
+- `> **Note:**` for both callouts — rejected; conflates an advisory note with a
+  failure-risk warning.

--- a/specs/598-analyzer-routing-docs/spec.md
+++ b/specs/598-analyzer-routing-docs/spec.md
@@ -1,0 +1,161 @@
+# Feature Specification: Document Routing Limits in Analyzer Mode
+
+**Feature Branch**: `598-analyzer-routing-docs`
+**Created**: 2026-02-20
+**Status**: Draft
+**Input**: User description: "Docs: Document that routing config does not apply in analyzer/policy-pack mode"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Developer Confused Why Extra Plugin Fires (Priority: P1)
+
+A developer configures routing rules expecting only `aws-public` to respond during
+`pulumi preview --policy-pack`. They are surprised when their `recorder` debug plugin
+also fires for every resource, creating unwanted side effects (e.g., recorded request
+files piling up in CI). They turn to the routing guide for help and find no explanation
+for this behavior.
+
+**Why this priority**: This is the primary confusion the issue describes. Users invest
+time configuring routing, run `pulumi preview --policy-pack`, and the behavior
+contradicts what the routing guide implies. Documenting this prevents support
+escalations and wasted debugging time.
+
+**Independent Test**: Can be validated by reading `docs/guides/routing.md` alone and
+confirming it contains a clear callout that routing does not apply in analyzer/policy-pack
+mode.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reads `docs/guides/routing.md` after routing config fails to
+   exclude a plugin in analyzer mode, **When** they scroll to the relevant section,
+   **Then** they find a clearly labelled callout stating that routing configuration is
+   not consulted during `pulumi preview --policy-pack`.
+2. **Given** a developer reads the routing callout, **When** they look for how to
+   exclude plugins in analyzer mode, **Then** they are directed to the
+   `analyzer-integration.md` documentation for the `FINFOCUS_HOME` isolation procedure.
+
+---
+
+### User Story 2 - Operator Needs to Exclude a Plugin in CI Policy-Pack Run (Priority: P2)
+
+A platform engineer sets up a CI pipeline using `pulumi preview --policy-pack`. They
+want only the cost-data plugin (e.g., `aws-public`) to run and need to exclude the
+`recorder` debug plugin to avoid unnecessary file writes. They need a tested, repeatable
+procedure for this.
+
+**Why this priority**: Without actionable isolation instructions, users have no recourse
+once they discover routing does not work. The `FINFOCUS_HOME` mechanism is the only path
+but is undiscovered and undocumented.
+
+**Independent Test**: Can be validated by reading `docs/analyzer-integration.md` and
+confirming it contains a complete, step-by-step "Isolating plugins in analyzer mode"
+section with a `FINFOCUS_HOME` example.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator reads `docs/analyzer-integration.md`, **When** they navigate to
+   the "Isolating plugins in analyzer mode" section, **Then** they find step-by-step
+   instructions for creating an isolated plugin directory using `FINFOCUS_HOME`.
+2. **Given** the operator follows the documented steps using real directory creation and
+   file-level symlinks, **When** they run `pulumi preview --policy-pack` with
+   `FINFOCUS_HOME` set, **Then** only the plugins present in the isolated directory are
+   loaded.
+3. **Given** the operator reads the symlink instructions, **When** they attempt the
+   directory-level symlink shortcut, **Then** the documentation warns them it does not
+   work (due to issue #750) and shows the correct file-level symlink approach.
+
+---
+
+### User Story 3 - Developer Wants to Understand Why Global Plugins Cannot Be Excluded (Priority: P3)
+
+A developer has a plugin with `supported_providers: ["*"]` and expects that omitting it
+from the `routing:` config will exclude it. After testing, they find it still fires.
+They want documentation explaining why global plugins are always included.
+
+**Why this priority**: This is a secondary discovery path. Users who know about routing
+may still be confused by the global plugin behavior. The callout in `routing.md` should
+cover this.
+
+**Independent Test**: Can be validated by reading the routing callout and confirming
+it mentions that global plugins (`supported_providers: ["*"]`) cannot be excluded via
+routing in any mode.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reads the analyzer-mode callout in `routing.md`, **When** they
+   look for whether routing can exclude a global plugin, **Then** they find an explicit
+   statement that global plugins are always included for all resources.
+
+---
+
+### Edge Cases
+
+- What if issue #750 is fixed and directory-level symlinks start working? The docs must
+  link to #750 so users can check whether the workaround is still needed.
+- What if `FINFOCUS_HOME` contains no plugins at all? The example should clarify that
+  finfocus will load no plugins (zero cost data) rather than falling back to `~/.finfocus`.
+- What if the user sets `FINFOCUS_HOME` and also has `PULUMI_HOME`? The precedence order
+  (`FINFOCUS_HOME` > `PULUMI_HOME/finfocus` > `~/.finfocus`) should be referenced.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `docs/guides/routing.md` MUST contain a clearly-labelled callout, placed
+  after the "Common Configuration Patterns" section and before the "Validation" section,
+  stating that routing configuration is NOT applied during `pulumi preview --policy-pack`
+  (analyzer/policy-pack mode).
+- **FR-002**: The callout in `routing.md` MUST state that global plugins
+  (`supported_providers: ["*"]`) cannot be excluded via routing in any mode.
+- **FR-003**: The callout in `routing.md` MUST direct users to `analyzer-integration.md`
+  for the plugin isolation procedure.
+- **FR-004**: `docs/analyzer-integration.md` MUST contain a new "Isolating plugins in
+  analyzer mode" section with a step-by-step procedure using `FINFOCUS_HOME`.
+- **FR-005**: The isolation procedure MUST document the file-level symlink requirement
+  and explicitly warn that directory-level symlinks are broken until issue #750 is fixed,
+  with a link to the issue.
+- **FR-006**: The isolation procedure MUST include an example `FINFOCUS_HOME` directory
+  setup showing how to expose only selected plugins.
+- **FR-007**: The isolation procedure SHOULD include an inline `bash` code block
+  demonstrating how to run `pulumi preview --policy-pack` with `FINFOCUS_HOME` set to
+  the isolated directory. No new script files are to be created.
+- **FR-008**: Both documents MUST pass `make docs-lint` (markdownlint) without errors
+  after the changes are applied.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A developer encountering unexpected plugin behavior in analyzer mode can
+  discover the documented explanation within one page read of `routing.md`.
+- **SC-002**: An operator following the isolation procedure step-by-step is able to
+  run `pulumi preview --policy-pack` with only their chosen plugins loaded; the procedure
+  is complete with no missing steps.
+- **SC-003**: Documentation linting (`make docs-lint`) reports zero errors or warnings
+  on both modified files after changes are applied.
+- **SC-004**: No new documentation pages are created; all changes are additive to the
+  two existing files identified in the issue.
+
+## Clarifications
+
+### Session 2026-02-20
+
+- Q: Where in `docs/guides/routing.md` should the analyzer-mode callout be placed? → A: After the "Common Configuration Patterns" section, before "Validation".
+- Q: Should FR-007's shell command example be an inline code block or a new script file? → A: Inline `bash` code block inside `analyzer-integration.md`; no new files.
+
+## Assumptions
+
+- The `FINFOCUS_HOME` isolation mechanism is already tested and confirmed working as of
+  finfocus v0.3.1 (per issue facts).
+- The `analyzer-integration.md` file exists at `docs/analyzer-integration.md` and
+  contains existing sections into which the new section will be appended.
+- Issue #750 remains open; documentation references it as a known limitation and links
+  to it.
+- The project's markdownlint configuration permits `> **Note:**` blockquote style
+  callouts used elsewhere in the docs.
+- The docs directory uses Jekyll with GitHub Pages; standard markdown blockquotes and
+  fenced code blocks are acceptable formatting.
+- The `## Changelog` section in `docs/guides/routing.md` will be updated with a new
+  version entry to document the analyzer-mode callout addition. This is consistent with
+  Constitution Principle IV (Documentation Integrity) and the existing changelog
+  convention in that file.

--- a/specs/598-analyzer-routing-docs/tasks.md
+++ b/specs/598-analyzer-routing-docs/tasks.md
@@ -1,0 +1,173 @@
+---
+
+description: "Task list for 598-analyzer-routing-docs"
+
+---
+
+# Tasks: Document Routing Limits in Analyzer Mode
+
+**Input**: Design documents from `/specs/598-analyzer-routing-docs/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅
+
+**Tests**: This is a documentation-only feature. Per Constitution Principle II,
+validation is `make docs-lint` (markdownlint). There are no Go code changes and
+therefore no unit or integration tests. Both modified files MUST pass `make docs-lint`
+with zero errors before tasks are marked complete.
+
+**Completeness**: Per Constitution Principle VI, all documentation content must be
+fully written. No placeholder text, `TODO` markers, or `[INSERT HERE]` stubs are
+permitted in committed changes.
+
+**Documentation**: This feature IS the documentation update. The quality gate is
+`make docs-lint` passing with zero errors on both modified files.
+
+**Organization**: Tasks are grouped by user story. US1 and US3 share a phase because
+both are addressed by the same callout block in `docs/guides/routing.md`.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Pre-flight)
+
+**Purpose**: Verify the baseline documentation build is clean before any edits.
+
+- [x] T001 Confirm `make docs-lint` passes with zero errors on the unmodified branch (baseline check)
+
+---
+
+## Phase 2: User Stories 1 & 3 — routing.md Callout (Priority: P1/P3) 🎯 MVP
+
+**Goal**: A developer reading `docs/guides/routing.md` after a failed routing exclusion
+in analyzer mode finds a clear, actionable callout explaining: (1) routing is not
+consulted in analyzer/policy-pack mode, (2) global plugins cannot be excluded via
+routing in any mode, (3) where to find the isolation procedure.
+
+**Independent Test**: Read `docs/guides/routing.md` from the "Common Configuration
+Patterns" section to the end. The callout must appear immediately before `## Validation`
+and must contain all three facts (routing not applied, global plugins always fire,
+link to analyzer-integration.md).
+
+**Note**: US3 (global plugins cannot be excluded) is fully addressed by the same
+callout as US1. No separate phase is needed for US3.
+
+### Implementation for User Stories 1 & 3
+
+- [x] T002 [US1] [US3] Add analyzer-mode callout blockquote to `docs/guides/routing.md` after the "Common Configuration Patterns" section (before `## Validation`): state that routing is not consulted in policy-pack mode, that global plugins always fire, and cross-reference `analyzer-integration.md#isolating-plugins-in-analyzer-mode`
+- [x] T003 [P] [US1] Update the `## Changelog` section in `docs/guides/routing.md` with a new entry documenting the analyzer-mode callout addition
+
+**Checkpoint**: After T002 and T003, read `docs/guides/routing.md` and verify the
+callout is visible, correctly placed, and all three FR-001/FR-002/FR-003 facts are
+present. US1 and US3 acceptance scenarios are now independently verifiable.
+
+---
+
+## Phase 3: User Story 2 — analyzer-integration.md Isolation Procedure (Priority: P2)
+
+**Goal**: An operator reading `docs/analyzer-integration.md` finds a complete,
+tested step-by-step procedure for isolating plugins in analyzer mode using
+`FINFOCUS_HOME`, including the file-level symlink requirement, the issue #750 warning,
+and an inline bash example.
+
+**Independent Test**: Read `docs/analyzer-integration.md` and locate the "Isolating
+Plugins in Analyzer Mode" section. The section must contain: `FINFOCUS_HOME`
+explanation, Step 1 (`mkdir -p`), Step 2 (`ln -sf` binary), Step 3 (`FINFOCUS_HOME=`
+inline example), the `> **Warning:**` callout for issue #750, and the empty-directory
+behavior note.
+
+### Implementation for User Story 2
+
+- [x] T004 [US2] Add `## Isolating Plugins in Analyzer Mode` section to `docs/analyzer-integration.md` immediately before `## See Also`, containing: (a) explanation of `FINFOCUS_HOME` as the only isolation mechanism, (b) `> **Warning:**` callout noting directory-level symlinks are broken until [issue #750](https://github.com/rshade/finfocus/issues/750), (c) Step 1 `mkdir -p` real directory creation, (d) Step 2 `ln -sf` file-level binary symlink, (e) Step 3 inline `bash` code block with `FINFOCUS_HOME=~/.finfocus/demo pulumi preview --policy-pack ...`, (f) note that empty `FINFOCUS_HOME` loads zero plugins with no fallback, (g) `FINFOCUS_HOME` precedence reference. **Note**: when copying content from `plan.md` Phase 1 design block, remove the backslash escapes before fenced code fences (`` \``` `` → `` ``` ``)
+
+**Checkpoint**: After T004, read `docs/analyzer-integration.md` from "Isolating Plugins
+in Analyzer Mode" to "See Also". All US2 acceptance scenarios are now verifiable.
+
+---
+
+## Phase 4: Polish & Validation
+
+**Purpose**: Confirm both modified files meet quality gates with zero lint errors.
+
+- [x] T005 [P] Run `make docs-lint` on the full docs directory and fix any markdownlint errors introduced by T002, T003, or T004 in `docs/guides/routing.md` and `docs/analyzer-integration.md`
+- [x] T006 [P] Run `make lint` (full pipeline) to confirm no regressions in Go linting or other checks
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Pre-flight)**: No dependencies — run first
+- **Phase 2 (US1/US3)**: Depends on Phase 1 completion
+- **Phase 3 (US2)**: Independent of Phase 2 — can run in parallel with Phase 2 (different files)
+- **Phase 4 (Polish)**: Depends on Phase 2 and Phase 3 completion
+
+### User Story Dependencies
+
+- **US1 (P1)**: T001 → T002 → T003
+- **US3 (P3)**: Covered by US1 phase (same callout block); no additional tasks
+- **US2 (P2)**: T001 → T004 (independent of US1/US3)
+
+### Within Each Phase
+
+- T002 must complete before T003 (changelog references the added callout)
+- T005 and T006 are independent of each other [P]
+
+### Parallel Opportunities
+
+- T003 and T004 can run simultaneously (different files, no shared dependencies)
+- T005 and T006 can run simultaneously
+
+---
+
+## Parallel Example: Phase 2 + Phase 3 Overlap
+
+```text
+After T001 (baseline check):
+
+  Thread A: T002 → T003   (docs/guides/routing.md)
+  Thread B: T004           (docs/analyzer-integration.md)
+
+After both threads complete:
+
+  T005 [P] + T006 [P]     (validation — run together)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Pre-flight (T001)
+2. Complete Phase 2: US1/US3 (T002, T003)
+3. **STOP and VALIDATE**: Run `make docs-lint` on `docs/guides/routing.md` only
+4. US1 routing.md callout is independently verifiable at this point
+
+### Incremental Delivery
+
+1. Pre-flight (T001) → Foundation confirmed
+2. US1/US3 callout (T002, T003) → `routing.md` complete
+3. US2 isolation procedure (T004) → `analyzer-integration.md` complete
+4. Polish (T005, T006) → All acceptance criteria met, issue #759 can be closed
+
+### Minimal Approach (Single Developer)
+
+```text
+T001 → T002 → T003 → T004 → T005 → T006
+```
+
+Total estimated edits: ~15 lines in routing.md, ~40 lines in analyzer-integration.md.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no shared dependencies
+- [Story] label maps task to specific user story for traceability
+- US3 has no independent implementation tasks — it is fully addressed by the US1 callout
+- `make docs-lint` is the sole quality gate for this feature (no Go code changes)
+- Do not create new files; all changes are additive to the two existing docs files
+- The plan.md contains the full verbatim callout and section content ready for insertion


### PR DESCRIPTION
## Summary

- Clarifies that `routing:` config in `~/.finfocus/config.yaml` is not consulted when finfocus runs as a Pulumi policy pack (`pulumi preview --policy-pack`); all installed plugins are loaded unconditionally in that mode
- Documents that global plugins (`supported_providers: ["*"]`) cannot be excluded via routing in any mode — they are always queried
- Adds a step-by-step `FINFOCUS_HOME` isolation procedure for operators who need to control which plugins run during policy-pack analysis, including the file-level symlink workaround required until issue #750 is resolved

## Test plan

- [x] `make docs-lint` passes with zero errors (90 files checked)
- [x] `make lint` passes with zero issues (golangci-lint, markdownlint, actionlint)
- [x] Callout visible in `routing.md` immediately before `## Validation`
- [x] Isolation procedure in `analyzer-integration.md` contains all required steps: `FINFOCUS_HOME` explanation, `mkdir -p`, `ln -sf`, `pulumi preview` inline example, warning for #750, empty-dir behavior

## Changes

### Modified files

- `docs/guides/routing.md` — added analyzer-mode limitation callout after "Common Configuration Patterns"; updated Changelog (v0.3.1)
- `docs/analyzer-integration.md` — added "Isolating Plugins in Analyzer Mode" section with `FINFOCUS_HOME` step-by-step procedure before "See Also"

Closes #759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **New guide on isolating plugins in analyzer mode** using the FINFOCUS_HOME environment variable and file-level symlinks
* **Clarified routing limitations** when used as a Pulumi policy pack
* **Updated release notes** for v0.3.1 with analyzer/policy-pack mode details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->