### PR TITLE
fix: respect --yes flag when change detection fails in overview TUI

### DIFF
--- a/internal/cli/overview.go
+++ b/internal/cli/overview.go
@@ -798,6 +798,26 @@ const (
 	phaseEnrichResources = 5
 )
 
+// resolveIsStateOnly determines whether to operate in state-only mode (no pulumi preview).
+//
+// When params.yes is true the user has explicitly requested a preview; a detection error
+// must NOT override that intent.  When params.yes is false a detection error is a safe
+// signal to fall back to state-only so the user can trigger a preview manually with 'p'.
+func resolveIsStateOnly(params overviewParams, signal pulumidetect.ChangeSignal, detectErr error) bool {
+	explicitStateOnly := params.pulumiState != "" && params.pulumiJSON == "" && !params.yes
+	runPreviewNow := !explicitStateOnly && (params.yes || signal.IsFirstDeploy || signal.HasLikelyChanges)
+	isStateOnly := !runPreviewNow
+
+	// If change detection failed and the user did NOT explicitly request a preview
+	// (--yes), fall back to state-only so the user can decide whether to trigger
+	// preview manually with 'p'.
+	if detectErr != nil && !params.yes {
+		isStateOnly = true
+	}
+
+	return isStateOnly
+}
+
 // overviewInitAndEnrich performs data loading and enrichment in a background
 // goroutine, sending phase progress and data messages to the Bubble Tea program.
 //
@@ -840,8 +860,9 @@ func overviewInitAndEnrich(
 			Ctx(enrichCtx).
 			Str("component", "cli").
 			Str("operation", "overview_tui_init").
+			Bool("yes", params.yes).
 			Err(detectErr).
-			Msg("change detection failed; falling back to state-only mode")
+			Msg("change detection failed; will fall back to state-only unless --yes was set")
 	}
 
 	// Decide whether to run pulumi preview now.
@@ -849,15 +870,7 @@ func overviewInitAndEnrich(
 	// or the conservative heuristic (HasLikelyChanges=true → run preview; false → state-only).
 	// When --pulumi-state is provided without --pulumi-json (and without --yes), default to
 	// state-only mode so the user can press 'p' to load pending changes on demand.
-	explicitStateOnly := params.pulumiState != "" && params.pulumiJSON == "" && !params.yes
-	runPreviewNow := !explicitStateOnly && (params.yes || signal.IsFirstDeploy || signal.HasLikelyChanges)
-	isStateOnly := !runPreviewNow
-
-	// If change detection failed, fall back to state-only so the user can
-	// decide whether to trigger preview manually with 'p'.
-	if detectErr != nil {
-		isStateOnly = true
-	}
+	isStateOnly := resolveIsStateOnly(params, signal, detectErr)
 
 	// Phase 3: Merge resources (from state only when state-first, from state+plan when preview runs).
 	p.Send(tui.OverviewPhaseMsg{Index: phaseMergeResources, Phase: "Merging resources..."})

--- a/internal/cli/overview_phase_internal_test.go
+++ b/internal/cli/overview_phase_internal_test.go
@@ -1,13 +1,87 @@
 package cli
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	pulumidetect "github.com/rshade/finfocus/internal/pulumi"
 	"github.com/rshade/finfocus/internal/tui"
 )
+
+// TestResolveIsStateOnly verifies that detectErr does not override --yes, and that
+// without --yes a detection error correctly forces state-only mode.
+func TestResolveIsStateOnly(t *testing.T) {
+	detectErr := errors.New("change detection failed")
+	noErr := error(nil)
+
+	tests := []struct {
+		name        string
+		params      overviewParams
+		signal      pulumidetect.ChangeSignal
+		detectErr   error
+		wantIsState bool
+	}{
+		{
+			name:        "yes=true, no error: preview runs",
+			params:      overviewParams{yes: true},
+			signal:      pulumidetect.ChangeSignal{},
+			detectErr:   noErr,
+			wantIsState: false,
+		},
+		{
+			name:        "yes=true, detect error: preview must still run (bug fix)",
+			params:      overviewParams{yes: true},
+			signal:      pulumidetect.ChangeSignal{},
+			detectErr:   detectErr,
+			wantIsState: false,
+		},
+		{
+			name:        "yes=false, no error, no changes: state-only",
+			params:      overviewParams{yes: false},
+			signal:      pulumidetect.ChangeSignal{HasLikelyChanges: false},
+			detectErr:   noErr,
+			wantIsState: true,
+		},
+		{
+			name:        "yes=false, no error, likely changes: preview runs",
+			params:      overviewParams{yes: false},
+			signal:      pulumidetect.ChangeSignal{HasLikelyChanges: true},
+			detectErr:   noErr,
+			wantIsState: false,
+		},
+		{
+			name:        "yes=false, detect error: falls back to state-only",
+			params:      overviewParams{yes: false},
+			signal:      pulumidetect.ChangeSignal{HasLikelyChanges: true},
+			detectErr:   detectErr,
+			wantIsState: true,
+		},
+		{
+			name:        "explicit state-only (pulumi-state set, no pulumi-json, no yes): state-only",
+			params:      overviewParams{yes: false, pulumiState: "state.json", pulumiJSON: ""},
+			signal:      pulumidetect.ChangeSignal{HasLikelyChanges: true},
+			detectErr:   noErr,
+			wantIsState: true,
+		},
+		{
+			name:        "explicit state-only overridden by yes: preview runs",
+			params:      overviewParams{yes: true, pulumiState: "state.json", pulumiJSON: ""},
+			signal:      pulumidetect.ChangeSignal{},
+			detectErr:   noErr,
+			wantIsState: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveIsStateOnly(tt.params, tt.signal, tt.detectErr)
+			assert.Equal(t, tt.wantIsState, got)
+		})
+	}
+}
 
 // TestPhaseConstantsAlignWithTUI ensures the phase index constants stay in sync
 // with tui.PhaseNames. If PhaseNames grows or shrinks, this test fails, forcing


### PR DESCRIPTION
Fixes #762

When `detectErr != nil`, the code was unconditionally setting `isStateOnly = true`, silently ignoring an explicit `--yes` flag.

**Changes:**
- Extracted the isStateOnly decision into a testable `resolveIsStateOnly` helper
- Fixed condition to `detectErr != nil && !params.yes`
- Added 7 table-driven unit tests covering all critical branches

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced change detection error handling with improved diagnostics that provide better contextual information when detection fails.
* **Tests**
  * Expanded test coverage to validate state-only mode behavior and resolution across various configuration scenarios and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->