### PR TITLE
feat(cli): add short flags (-s, -f, -a) to overview command

### DIFF
--- a/internal/cli/overview.go
+++ b/internal/cli/overview.go
@@ -89,13 +89,13 @@ instead of running Pulumi CLI commands.`,
 
 	cmd.Flags().StringVar(&params.pulumiJSON, "pulumi-json", "", "path to Pulumi preview JSON")
 	cmd.Flags().StringVar(&params.pulumiState, "pulumi-state", "", "path to Pulumi state JSON")
-	cmd.Flags().StringVar(&params.stack, "stack", "",
+	cmd.Flags().StringVarP(&params.stack, "stack", "s", "",
 		"Pulumi stack name for auto-detection (ignored with --pulumi-state/--pulumi-json)")
 	cmd.Flags().StringVar(&params.fromStr, "from", "", "start date (YYYY-MM-DD or RFC3339)")
 	cmd.Flags().StringVar(&params.toStr, "to", "", "end date (YYYY-MM-DD or RFC3339, defaults to now)")
-	cmd.Flags().StringVar(&params.adapter, "adapter", "", "restrict to a specific adapter plugin")
+	cmd.Flags().StringVarP(&params.adapter, "adapter", "a", "", "restrict to a specific adapter plugin")
 	cmd.Flags().StringVar(&params.output, "output", "table", "output format (table, json, ndjson)")
-	cmd.Flags().StringSliceVar(&params.filter, "filter", nil, "resource filters")
+	cmd.Flags().StringSliceVarP(&params.filter, "filter", "f", nil, "resource filters")
 	cmd.Flags().BoolVar(&params.plain, "plain", false, "force non-interactive plain text output")
 	cmd.Flags().BoolVarP(&params.yes, "yes", "y", false, "skip confirmation prompts")
 	cmd.Flags().BoolVar(&params.noPagination, "no-pagination", false, "disable pagination (plain mode only)")

--- a/internal/cli/overview_test.go
+++ b/internal/cli/overview_test.go
@@ -267,6 +267,25 @@ func TestNewOverviewCmd_YesShortFlag(t *testing.T) {
 	assert.Equal(t, "y", yesFlag.Shorthand)
 }
 
+func TestNewOverviewCmd_ShortFlags(t *testing.T) {
+	cmd := cli.NewOverviewCmd()
+
+	tests := []struct {
+		long  string
+		short string
+	}{
+		{"stack", "s"},
+		{"filter", "f"},
+		{"adapter", "a"},
+	}
+
+	for _, tt := range tests {
+		flag := cmd.Flags().Lookup(tt.long)
+		require.NotNil(t, flag, "--%s flag should be registered", tt.long)
+		assert.Equal(t, tt.short, flag.Shorthand, "--%s should have short flag -%s", tt.long, tt.short)
+	}
+}
+
 // T013: Budget flag registration and behavior on overview command
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `-s` for `--stack`, `-f` for `--filter`, `-a` for `--adapter` on the overview command, matching the original spec from #578
- Uses Cobra's `StringVarP`/`StringSliceVarP` pattern consistent with the existing `-y` short flag for `--yes`
- No flag conflicts with root or parent command persistent flags

## Test plan

- [x] `TestNewOverviewCmd_ShortFlags` verifies all three short flags
- [x] `TestNewOverviewCmd_HelpFlag` continues to pass
- [x] `make test` passes
- [x] `make lint` passes with zero issues

## Changes

### Modified files

- `internal/cli/overview.go` - Change `StringVar` to `StringVarP` and `StringSliceVar` to `StringSliceVarP` for stack, adapter, filter flags
- `internal/cli/overview_test.go` - Add table-driven test for short flag registration

Closes #644