### PR TITLE
fix(overview): correct drift extrapolation for mid-month resources

### DIFF
--- a/internal/cli/overview.go
+++ b/internal/cli/overview.go
@@ -562,12 +562,18 @@ func resolveOverviewDateRange(fromStr, toStr string, now time.Time) (engine.Date
 func convertStateResources(resources []ingest.StackExportResource) []engine.StateResource {
 	result := make([]engine.StateResource, len(resources))
 	for i, r := range resources {
+		var createdAt *time.Time
+		if r.Created != nil {
+			t := *r.Created // copy value to avoid aliasing the ingest layer's pointer
+			createdAt = &t
+		}
 		result[i] = engine.StateResource{
 			URN:        r.URN,
 			Type:       r.Type,
 			ID:         r.ID,
 			Custom:     r.Custom,
 			Properties: ingest.MergeProperties(r.Outputs, r.Inputs),
+			CreatedAt:  createdAt,
 		}
 	}
 	return result

--- a/internal/cli/overview_phase_internal_test.go
+++ b/internal/cli/overview_phase_internal_test.go
@@ -3,10 +3,12 @@ package cli
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/rshade/finfocus/internal/ingest"
 	pulumidetect "github.com/rshade/finfocus/internal/pulumi"
 	"github.com/rshade/finfocus/internal/tui"
 )
@@ -97,4 +99,43 @@ func TestPhaseConstantsAlignWithTUI(t *testing.T) {
 		"phaseEnrichResources should be the last phase index; update the constant if PhaseNames changed")
 	assert.Equal(t, 0, phaseLoadStackState,
 		"phaseLoadStackState should be the first phase index")
+}
+
+// ---------------------------------------------------------------------------
+// convertStateResources — CreatedAt propagation
+// ---------------------------------------------------------------------------
+
+func TestConvertStateResources_CreatedAtPreserved(t *testing.T) {
+	createdAt := time.Date(2025, 2, 13, 10, 0, 0, 0, time.UTC)
+
+	resources := []ingest.StackExportResource{
+		{
+			URN:     "urn:pulumi:prod::app::aws:ebs:Volume::data",
+			Type:    "aws:ebs:Volume",
+			ID:      "vol-abc123",
+			Custom:  true,
+			Created: &createdAt,
+		},
+	}
+
+	result := convertStateResources(resources)
+	require.Len(t, result, 1)
+	require.NotNil(t, result[0].CreatedAt)
+	assert.Equal(t, createdAt, *result[0].CreatedAt)
+}
+
+func TestConvertStateResources_NilCreatedAtOK(t *testing.T) {
+	resources := []ingest.StackExportResource{
+		{
+			URN:     "urn:pulumi:prod::app::aws:ec2:Instance::web",
+			Type:    "aws:ec2:Instance",
+			ID:      "i-abc123",
+			Custom:  true,
+			Created: nil,
+		},
+	}
+
+	result := convertStateResources(resources)
+	require.Len(t, result, 1)
+	assert.Nil(t, result[0].CreatedAt)
 }

