### PR TITLE
docs: fix incorrect analyzers: in Pulumi.yaml claim in architecture doc

### DIFF
--- a/docs/architecture/analyzer.md
+++ b/docs/architecture/analyzer.md
@@ -199,15 +199,19 @@ finfocus analyzer serve
 finfocus analyzer serve --debug
 ```
 
-Configure Pulumi to use the analyzer in `Pulumi.yaml`:
+Invoke the analyzer via the `--policy-pack` flag. The binary must be on your PATH:
 
-```yaml
-analyzers:
-  - name: finfocus
+```bash
+export PATH="${HOME}/.finfocus/analyzer:${PATH}"
+pulumi preview --policy-pack ~/.finfocus/analyzer
 ```
 
-Pulumi launches `finfocus analyzer serve` as a subprocess, reads the port from
-stdout, and connects over gRPC for the duration of the preview or update.
+Pulumi finds `pulumi-analyzer-policy-finfocus` by searching PATH, executes it as
+a subprocess, reads the port from stdout, and connects over gRPC for the duration
+of the preview or update.
+
+> **Note:** Adding `analyzers:` to `Pulumi.yaml` does not work for YAML-runtime
+> projects. Use `--policy-pack` with the binary on PATH.
 
 ## Logging
 


### PR DESCRIPTION
Remove the incorrect suggestion that `analyzers: - name: finfocus` in `Pulumi.yaml` works for YAML-runtime projects. Replace with the correct `--policy-pack` invocation that requires the binary on PATH.

The `analyzers:` key in `Pulumi.yaml` is silently ignored for YAML-runtime projects (verified against Pulumi CLI v3.223.0).

Closes #758

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated analyzer configuration guidance: now uses `--policy-pack` invocation with PATH-resolved binaries instead of Pulumi.yaml configuration.
  * Added clarification that YAML-runtime projects do not support analyzer configurations.
  * Updated documentation on port handling and logging constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->