### PR TITLE
refactor(cli): extract progress constant and add goroutine comment in…

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,8 +25,6 @@ continues with TUI quality fixes and the remaining performance pipeline.*
         ([#720](https://github.com/rshade/finfocus/issues/720)) [S]
   - [ ] Show phase progress lines sequentially and add preview phase
         ([#714](https://github.com/rshade/finfocus/issues/714)) [M]
-  - [ ] Extend table separator line to terminal width in overview TUI
-        ([#718](https://github.com/rshade/finfocus/issues/718)) [S]
   - [ ] Extract progress constant and add goroutine comment in overview
         ([#721](https://github.com/rshade/finfocus/issues/721)) [S]
   - [ ] False-positive drift for resources created mid-month in overview
@@ -40,13 +38,7 @@ continues with TUI quality fixes and the remaining performance pipeline.*
         ([#691](https://github.com/rshade/finfocus/issues/691)) [M]
   - [ ] Add `--state-only` flag to skip pulumi preview
         ([#690](https://github.com/rshade/finfocus/issues/690)) [M]
-- [x] **BoltDB Cache Stability** *(post-#674 migration fixes)*
-  - [x] `BoltStore.Set` returns nil when disabled, inconsistent with other
-        methods
-        ([#682](https://github.com/rshade/finfocus/issues/682)) [S]
 - [ ] **Engine & Recorder Fixes**
-  - [ ] `classifyError` should handle `context.Canceled` and `context.DeadlineExceeded`
-        ([#726](https://github.com/rshade/finfocus/issues/726)) [S]
   - [ ] Implement `GetPricingSpec` and `EstimateCost` methods on RecorderPlugin
         ([#734](https://github.com/rshade/finfocus/issues/734)) [M]
 
@@ -123,6 +115,8 @@ continues with TUI quality fixes and the remaining performance pipeline.*
   - [ ] Upgrade to Bubble Tea v2, Lip Gloss v2, Bubbles v2 (after stable
         release)
         ([#552](https://github.com/rshade/finfocus/issues/552)) [L]
+  - [ ] Upgrade charmbracelet dependencies to v2 (detailed migration plan)
+        ([#827](https://github.com/rshade/finfocus/issues/827)) [L]
   - *Blocked: Bubble Tea v2 must exit release candidate status*
 - [ ] **Cache Architecture Improvements**
   - [ ] Add optional LRU in-memory cache layer to complement BoltStore
@@ -220,6 +214,16 @@ continues with TUI quality fixes and the remaining performance pipeline.*
 
 ### 2026-Q1
 
+- [x] **TUI & Engine Fixes** *(Completed 2026-02-28)*
+  - [x] Extend table separator line to terminal width in overview TUI
+        ([#718](https://github.com/rshade/finfocus/issues/718))
+  - [x] `classifyError` should handle `context.Canceled` and
+        `context.DeadlineExceeded`
+        ([#726](https://github.com/rshade/finfocus/issues/726))
+- [x] **BoltDB Cache Stability** *(post-#674 migration fixes)*
+  - [x] `BoltStore.Set` returns nil when disabled, inconsistent with other
+        methods
+        ([#682](https://github.com/rshade/finfocus/issues/682))
 - [x] **Analyzer Quality Fixes** *(Completed 2026-02-27)*
   - [x] Eliminate duplicate `ResolvePolicyPackDir` call in `RunChecks`
         ([#822](https://github.com/rshade/finfocus/issues/822))

--- a/internal/cli/overview.go
+++ b/internal/cli/overview.go
@@ -893,6 +893,10 @@ const (
 	phaseStartPlugins    = 3
 	phasePrepareEngine   = 4
 	phaseEnrichResources = 5
+
+	// progressReportInterval controls how often enrichment progress is
+	// reported to the TUI (every N rows).
+	progressReportInterval = 10
 )
 
 // resolveIsStateOnly determines whether to operate in state-only mode (no pulumi preview).
@@ -1324,6 +1328,9 @@ func bridgeEnrichmentToTUI(
 	dismissalRecords := loadDismissalRecordsForOverview(enrichCtx)
 
 	progressChan := make(chan engine.OverviewRowUpdate, len(rows))
+	// EnrichOverviewRows runs in its own goroutine so the TUI event loop
+	// stays responsive. p.Send is safe to call concurrently — Bubble Tea's
+	// Send selects on p.ctx.Done(), so it returns promptly during shutdown.
 	go func() {
 		engine.EnrichOverviewRows(enrichCtx, rows, eng, dateRange, progressChan)
 	}()
@@ -1346,7 +1353,7 @@ func bridgeEnrichmentToTUI(
 			Row:   update.Row,
 		})
 
-		if loadedCount%10 == 0 || loadedCount == len(rows) {
+		if loadedCount%progressReportInterval == 0 || loadedCount == len(rows) {
 			p.Send(tui.OverviewLoadingProgressMsg{
 				Loaded: loadedCount,
 				Total:  len(rows),


### PR DESCRIPTION
… overview

## Summary

- Extract bare literal `10` into named `progressReportInterval` constant within the existing phase-index const block, making the TUI progress reporting interval self-documenting and easy to tune
- Add a comment above the `go func()` in `bridgeEnrichmentToTUI` explaining why `p.Send` is safe to call from a goroutine (Bubble Tea's `Send` selects on `p.ctx.Done()`)

## Test plan

- [x] `make test` passes (cli package: 215s, 0 failures)
- [x] `make lint` passes with zero issues
- [x] `go vet ./internal/cli/...` clean

## Changes

### Modified files

- `internal/cli/overview.go` - Added `progressReportInterval` constant, replaced bare `10` with it, added goroutine safety comment above `go func()` in `bridgeEnrichmentToTUI`

Closes #721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and clarity in progress reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->