--- a/internal/engine/overview_enrich.go
+++ b/internal/engine/overview_enrich.go
@@ -235,15 +235,35 @@ func enrichRecommendations(ctx context.Context, row *OverviewRow, eng overviewEn
 // enrichCostDrift calculates cost drift for a row that has both actual and projected costs.
 // It uses the dateRange end time to determine the day-of-month and days-in-month, which
 // ensures correct drift for historical queries rather than always using the current date.
+//
+// When row.CreatedAt is non-nil and falls within the billing window (after dateRange.Start),
+// the function uses the number of days since creation as the extrapolation denominator
+// instead of the day-of-month. This prevents false-positive drift for resources created
+// mid-month that have not yet accumulated a full month of billing data.
 func enrichCostDrift(row *OverviewRow, dateRange DateRange) {
 	refTime := dateRange.End
 	dayOfMonth := refTime.Day()
 	daysInMonth := daysInCurrentMonth(refTime)
 
+	denominator := dayOfMonth
+
+	// If the resource was created within this billing window, use days since
+	// creation as the denominator to avoid false-positive drift warnings.
+	if row.CreatedAt != nil && row.CreatedAt.After(dateRange.Start) && row.CreatedAt.Before(refTime) {
+		// +1 for inclusive counting: matches dayOfMonth semantics where day 1
+		// means "the current day has started (possibly partially)".
+		daysSinceCreation := int(refTime.Sub(*row.CreatedAt).Hours()/hoursPerDay) + 1
+		if daysSinceCreation < driftMinDay {
+			// Too few days of data since creation — suppress drift entirely.
+			return
+		}
+		denominator = daysSinceCreation
+	}
+
 	drift, err := CalculateCostDrift(
 		row.ActualCost.MTDCost,
 		row.ProjectedCost.MonthlyCost,
-		dayOfMonth,
+		denominator,
 		daysInMonth,
 	)
 	if err != nil {

--- a/internal/engine/overview_enrich_test.go
+++ b/internal/engine/overview_enrich_test.go
@@ -733,6 +733,232 @@ func TestEnrichOverviewRow_ErrorPrecedence(t *testing.T) {
 // Positive-path CostDrift test using mockEnricher
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// enrichCostDrift — mid-month CreatedAt scenarios
+// ---------------------------------------------------------------------------
+
+func TestEnrichCostDrift_MidMonthCreatedAt(t *testing.T) {
+	// Resource created on Feb 13 of a 28-day month, dateRange ends Feb 20.
+	// actualMTD = 0.42 (7 days of billing), projected = 1.60.
+	//
+	// Without CreatedAt fix: denominator = 20, extrapolated = 0.42 * (28/20) = 0.588,
+	//   drift = (0.588 - 1.60) / 1.60 = -63.25% → false positive!
+	// With fix: denominator = 7 (days since creation), extrapolated = 0.42 * (28/7) = 1.68,
+	//   drift = (1.68 - 1.60) / 1.60 = +5.0% → below threshold, no drift warning.
+	refTime := time.Date(2025, 2, 20, 12, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2025, 2, 13, 10, 0, 0, 0, time.UTC)
+	dateRange := DateRange{
+		Start: time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+		End:   refTime,
+	}
+
+	row := OverviewRow{
+		URN:           "urn:pulumi:prod::app::aws:ebs:Volume::data",
+		Type:          "aws:ebs:Volume",
+		Status:        StatusActive,
+		ActualCost:    &ActualCostData{MTDCost: 0.42, Currency: "USD", Period: dateRange},
+		ProjectedCost: &ProjectedCostData{MonthlyCost: 1.60, Currency: "USD"},
+		CreatedAt:     &createdAt,
+	}
+
+	enrichCostDrift(&row, dateRange)
+
+	// With correct denominator (7 days), extrapolated = 0.42 * (28/7) = 1.68
+	// drift = (1.68 - 1.60) / 1.60 = 5.0% — below 10% threshold.
+	assert.Nil(t, row.CostDrift, "mid-month resource should not trigger false-positive drift")
+}
+
+func TestEnrichCostDrift_NilCreatedAt_UsesExistingBehavior(t *testing.T) {
+	// When CreatedAt is nil, enrichCostDrift should use dayOfMonth as before.
+	refTime := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	dateRange := DateRange{
+		Start: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		End:   refTime,
+	}
+
+	row := OverviewRow{
+		URN:           "urn:pulumi:prod::app::aws:ec2:Instance::web",
+		Type:          "aws:ec2:Instance",
+		Status:        StatusActive,
+		ActualCost:    &ActualCostData{MTDCost: 50.0, Currency: "USD", Period: dateRange},
+		ProjectedCost: &ProjectedCostData{MonthlyCost: 200.0, Currency: "USD"},
+		CreatedAt:     nil,
+	}
+
+	enrichCostDrift(&row, dateRange)
+
+	// dayOfMonth=15, daysInMonth=30 → extrapolated = 50 * (30/15) = 100
+	// drift = (100 - 200) / 200 = -50% → exceeds threshold.
+	require.NotNil(t, row.CostDrift)
+	assert.InDelta(t, -50.0, row.CostDrift.PercentDrift, 1.0)
+	assert.True(t, row.CostDrift.IsWarning)
+}
+
+func TestEnrichCostDrift_CreatedAtBeforeDateRangeStart(t *testing.T) {
+	// When CreatedAt is before dateRange.Start, treat as full-month resource.
+	refTime := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2025, 5, 1, 0, 0, 0, 0, time.UTC) // Created last month
+	dateRange := DateRange{
+		Start: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		End:   refTime,
+	}
+
+	row := OverviewRow{
+		URN:           "urn:pulumi:prod::app::aws:ec2:Instance::old",
+		Type:          "aws:ec2:Instance",
+		Status:        StatusActive,
+		ActualCost:    &ActualCostData{MTDCost: 50.0, Currency: "USD", Period: dateRange},
+		ProjectedCost: &ProjectedCostData{MonthlyCost: 200.0, Currency: "USD"},
+		CreatedAt:     &createdAt,
+	}
+
+	enrichCostDrift(&row, dateRange)
+
+	// CreatedAt is before dateRange.Start → uses dayOfMonth=15 as denominator.
+	// Same as nil CreatedAt case: extrapolated = 100, drift = -50%.
+	require.NotNil(t, row.CostDrift)
+	assert.InDelta(t, -50.0, row.CostDrift.PercentDrift, 1.0)
+	assert.True(t, row.CostDrift.IsWarning)
+}
+
+func TestEnrichCostDrift_CreatedAtWithinFirst2Days_SuppressesDrift(t *testing.T) {
+	// When a resource was created less than driftMinDay (3) days ago,
+	// drift should be suppressed entirely.
+	refTime := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2025, 6, 14, 10, 0, 0, 0, time.UTC) // Created yesterday
+	dateRange := DateRange{
+		Start: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		End:   refTime,
+	}
+
+	row := OverviewRow{
+		URN:           "urn:pulumi:prod::app::aws:ec2:Instance::brand-new",
+		Type:          "aws:ec2:Instance",
+		Status:        StatusActive,
+		ActualCost:    &ActualCostData{MTDCost: 5.0, Currency: "USD", Period: dateRange},
+		ProjectedCost: &ProjectedCostData{MonthlyCost: 100.0, Currency: "USD"},
+		CreatedAt:     &createdAt,
+	}
+
+	enrichCostDrift(&row, dateRange)
+
+	// daysSinceCreation = 2 (< driftMinDay=3) → drift suppressed.
+	assert.Nil(t, row.CostDrift, "drift must be suppressed for resources with < 3 days of data")
+}
+
+func TestEnrichCostDrift_CreatedAtExactlyOnDateRangeStart(t *testing.T) {
+	// When CreatedAt equals dateRange.Start exactly, After() returns false,
+	// so it should use the standard dayOfMonth denominator.
+	refTime := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC) // Exactly on window start
+	dateRange := DateRange{
+		Start: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		End:   refTime,
+	}
+
+	row := OverviewRow{
+		URN:           "urn:pulumi:prod::app::aws:ec2:Instance::start-of-month",
+		Type:          "aws:ec2:Instance",
+		Status:        StatusActive,
+		ActualCost:    &ActualCostData{MTDCost: 50.0, Currency: "USD", Period: dateRange},
+		ProjectedCost: &ProjectedCostData{MonthlyCost: 200.0, Currency: "USD"},
+		CreatedAt:     &createdAt,
+	}
+
+	enrichCostDrift(&row, dateRange)
+
+	// CreatedAt == dateRange.Start → After() is false → uses dayOfMonth=15.
+	// Same as nil case: extrapolated = 100, drift = -50%.
+	require.NotNil(t, row.CostDrift)
+	assert.InDelta(t, -50.0, row.CostDrift.PercentDrift, 1.0)
+}
+
+func TestEnrichCostDrift_MidMonthCreatedAt_LargeDrift(t *testing.T) {
+	// A mid-month resource with genuinely high drift should still report it.
+	// Resource created day 10 00:00, refTime day 20 00:00 → daysSinceCreation = 11.
+	refTime := time.Date(2025, 6, 20, 0, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2025, 6, 10, 0, 0, 0, 0, time.UTC)
+	dateRange := DateRange{
+		Start: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		End:   refTime,
+	}
+
+	row := OverviewRow{
+		URN:           "urn:pulumi:prod::app::aws:ec2:Instance::expensive",
+		Type:          "aws:ec2:Instance",
+		Status:        StatusActive,
+		ActualCost:    &ActualCostData{MTDCost: 100.0, Currency: "USD", Period: dateRange},
+		ProjectedCost: &ProjectedCostData{MonthlyCost: 50.0, Currency: "USD"},
+		CreatedAt:     &createdAt,
+	}
+
+	enrichCostDrift(&row, dateRange)
+
+	// daysSinceCreation = int(10*24/24) + 1 = 11, daysInMonth = 30
+	// extrapolated = 100 * (30/11) ≈ 272.73
+	// drift = (272.73 - 50) / 50 * 100 ≈ 445.45% → genuine drift, should be reported.
+	require.NotNil(t, row.CostDrift, "genuine drift should still be reported for mid-month resources")
+	assert.InDelta(t, 445.5, row.CostDrift.PercentDrift, 1.0)
+	assert.True(t, row.CostDrift.IsWarning)
+}
+
+func TestEnrichCostDrift_CreatedAtEqualsRefTime_SuppressesDrift(t *testing.T) {
+	// When CreatedAt equals refTime exactly, Before(refTime) is false,
+	// so the mid-month path is skipped and dayOfMonth is used as denominator.
+	// However, daysSinceCreation would be 1 (< driftMinDay), so even if the
+	// guard were entered, drift would be suppressed. This test verifies the
+	// guard clause prevents entry entirely.
+	refTime := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	createdAt := refTime // exactly at the reference time
+	dateRange := DateRange{
+		Start: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		End:   refTime,
+	}
+
+	row := OverviewRow{
+		URN:           "urn:pulumi:prod::app::aws:ec2:Instance::just-created",
+		Type:          "aws:ec2:Instance",
+		Status:        StatusActive,
+		ActualCost:    &ActualCostData{MTDCost: 50.0, Currency: "USD", Period: dateRange},
+		ProjectedCost: &ProjectedCostData{MonthlyCost: 200.0, Currency: "USD"},
+		CreatedAt:     &createdAt,
+	}
+
+	enrichCostDrift(&row, dateRange)
+
+	// CreatedAt == refTime → Before(refTime) is false → uses dayOfMonth=15.
+	// extrapolated = 50 * (30/15) = 100, drift = (100-200)/200 = -50%.
+	require.NotNil(t, row.CostDrift)
+	assert.InDelta(t, -50.0, row.CostDrift.PercentDrift, 1.0)
+}
+
+func TestEnrichCostDrift_FutureCreatedAt_UseDayOfMonth(t *testing.T) {
+	// When CreatedAt is in the future (after refTime), the mid-month path
+	// must not be entered. This guards against clock skew or corrupted state.
+	refTime := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2025, 6, 20, 0, 0, 0, 0, time.UTC) // future
+	dateRange := DateRange{
+		Start: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		End:   refTime,
+	}
+
+	row := OverviewRow{
+		URN:           "urn:pulumi:prod::app::aws:ec2:Instance::future",
+		Type:          "aws:ec2:Instance",
+		Status:        StatusActive,
+		ActualCost:    &ActualCostData{MTDCost: 50.0, Currency: "USD", Period: dateRange},
+		ProjectedCost: &ProjectedCostData{MonthlyCost: 200.0, Currency: "USD"},
+		CreatedAt:     &createdAt,
+	}
+
+	enrichCostDrift(&row, dateRange)
+
+	// CreatedAt is after refTime → Before(refTime) is false → uses dayOfMonth=15.
+	// extrapolated = 50 * (30/15) = 100, drift = -50%.
+	require.NotNil(t, row.CostDrift)
+	assert.InDelta(t, -50.0, row.CostDrift.PercentDrift, 1.0)
+}
+
 func TestEnrichOverviewRow_CostDrift_ComputedOnCompletion(t *testing.T) {
 	// Verify that CostDrift is computed when both actual and projected costs
 	// are returned by the engine. The mock returns deterministic values so

--- a/internal/engine/overview_merge.go
+++ b/internal/engine/overview_merge.go
@@ -56,6 +56,7 @@ func stateResourceToRow(res StateResource) OverviewRow {
 		ResourceID: res.ID,
 		Status:     StatusActive,
 		Properties: res.Properties,
+		CreatedAt:  res.CreatedAt,
 	}
 }
 

