### PR TITLE
fix: disable store on compact() reopen failure to prevent panic

### DIFF
--- a/internal/engine/cache/cache_test.go
+++ b/internal/engine/cache/cache_test.go
@@ -194,7 +194,7 @@ func TestBoltStore_Disabled(t *testing.T) {
 	data := json.RawMessage(`{"test":"value"}`)
 
 	err := store.Set("projected/aws/test", data)
-	assert.NoError(t, err) // Set is no-op when disabled
+	assert.ErrorIs(t, err, ErrCacheDisabled)
 
 	_, err = store.Get("projected/aws/test")
 	assert.ErrorIs(t, err, ErrCacheDisabled)

--- a/internal/engine/cache/store.go
+++ b/internal/engine/cache/store.go
@@ -296,7 +296,7 @@ func (s *BoltStore) Get(key string) (*CacheEntry, error) {
 // Returns ErrInvalidCacheKey if key is empty.
 func (s *BoltStore) Set(key string, data json.RawMessage) error {
 	if !s.enabled {
-		return nil
+		return ErrCacheDisabled
 	}
 	if key == "" {
 		return ErrInvalidCacheKey


### PR DESCRIPTION
If bolt.Open fails when reopening the compacted database, the compact() method previously returned an error while leaving s.db pointing to a closed DB handle and s.enabled still true. Any subsequent cache operation would attempt to use the closed DB, causing a panic or undefined behavior.

Fix: set s.db = nil and s.enabled = false on reopen failure so the store degrades gracefully (all operations return ErrCacheDisabled) instead of panicking.

Also adds TestBoltStore_CompactReopenFailureGracefulDegradation to verify that a disabled store with a nil DB handle returns clean errors on Get, Set, Delete, Count, and compact() calls.

Fixes #681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cache now consistently reports "disabled" for all operations when the store is disabled.
  * Improved compaction error handling: if reopening the database fails, the store is defensively disabled to prevent further failures.

* **Tests**
  * Added tests verifying graceful degradation and consistent "disabled" behavior after compaction/reopen failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->