### PR TITLE
feat(tui): make table separator line extend to terminal width

### DIFF
--- a/internal/tui/overview_model.go
+++ b/internal/tui/overview_model.go
@@ -18,6 +18,23 @@ import (
 // maxOverviewResourcesPerPage is the pagination threshold.
 const maxOverviewResourcesPerPage = 250
 
+// Column width constants for the overview table.
+// All columns except Resource have fixed widths; Resource absorbs extra terminal width.
+const (
+	colWidthType      = 20
+	colWidthStatus    = 10
+	colWidthActual    = 12
+	colWidthProjected = 12
+	colWidthDelta     = 12
+	colWidthDrift     = 8
+	colWidthRecs      = 9
+	// fixedColumnsTotal is the sum of all non-Resource column widths.
+	fixedColumnsTotal = colWidthType + colWidthStatus + colWidthActual +
+		colWidthProjected + colWidthDelta + colWidthDrift + colWidthRecs
+	// minResourceColWidth is the minimum width for the Resource column.
+	minResourceColWidth = 30
+)
+
 // OverviewResourceLoadedMsg is sent when a single resource's data is enriched.
 type OverviewResourceLoadedMsg struct {
 	Index int
@@ -196,6 +213,16 @@ func NewOverviewModel(
 // Err returns any error that caused the TUI to exit (e.g., init failure).
 func (m OverviewModel) Err() error {
 	return m.err
+}
+
+// resourceColumnWidth returns the dynamic width for the Resource column.
+// It expands to fill available terminal width, with a minimum of minResourceColWidth.
+func (m *OverviewModel) resourceColumnWidth() int {
+	available := m.width - fixedColumnsTotal - borderPadding
+	if available < minResourceColWidth {
+		return minResourceColWidth
+	}
+	return available
 }
 
 // Init initializes the model (Bubble Tea interface).
@@ -558,22 +585,23 @@ func (m *OverviewModel) buildOverviewTable() table.Model {
 	if m.isStateOnly && !m.previewLoaded {
 		projectedHeader = "Projected*"
 	}
+	resourceWidth := m.resourceColumnWidth()
 	columns := []table.Column{
-		{Title: "Resource", Width: 30},      //nolint:mnd // Column width.
-		{Title: "Type", Width: 20},          //nolint:mnd // Column width.
-		{Title: "Status", Width: 10},        //nolint:mnd // Column width.
-		{Title: "Actual", Width: 12},        //nolint:mnd // Column width.
-		{Title: projectedHeader, Width: 12}, //nolint:mnd // Column width.
-		{Title: "Delta", Width: 12},         //nolint:mnd // Column width.
-		{Title: "Drift%", Width: 8},         //nolint:mnd // Column width.
-		{Title: "Recs", Width: 9},           //nolint:mnd // Column width.
+		{Title: "Resource", Width: resourceWidth},
+		{Title: "Type", Width: colWidthType},
+		{Title: "Status", Width: colWidthStatus},
+		{Title: "Actual", Width: colWidthActual},
+		{Title: projectedHeader, Width: colWidthProjected},
+		{Title: "Delta", Width: colWidthDelta},
+		{Title: "Drift%", Width: colWidthDrift},
+		{Title: "Recs", Width: colWidthRecs},
 	}
 
 	visibleRows := m.getVisibleRows()
 	rows := make([]table.Row, len(visibleRows))
 
 	for i, overviewRow := range visibleRows {
-		resourceName := truncateResourceName(overviewRow.URN)
+		resourceName := truncateResourceName(overviewRow.URN, resourceWidth)
 		statusStr := overviewRow.Status.String()
 
 		actualStr := "-"
@@ -639,9 +667,8 @@ func (m *OverviewModel) buildOverviewTable() table.Model {
 	return t
 }
 
-// truncateResourceName shortens a URN for display.
-func truncateResourceName(urn string) string {
-	const maxLen = 30
+// truncateResourceName shortens a URN for display within the given maxLen.
+func truncateResourceName(urn string, maxLen int) string {
 	if urn == "" {
 		return urn
 	}
@@ -655,7 +682,8 @@ func truncateResourceName(urn string) string {
 	if len(name) <= maxLen {
 		return name
 	}
-	return name[:maxLen-3] + "..."
+	const ellipsis = 3
+	return name[:maxLen-ellipsis] + "..."
 }
 
 // applyFilter filters rows based on text input. It always calls refreshTable

--- a/internal/tui/overview_model_test.go
+++ b/internal/tui/overview_model_test.go
@@ -349,6 +349,105 @@ func TestOverviewModel_WindowResize(t *testing.T) {
 	assert.Equal(t, 40, model.height)
 }
 
+// TestOverviewModel_ResourceColumnWidth verifies dynamic resource column sizing.
+func TestOverviewModel_ResourceColumnWidth(t *testing.T) {
+	ctx := context.Background()
+	rows := []engine.OverviewRow{
+		{URN: "urn:test", Type: "aws:ec2:Instance", Status: engine.StatusActive},
+	}
+
+	tests := []struct {
+		name     string
+		width    int
+		expected int
+	}{
+		{
+			name:     "default 80 width",
+			width:    defaultWidth,
+			expected: minResourceColWidth,
+		},
+		{
+			name:     "wide terminal 160",
+			width:    160,
+			expected: 160 - fixedColumnsTotal - borderPadding,
+		},
+		{
+			name:     "narrow terminal clamps to minimum",
+			width:    50,
+			expected: minResourceColWidth,
+		},
+		{
+			name:     "exact breakpoint",
+			width:    fixedColumnsTotal + borderPadding + minResourceColWidth,
+			expected: minResourceColWidth,
+		},
+		{
+			name:     "one above breakpoint",
+			width:    fixedColumnsTotal + borderPadding + minResourceColWidth + 1,
+			expected: minResourceColWidth + 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model, _ := NewOverviewModel(ctx, rows, 1, nil, nil)
+			model.width = tt.width
+			assert.Equal(t, tt.expected, model.resourceColumnWidth())
+		})
+	}
+}
+
+// TestTruncateResourceName verifies URN truncation with dynamic max length.
+func TestTruncateResourceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		urn      string
+		maxLen   int
+		expected string
+	}{
+		{
+			name:     "empty URN",
+			urn:      "",
+			maxLen:   30,
+			expected: "",
+		},
+		{
+			name:     "short URN within limit",
+			urn:      "short-name",
+			maxLen:   30,
+			expected: "short-name",
+		},
+		{
+			name:     "long URN extracts last component",
+			urn:      "urn:pulumi:stack::project::aws:ec2:Instance::my-instance",
+			maxLen:   30,
+			expected: "my-instance",
+		},
+		{
+			name:     "last component exceeds maxLen",
+			urn:      "urn:pulumi:stack::project::aws:ec2:Instance::this-is-a-very-long-resource-name-that-exceeds",
+			maxLen:   30,
+			expected: "this-is-a-very-long-resourc...",
+		},
+		{
+			name:     "wider terminal allows more characters",
+			urn:      "urn:pulumi:stack::project::aws:ec2:Instance::this-is-a-very-long-resource-name-that-exceeds",
+			maxLen:   50,
+			expected: "this-is-a-very-long-resource-name-that-exceeds",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := truncateResourceName(tt.urn, tt.maxLen)
+			assert.Equal(t, tt.expected, result)
+			if tt.urn != "" {
+				assert.LessOrEqual(t, len(result), tt.maxLen)
+			}
+		})
+	}
+}
+
 // TestOverviewModel_GetCost verifies cost extraction for sorting.
 func TestOverviewModel_GetCost(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- Extract column widths to named constants, replacing inline magic numbers with `colWidthType`, `colWidthStatus`, etc.
- Add `resourceColumnWidth()` method that dynamically sizes the Resource column to fill available terminal width
- Update `truncateResourceName` to accept a dynamic max length so wider terminals display longer resource names
- Clamp to minimum width of 30 on narrow terminals to preserve the current default behavior

## Test plan

- [x] `make test` passes
- [x] `make lint` passes with zero issues
- [x] New `TestOverviewModel_ResourceColumnWidth` covers wide, narrow, default, and boundary terminal widths
- [x] New `TestTruncateResourceName` covers empty URN, short URN, long URN extraction, ellipsis truncation, and wider terminals

## Changes

### Modified files

- `internal/tui/overview_model.go` - Extract column width constants, add `resourceColumnWidth()` method, make Resource column dynamic, update `truncateResourceName` signature
- `internal/tui/overview_model_test.go` - Add table-driven tests for `resourceColumnWidth()` and `truncateResourceName()`

Closes #718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Overview table now dynamically adjusts the resource column width based on terminal size while respecting minimum constraints for usability.
  * Resource names are intelligently truncated based on available space with consistent ellipsis formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->