### PR TITLE
test(ingest): add require.NotNil guard and convert to testify assertions

### DIFF
--- a/internal/ingest/pulumi_plan_test.go
+++ b/internal/ingest/pulumi_plan_test.go
@@ -152,29 +152,15 @@ func TestLoadPulumiPlan(t *testing.T) {
 			plan, err := ingest.LoadPulumiPlan(tmpFile)
 
 			if tt.wantErr {
-				if err == nil {
-					t.Errorf("LoadPulumiPlan() expected error, got nil")
-					return
-				}
-				if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
-					t.Errorf(
-						"LoadPulumiPlan() error = %v, want error containing %v",
-						err,
-						tt.errMsg,
-					)
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
 				}
 				return
 			}
 
-			if err != nil {
-				t.Errorf("LoadPulumiPlan() unexpected error = %v", err)
-				return
-			}
-
-			if plan == nil {
-				t.Errorf("LoadPulumiPlan() returned nil plan")
-				return
-			}
+			require.NoError(t, err)
+			require.NotNil(t, plan)
 
 			if tt.validate != nil {
 				tt.validate(t, plan)
@@ -186,12 +172,8 @@ func TestLoadPulumiPlan(t *testing.T) {
 func TestLoadPulumiPlan_FileErrors(t *testing.T) {
 	t.Run("nonexistent_file", func(t *testing.T) {
 		_, err := ingest.LoadPulumiPlan("/nonexistent/path/file.json")
-		if err == nil {
-			t.Error("LoadPulumiPlan() expected error for nonexistent file, got nil")
-		}
-		if !strings.Contains(err.Error(), "reading plan file") {
-			t.Errorf("LoadPulumiPlan() error = %v, want error containing 'reading plan file'", err)
-		}
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reading plan file")
 	})
 }
 


### PR DESCRIPTION
## Summary

- Replace manual `if/t.Errorf/return` patterns in `TestLoadPulumiPlan` runner with `require.NoError`, `require.NotNil`, and `assert.Contains`
- Fix nil-dereference bug in `TestLoadPulumiPlan_FileErrors` where `err.Error()` was called without confirming `err != nil`
- The original `TestLoadPulumiPlan_ComplexInputs` was already consolidated by #794; this applies the guard to the shared runner

## Test plan

- [x] `go test -v ./internal/ingest/... -run TestLoadPulumiPlan` passes
- [x] `make test` passes
- [x] `make lint` passes with zero issues

## Changes

### Modified files

- `internal/ingest/pulumi_plan_test.go` - Convert TestLoadPulumiPlan and TestLoadPulumiPlan_FileErrors to testify assertions; add `require.NotNil(t, plan)` guard

Closes #790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertions for plan loading validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->