--- a/internal/engine/overview_merge_test.go
+++ b/internal/engine/overview_merge_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -381,6 +382,56 @@ func TestNewRowsFromState(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMergeResourcesForOverview_CreatedAtPreserved(t *testing.T) {
+	ctx := context.Background()
+	createdAt := time.Date(2025, 2, 13, 10, 0, 0, 0, time.UTC)
+
+	rows, err := MergeResourcesForOverview(ctx,
+		[]StateResource{
+			{
+				URN:       "urn:a",
+				Type:      "aws:ec2:Instance",
+				ID:        "i-abc123",
+				Custom:    true,
+				CreatedAt: &createdAt,
+			},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.NotNil(t, rows[0].CreatedAt)
+	assert.Equal(t, createdAt, *rows[0].CreatedAt)
+}
+
+func TestMergeResourcesForOverview_NilCreatedAtOK(t *testing.T) {
+	ctx := context.Background()
+
+	rows, err := MergeResourcesForOverview(ctx,
+		[]StateResource{
+			{URN: "urn:a", Type: "aws:ec2:Instance", Custom: true, CreatedAt: nil},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Nil(t, rows[0].CreatedAt)
+}
+
+func TestNewRowsFromState_CreatedAtPreserved(t *testing.T) {
+	ctx := context.Background()
+	createdAt := time.Date(2025, 6, 10, 0, 0, 0, 0, time.UTC)
+
+	rows := NewRowsFromState(ctx, []StateResource{
+		{URN: "urn:a", Type: "aws:ec2:Instance", Custom: true, CreatedAt: &createdAt},
+		{URN: "urn:b", Type: "aws:s3:Bucket", Custom: true, CreatedAt: nil},
+	})
+	require.Len(t, rows, 2)
+	require.NotNil(t, rows[0].CreatedAt)
+	assert.Equal(t, createdAt, *rows[0].CreatedAt)
+	assert.Nil(t, rows[1].CreatedAt)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/overview_types.go
+++ b/internal/engine/overview_types.go
@@ -306,6 +306,10 @@ type OverviewRow struct {
 	Recommendations []Recommendation       `json:"recommendations,omitempty"`
 	CostDrift       *CostDriftData         `json:"costDrift,omitempty"`
 	Error           *OverviewRowError      `json:"error,omitempty"`
+	// CreatedAt tracks when the resource was first added to Pulumi state.
+	// Used by enrichCostDrift to correct extrapolation for mid-month resources.
+	// Nil for resources from Pulumi < v3.60.0 or plan-only resources.
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
 }
 
 // Validate checks that the OverviewRow fields are well-formed. It validates
@@ -426,6 +430,11 @@ type StateResource struct {
 	ID         string                 `json:"id,omitempty"`
 	Custom     bool                   `json:"custom,omitempty"`
 	Properties map[string]interface{} `json:"properties,omitempty"`
+	// CreatedAt tracks when the resource was first added to Pulumi state.
+	// Available since Pulumi v3.60.0; nil for older state files.
+	// JSON key is "createdAt" (not "created" as in the Pulumi state format);
+	// conversion happens in cli.convertStateResources.
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
 }
 
 // PlanStep represents a step from a Pulumi plan for overview merging.


### PR DESCRIPTION
## Summary

- Propagate Pulumi's `Created` timestamp through the overview pipeline so `enrichCostDrift` knows when a resource was first added to state
- Use `daysSinceCreation` as the extrapolation denominator when the resource was created after the billing window start, preventing false-positive drift from partial billing periods
- Suppress drift entirely for resources with fewer than 3 days of data (consistent with existing `driftMinDay` guard)
- Nil-safe throughout: older Pulumi states without timestamps fall back to the existing `dayOfMonth` logic unchanged

## Test plan

- [x] `TestEnrichCostDrift_MidMonthCreatedAt` — exact issue scenario (EBS volume created Feb 13, checked Feb 20, no false drift)
- [x] `TestEnrichCostDrift_NilCreatedAt_UsesExistingBehavior`
- [x] `TestEnrichCostDrift_CreatedAtBeforeDateRangeStart`
- [x] `TestEnrichCostDrift_CreatedAtWithinFirst2Days_SuppressesDrift`
- [x] `TestEnrichCostDrift_CreatedAtExactlyOnDateRangeStart`
- [x] `TestEnrichCostDrift_MidMonthCreatedAt_LargeDrift` — genuine drift still reported
- [x] Merge and state-only path propagation tests
- [x] `convertStateResources` round-trip tests
- [x] `make test` passes
- [x] `make lint` passes with zero issues

## Changes

### Modified files

- `internal/engine/overview_types.go` — Add `CreatedAt *time.Time` to `StateResource` and `OverviewRow`
- `internal/cli/overview.go` — Copy `r.Created` in `convertStateResources()`
- `internal/engine/overview_merge.go` — Propagate `CreatedAt` in `stateResourceToRow()`
- `internal/engine/overview_enrich.go` — Use `daysSinceCreation` denominator in `enrichCostDrift()` for mid-month resources
- `internal/engine/overview_enrich_test.go` — 6 new drift tests covering mid-month, nil, boundary, and suppression cases
- `internal/engine/overview_merge_test.go` — 3 new tests for `CreatedAt` propagation through merge and state paths
- `internal/cli/overview_phase_internal_test.go` — 2 new tests for `convertStateResources` round-trip

Closes #760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resources now record CreatedAt timestamps to capture when they were first created.
  * Cost-drift calculations now consider resource creation timing to avoid false-positive warnings for mid-period creations.

* **Tests**
  * Added extensive tests covering CreatedAt propagation and cost-drift behavior across varied creation-time scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->