### PR TITLE
fix: FINFOCUS_HIDE_ALIAS_HINT should use presence-based check, not value-based

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -89,8 +89,8 @@ func NewRootCmdWithArgs(
 				}
 
 				// Alias reminder - use injected lookupEnv for test isolation
-				aliasHint, _ := lookupEnv("FINFOCUS_HIDE_ALIAS_HINT")
-				if aliasHint == "" && !pluginMode {
+				_, hideAlias := lookupEnv("FINFOCUS_HIDE_ALIAS_HINT")
+				if !hideAlias && !pluginMode {
 					msg := "Tip: Add 'alias fin=finfocus' to your shell profile for a shorter command!"
 					cmd.PrintErrln(msg)
 				}


### PR DESCRIPTION
Change the alias hint suppression to check variable presence instead of value, matching the pattern used by FINFOCUS_SKIP_MIGRATION_CHECK.

This means setting FINFOCUS_HIDE_ALIAS_HINT= (empty string) now correctly suppresses the alias hint.

Fixes #783

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment variable handling for controlling alias hint visibility, improving the predictability and consistency of when informational tips appear in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->