### PR TITLE
test: fix vacuous exit code 0 test in budget_scoped_test.go

### DIFF
--- a/internal/config/budget_scoped_test.go
+++ b/internal/config/budget_scoped_test.go
@@ -151,9 +151,10 @@ func TestScopedBudget_Validation(t *testing.T) {
 		{
 			name: "valid exit code 0 (warning mode)",
 			budget: &config.ScopedBudget{
-				Amount:   1000.0,
-				Currency: "USD",
-				ExitCode: ptr(0),
+				Amount:          1000.0,
+				Currency:        "USD",
+				ExitOnThreshold: ptr(true),
+				ExitCode:        ptr(0),
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
Add ExitOnThreshold: ptr(true) to the 'valid exit code 0 (warning mode)' test case so validateExitCode() actually exercises the range check instead of returning early when ExitOnThreshold is nil/false.

Realign struct field spacing to match adjacent test cases.

Fixes #786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ExitOnThreshold option to budget configuration, enabling the system to exit when budget thresholds are reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->