### PR TITLE
fix(cli): wait for enrichment goroutine before plugin cleanup in over…

### DIFF
--- a/internal/cli/overview.go
+++ b/internal/cli/overview.go
@@ -742,23 +742,34 @@ func runInteractiveOverviewWithInit(
 	// to the main goroutine for accurate audit logging.
 	var rowCount atomic.Int64
 
+	// enrichDone is closed when the background goroutine exits. The cleanup
+	// path waits on this channel so plugin connections are not torn down while
+	// enrichment gRPC calls are still in flight (see issue #716).
+	enrichDone := make(chan struct{})
+
 	// Start data loading and enrichment in background
-	go overviewInitAndEnrich(enrichCtx, cmd, p, params, dateRange, audit, cleanupChan, &rowCount, passphraseChan)
+	go func() {
+		defer close(enrichDone)
+		overviewInitAndEnrich(enrichCtx, cmd, p, params, dateRange, audit, cleanupChan, &rowCount, passphraseChan)
+	}()
 
 	// Run the TUI (blocks until user quits or error)
 	finalModel, err := p.Run()
 	enrichCancel()
 
-	// Drain cleanup from the background goroutine with a short timeout.
-	// The goroutine may still be mid-send after enrichCancel(), so we block
-	// briefly to ensure the plugin cleanup callback is not lost.
+	// Wait for the enrichment goroutine to finish before closing plugin
+	// connections. This prevents a race where cleanup() tears down gRPC
+	// connections while EnrichOverviewRows still has calls in flight.
+	<-enrichDone
+
+	// Drain cleanup from the background goroutine.
 	select {
 	case cleanup := <-cleanupChan:
 		if cleanup != nil {
 			cleanup()
 		}
-	case <-time.After(2 * time.Second): //nolint:mnd // Grace period for goroutine to send cleanup.
-		// Plugins were never opened (early exit or error before openPlugins)
+	default:
+		// Plugins were never opened (early exit or error before openPlugins).
 	}
 
 	if err != nil {


### PR DESCRIPTION
…view

## Summary

- Replace racy 2-second timeout with deterministic `enrichDone` channel that is closed when the enrichment goroutine exits
- After the TUI exits and `enrichCancel()` fires, the cleanup path now blocks on `<-enrichDone` so gRPC connections are never torn down while `EnrichOverviewRows` calls are in flight
- The `cleanupChan` drain switches from `time.After` fallback to a non-blocking `default` branch since the goroutine is guaranteed to have finished by that point

## Test plan

- [x] `go vet ./internal/cli/...` passes
- [x] `go build ./internal/cli/...` compiles cleanly
- [x] Overview-related unit tests pass (`TestResolveIsStateOnly`, `TestOverviewPlainText_CacheHitReturnsProjectedCost`, `TestValidateBudgetFilter_Errors`)
- [ ] `make lint` full run
- [ ] `make test` full run

## Changes

### Modified files

- `internal/cli/overview.go` - Add `enrichDone` channel in `runInteractiveOverviewWithInit`; wrap goroutine with `defer close(enrichDone)`; wait on channel before draining cleanup; replace `time.After` timeout with `default` branch

Closes #716

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of background enrichment operations in the CLI to ensure proper cleanup and prevent potential resource conflicts during enrichment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->