### PR TITLE
chore: remove duplicate doc comments and extract placeholder helper

### DIFF
--- a/internal/cli/cost_projected.go
+++ b/internal/cli/cost_projected.go
@@ -48,34 +48,6 @@ type costProjectedParams struct {
 	jobs        int
 }
 
-// NewCostProjectedCmd creates the "projected" subcommand for calculating projected costs.
-//
-// The command analyzes a Pulumi preview to produce projected monthly costs and supports
-// auto-detection of a Pulumi project: when --pulumi-json is omitted, the current Pulumi
-// project is used and a preview is executed to obtain JSON input (use --stack to target
-// a specific stack during auto-detection).
-//
-// Registered flags:
-//   - --pulumi-json: optional path to a Pulumi preview JSON file (auto-detected if omitted)
-//   - --spec-dir: directory containing pricing specification files
-//   - --adapter: restrict processing to a single adapter plugin
-//   - --output: output format, one of table, json, or ndjson (default from configuration)
-//   - --filter: repeatable resource filter expression(s)
-//
-// NewCostProjectedCmd returns a Cobra command that calculates projected costs from a Pulumi plan.
-//
-// The command analyzes a Pulumi preview JSON output to produce projected monthly costs.
-// If --pulumi-json is omitted, the command will attempt to auto-detect the Pulumi project in the
-// current directory and run `pulumi preview --json`; use --stack to target a specific stack during
-// auto-detection. Available flags include:
-//
-//	--pulumi-json    Path to Pulumi preview JSON output (optional; auto-detected if omitted).
-//	--spec-dir       Directory containing pricing specification files.
-//	--adapter        Restrict processing to a single adapter plugin.
-//	--output         Output format: table, json, or ndjson.
-//	--filter         Repeatable resource filter expressions (e.g., "type=aws:ec2/instance").
-//	--utilization    Utilization rate for sustainability calculations, between 0.0 and 1.0.
-//
 // NewCostProjectedCmd returns a Cobra command configured to calculate projected costs
 // from a Pulumi preview JSON and render the results in table, JSON, or NDJSON formats.
 // The command accepts either an explicit Pulumi preview JSON file or will auto-detect

--- a/internal/engine/cache/key.go
+++ b/internal/engine/cache/key.go
@@ -26,16 +26,18 @@ func isValidBucket(name string) bool {
 	}
 }
 
+// placeholder returns "_" for empty strings to preserve fixed segment positions in cache keys.
+func placeholder(s string) string {
+	if s == "" {
+		return "_"
+	}
+	return s
+}
+
 // BuildProjectedKey constructs a human-readable cache key for per-resource projected costs.
 // The key has the form "projected/{provider}/{type}/{region}/{sku}".
 // Any empty segment is replaced with "_" to preserve fixed segment positions.
 func BuildProjectedKey(provider, resourceType, region, sku string) string {
-	placeholder := func(s string) string {
-		if s == "" {
-			return "_"
-		}
-		return s
-	}
 	return strings.Join([]string{
 		BucketProjected,
 		placeholder(provider),
@@ -51,13 +53,6 @@ func BuildProjectedKey(provider, resourceType, region, sku string) string {
 // and avoid ambiguity (e.g., provider="aws" vs resourceTypes=["aws"]).
 // The resulting key is safe for use as a top-level bucketed cache key.
 func BuildActualKey(provider string, resourceTypes []string, from, to time.Time, filters map[string]string) string {
-	placeholder := func(s string) string {
-		if s == "" {
-			return "_"
-		}
-		return s
-	}
-
 	// Sort resource types for determinism
 	sorted := make([]string, len(resourceTypes))
 	copy(sorted, resourceTypes)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -3444,8 +3444,6 @@ func generateProjectedCostResourceKey(resource ResourceDescriptor) (string, erro
 	return cache.BuildProjectedKey(resource.Provider, resource.Type, region, sku), nil
 }
 
-// generateActualCostCacheKey generates a deterministic cache key for an actual cost
-// query. Uses structured `/`-separated keys with time ranges and filter hashes.
 // generateActualCostCacheKey builds a deterministic cache key for an actual cost request.
 // The returned key encodes a prefix of the form "actual/{provider}/{types}/{from}/{to}/{filter-hash}"
 // and incorporates request-level options to ensure uniqueness.


### PR DESCRIPTION
Fixes #684

- Remove two orphaned doc comment blocks before `NewCostProjectedCmd` in `internal/cli/cost_projected.go`
- Remove redundant short one-liner stacked above the detailed doc comment for `generateActualCostCacheKey` in `internal/engine/engine.go`
- Extract repeated `placeholder` anonymous closure in `internal/engine/cache/key.go` to a package-level function

Generated with [Claude Code](https://claude.ai/code)