### PR TITLE
feat(router): add batchcost feature to capability routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,6 +455,7 @@ on projected costs. The `p` key triggers on-demand preview; when it completes,
 
 ## Recent Changes
 
+- 605-batch-cost-capability: Added batch cost capability to router feature mapping
 - 604-charm-v2-upgrade: Added Go 1.25.8 (see `go.mod`)
 
 ## Active Technologies
@@ -463,4 +464,5 @@ on projected costs. The `p` key triggers on-demand preview; when it completes,
 - Bubble Tea v2 (`charm.land/bubbletea/v2 v2.0.0`) (604-charm-v2-upgrade)
 - Bubbles v2 (`charm.land/bubbles/v2 v2.0.0`) (604-charm-v2-upgrade)
 - Lip Gloss v2 (`charm.land/lipgloss/v2 v2.0.0`) (604-charm-v2-upgrade)
+- finfocus-spec v0.5.7+ with BATCH_COST capability (605-batch-cost-capability)
 - CLI commands using Cobra, tabwriter, and Viper for config parsing

--- a/internal/router/features.go
+++ b/internal/router/features.go
@@ -29,10 +29,13 @@ const (
 
 	// FeatureBudgets enables budget tracking and alerts.
 	FeatureBudgets Feature = "Budgets"
+
+	// FeatureBatchCost enables batch cost queries across multiple resources.
+	FeatureBatchCost Feature = "BatchCost"
 )
 
 // ValidFeatures returns all supported Feature values (ProjectedCosts, ActualCosts,
-// Recommendations, Carbon, DryRun, Budgets).
+// Recommendations, Carbon, DryRun, Budgets, BatchCost).
 func ValidFeatures() []Feature {
 	return []Feature{
 		FeatureProjectedCosts,
@@ -41,6 +44,7 @@ func ValidFeatures() []Feature {
 		FeatureCarbon,
 		FeatureDryRun,
 		FeatureBudgets,
+		FeatureBatchCost,
 	}
 }
 
@@ -105,6 +109,7 @@ var methodToFeature = map[string]Feature{
 	"GetBudgets":          FeatureBudgets,
 	"GetBudgetHealth":     FeatureBudgets,
 	"EvaluateBudgetAlert": FeatureBudgets,
+	"BatchCost":           FeatureBatchCost,
 }
 
 // FeatureFromMethod returns the Feature corresponding to a gRPC method name.

--- a/internal/router/features_test.go
+++ b/internal/router/features_test.go
@@ -20,6 +20,7 @@ func TestIsValidFeature(t *testing.T) {
 		{"Carbon", "Carbon", true},
 		{"DryRun", "DryRun", true},
 		{"Budgets", "Budgets", true},
+		{"BatchCost", "BatchCost", true},
 
 		// Invalid features (case-sensitive)
 		{"lowercase projected", "projectedcosts", false},
@@ -43,7 +44,7 @@ func TestIsValidFeature(t *testing.T) {
 func TestValidFeatures(t *testing.T) {
 	features := ValidFeatures()
 
-	require.Len(t, features, 6, "should have 6 valid features")
+	require.Len(t, features, 7, "should have 7 valid features")
 
 	expected := []Feature{
 		FeatureProjectedCosts,
@@ -52,6 +53,7 @@ func TestValidFeatures(t *testing.T) {
 		FeatureCarbon,
 		FeatureDryRun,
 		FeatureBudgets,
+		FeatureBatchCost,
 	}
 
 	assert.Equal(t, expected, features)
@@ -60,7 +62,7 @@ func TestValidFeatures(t *testing.T) {
 func TestValidFeatureNames(t *testing.T) {
 	names := ValidFeatureNames()
 
-	require.Len(t, names, 6)
+	require.Len(t, names, 7)
 
 	expected := []string{
 		"ProjectedCosts",
@@ -69,6 +71,7 @@ func TestValidFeatureNames(t *testing.T) {
 		"Carbon",
 		"DryRun",
 		"Budgets",
+		"BatchCost",
 	}
 
 	assert.Equal(t, expected, names)
@@ -115,6 +118,7 @@ func TestFeatureFromMethod(t *testing.T) {
 		{"GetBudgets", "GetBudgets", FeatureBudgets, true},
 		{"GetBudgetHealth", "GetBudgetHealth", FeatureBudgets, true},
 		{"EvaluateBudgetAlert", "EvaluateBudgetAlert", FeatureBudgets, true},
+		{"BatchCost", "BatchCost", FeatureBatchCost, true},
 
 		// Invalid method mappings
 		{"empty", "", "", false},

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -493,6 +493,8 @@ func capabilityEnumFromFeature(feature Feature) (pbc.PluginCapability, bool) {
 		return pbc.PluginCapability_PLUGIN_CAPABILITY_DRY_RUN, true
 	case FeatureBudgets:
 		return pbc.PluginCapability_PLUGIN_CAPABILITY_BUDGETS, true
+	case FeatureBatchCost:
+		return pbc.PluginCapability_PLUGIN_CAPABILITY_BATCH_COST, true
 	default:
 		return pbc.PluginCapability_PLUGIN_CAPABILITY_UNSPECIFIED, false
 	}
@@ -512,6 +514,8 @@ func capabilityEnumFromString(capability string) (pbc.PluginCapability, bool) {
 		return pbc.PluginCapability_PLUGIN_CAPABILITY_DRY_RUN, true
 	case "Budgets", "budgets":
 		return pbc.PluginCapability_PLUGIN_CAPABILITY_BUDGETS, true
+	case "BatchCost", "batch_cost":
+		return pbc.PluginCapability_PLUGIN_CAPABILITY_BATCH_COST, true
 	default:
 		return pbc.PluginCapability_PLUGIN_CAPABILITY_UNSPECIFIED, false
 	}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 	"github.com/rshade/finfocus/internal/config"
 	"github.com/rshade/finfocus/internal/engine"
 	"github.com/rshade/finfocus/internal/pluginhost"
@@ -472,6 +473,30 @@ func TestSelectPlugins_InternalPulumiTypeFiltering(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			matches := router.SelectPlugins(ctx, tt.resource, "ProjectedCosts")
 			assert.Len(t, matches, tt.wantMatches)
+		})
+	}
+}
+
+func TestCapabilityEnumFromFeature_BatchCost(t *testing.T) {
+	capability, ok := capabilityEnumFromFeature(FeatureBatchCost)
+	require.True(t, ok)
+	assert.Equal(t, pbc.PluginCapability_PLUGIN_CAPABILITY_BATCH_COST, capability)
+}
+
+func TestCapabilityEnumFromString_BatchCost(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"PascalCase", "BatchCost"},
+		{"snake_case", "batch_cost"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capability, ok := capabilityEnumFromString(tt.input)
+			require.True(t, ok)
+			assert.Equal(t, pbc.PluginCapability_PLUGIN_CAPABILITY_BATCH_COST, capability)
 		})
 	}
 }

--- a/specs/605-batch-cost-capability/checklists/requirements.md
+++ b/specs/605-batch-cost-capability/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Recognize Batch Cost Capability
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- This is a small, well-scoped feature with clear boundaries defined by the upstream issue.

--- a/specs/605-batch-cost-capability/data-model.md
+++ b/specs/605-batch-cost-capability/data-model.md
@@ -1,0 +1,43 @@
+# Data Model: Batch Cost Capability
+
+**Date**: 2026-03-03
+**Feature**: 605-batch-cost-capability
+
+## Overview
+
+No new data entities are introduced. This feature adds a single constant value
+to the existing `Feature` type and maps it through existing capability
+resolution functions.
+
+## Existing Entities (unchanged)
+
+### Feature (type alias: `string`)
+
+- **Location**: `internal/router/features.go`
+- **Purpose**: Represents a plugin capability type used for routing decisions
+- **Current values**: ProjectedCosts, ActualCosts, Recommendations, Carbon,
+  DryRun, Budgets
+- **Addition**: `BatchCost` — represents the batch cost query capability
+
+### PluginCapability (proto enum)
+
+- **Location**: finfocus-spec (external dependency)
+- **Purpose**: Wire-format enum for plugin capability advertisement
+- **Relevant value**: `PLUGIN_CAPABILITY_BATCH_COST = 12`
+- **String form**: `"batch_cost"` (from `ConvertCapabilities()`)
+
+### PluginMetadata (struct)
+
+- **Location**: `internal/proto/types.go`
+- **Purpose**: Holds plugin info including capabilities string slice
+- **Impact**: No changes — `Capabilities []string` already carries `"batch_cost"`
+  when converted from proto
+
+## Relationships
+
+```text
+Proto Enum (BATCH_COST=12) → ConvertCapabilities() → "batch_cost" string
+                                                          ↓
+Feature constant (BatchCost) ← capabilityEnumFromString() ← normalizedCapabilitySet()
+                            → capabilityEnumFromFeature() → Proto Enum (for matching)
+```

--- a/specs/605-batch-cost-capability/plan.md
+++ b/specs/605-batch-cost-capability/plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan: Recognize Batch Cost Capability
+
+**Branch**: `605-batch-cost-capability` | **Date**: 2026-03-03 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/605-batch-cost-capability/spec.md`
+
+## Summary
+
+Add `FeatureBatchCost` to the router's feature/capability mapping system so the
+router can detect and match plugins that support batch cost queries. The
+capability string conversion (`ConvertCapabilities()` in pluginhost) and plugin
+list display already work — only the router feature constants and mapping
+functions need updating.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.7
+**Primary Dependencies**: finfocus-spec v0.5.7+ (proto definitions with
+`PLUGIN_CAPABILITY_BATCH_COST = 12`)
+**Storage**: N/A
+**Testing**: `go test` with testify (assert/require)
+**Target Platform**: Linux, macOS, Windows (amd64, arm64)
+**Project Type**: Single Go project (CLI tool)
+**Performance Goals**: N/A (additive constant mapping, no runtime impact)
+**Constraints**: None
+**Scale/Scope**: ~4 files modified, ~30 lines of production code, ~40 lines of tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **Plugin-First Architecture**: This is orchestration logic in Core that
+  recognizes a plugin-reported capability. No direct provider integration.
+- [x] **Test-Driven Development**: Tests planned for all modified functions.
+  No TUI changes (no golden files needed). 80% coverage maintained.
+- [x] **Cross-Platform Compatibility**: Pure Go code with no platform-specific
+  logic. Compiles on all targets.
+- [x] **Documentation Integrity**: Godoc comments on new constant. No
+  README/docs changes needed (capability list is dynamic from code).
+- [x] **Protocol Stability**: Additive only — new capability enum consumed
+  from upstream spec. No breaking changes.
+- [x] **Implementation Completeness**: Full implementation, no stubs or TODOs.
+- [x] **Quality Gates**: `make test && make lint` required before completion.
+- [x] **Multi-Repo Coordination**: Blocked by #844 (finfocus-spec v0.5.7
+  upgrade). Related to #846 (BatchCost RPC consumer).
+
+**Violations Requiring Justification**: None
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/605-batch-cost-capability/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (minimal — no data model changes)
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+internal/
+├── router/
+│   ├── features.go          # Add FeatureBatchCost constant, update ValidFeatures(),
+│   │                        #   add methodToFeature mapping
+│   ├── features_test.go     # Update tests for new feature constant
+│   ├── router.go            # Add cases in capabilityEnumFromFeature(),
+│   │                        #   capabilityEnumFromString()
+│   └── router_test.go       # Add tests for new capability mapping
+└── pluginhost/
+    └── host.go              # Already handles BATCH_COST (no changes needed)
+```
+
+**Structure Decision**: Existing Go project layout. Changes are confined to the
+`internal/router/` package (feature constants and capability mapping). The
+`internal/pluginhost/host.go` `ConvertCapabilities()` function already maps
+`PLUGIN_CAPABILITY_BATCH_COST` → `"batch_cost"` and requires no changes.

--- a/specs/605-batch-cost-capability/quickstart.md
+++ b/specs/605-batch-cost-capability/quickstart.md
@@ -1,0 +1,60 @@
+# Quickstart: Batch Cost Capability
+
+**Date**: 2026-03-03
+**Feature**: 605-batch-cost-capability
+
+## Prerequisites
+
+- finfocus-spec v0.5.7+ dependency upgraded (issue #844)
+- Go 1.25.7+
+
+## Implementation Steps
+
+### 1. Add Feature Constant
+
+In `internal/router/features.go`, add the `FeatureBatchCost` constant alongside
+existing features and update `ValidFeatures()`, `methodToFeature`.
+
+### 2. Add Router Mapping Cases
+
+In `internal/router/router.go`, add `FeatureBatchCost` cases to:
+
+- `capabilityEnumFromFeature()` — map Feature → proto enum
+- `capabilityEnumFromString()` — map "BatchCost"/"batch_cost" → proto enum
+
+### 3. Update Tests
+
+In `internal/router/features_test.go`:
+
+- Update `TestValidFeatures` count from 6 → 7
+- Add `FeatureBatchCost` to expected slice
+- Add `"BatchCost"` test case to `TestIsValidFeature`
+- Add `"BatchCost"` method mapping to `TestFeatureFromMethod`
+
+In `internal/router/router_test.go`:
+
+- Add test cases for `capabilityEnumFromFeature` with BatchCost
+- Add test cases for `capabilityEnumFromString` with "BatchCost" and
+  "batch_cost"
+
+### 4. Verify
+
+```bash
+make test
+make lint
+```
+
+## Verification
+
+After implementation, verify with:
+
+```bash
+# Unit tests pass
+go test -v ./internal/router/...
+
+# All tests pass
+make test
+
+# Linting passes
+make lint
+```

--- a/specs/605-batch-cost-capability/research.md
+++ b/specs/605-batch-cost-capability/research.md
@@ -1,0 +1,96 @@
+# Research: Batch Cost Capability
+
+**Date**: 2026-03-03
+**Feature**: 605-batch-cost-capability
+
+## Research Questions
+
+### RQ-1: Where does capability string conversion happen?
+
+**Decision**: `ConvertCapabilities()` in `internal/pluginhost/host.go:164-206`
+already handles `PLUGIN_CAPABILITY_BATCH_COST` → `"batch_cost"` (line 194-195).
+No changes needed.
+
+**Rationale**: The function was updated when finfocus-spec v0.5.7 was integrated
+(or is ready for it — the enum case already exists in the switch statement).
+
+**Alternatives considered**: None — single canonical location.
+
+### RQ-2: Where are Feature constants defined?
+
+**Decision**: `internal/router/features.go` defines Feature type and constants
+(lines 14-32). Currently has 6 features: ProjectedCosts, ActualCosts,
+Recommendations, Carbon, DryRun, Budgets. `FeatureBatchCost` must be added here.
+
+**Rationale**: Follows the established pattern — one constant per plugin
+capability that the router can match against.
+
+**Alternatives considered**: None — established pattern.
+
+### RQ-3: What functions need the new capability case?
+
+**Decision**: Three functions in `internal/router/router.go` need updating:
+
+1. `capabilityEnumFromFeature()` (line 482-499) — maps Feature → proto enum
+2. `capabilityEnumFromString()` (line 501-518) — maps string → proto enum
+   (both PascalCase "BatchCost" and snake_case "batch_cost")
+
+Additionally in `internal/router/features.go`:
+
+1. `ValidFeatures()` (line 36-45) — return slice of all features
+2. `methodToFeature` map (line 98-108) — maps gRPC method → Feature
+   (add "BatchCost" → FeatureBatchCost)
+
+**Rationale**: All these follow the exact same pattern as existing capabilities
+(Budgets was the most recent addition — follow that pattern).
+
+**Alternatives considered**: None — must match all existing patterns.
+
+### RQ-4: Does plugin list display need changes?
+
+**Decision**: No. `internal/cli/plugin_list.go` uses `formatCapabilities()`
+which joins whatever strings are in the plugin's `Metadata.Capabilities` slice.
+Since `ConvertCapabilities()` already produces `"batch_cost"`, it will appear
+automatically.
+
+**Rationale**: The display is generic — it doesn't have a hardcoded list of
+known capabilities.
+
+**Alternatives considered**: None — display is already capability-agnostic.
+
+### RQ-5: What is the gRPC method name for BatchCost?
+
+**Decision**: `"BatchCost"` — confirmed from `internal/proto/adapter_test.go`
+(line 3132) which defines `BatchCost()` method on the mock client.
+
+**Rationale**: Follows proto service naming convention (PascalCase method name).
+
+**Alternatives considered**: None — defined by proto.
+
+### RQ-6: Does `config routes test` need changes?
+
+**Decision**: No explicit changes needed. The `config routes test` command
+iterates over `router.ValidFeatureNames()` (lines 307, 366, 404 of
+`config_routes.go`). Once `FeatureBatchCost` is added to `ValidFeatures()`,
+it will automatically appear in route testing output.
+
+**Rationale**: The command dynamically pulls from `ValidFeatures()`.
+
+**Alternatives considered**: None — design is dynamic.
+
+## Summary
+
+This is a purely additive change to the router's feature mapping system.
+The pluginhost conversion and plugin list display already work. Only the
+router package needs updating to recognize BatchCost as a routable feature.
+
+Files requiring changes:
+
+| File | Change | Lines |
+|------|--------|-------|
+| `internal/router/features.go` | Add constant, update ValidFeatures(), add method mapping | ~8 lines |
+| `internal/router/router.go` | Add cases in 2 switch statements | ~6 lines |
+| `internal/router/features_test.go` | Update test expectations for 7 features | ~15 lines |
+| `internal/router/router_test.go` | Add test cases for new capability mapping | ~20 lines |
+
+Total: ~49 lines across 4 files.

--- a/specs/605-batch-cost-capability/spec.md
+++ b/specs/605-batch-cost-capability/spec.md
@@ -1,0 +1,121 @@
+# Feature Specification: Recognize Batch Cost Capability
+
+**Feature Branch**: `605-batch-cost-capability`
+**Created**: 2026-03-03
+**Status**: Draft
+**Input**: User description: "GitHub Issue #848 — Recognize PLUGIN_CAPABILITY_BATCH_COST in capability routing and plugin list"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View Batch Cost Capability in Plugin List (Priority: P1)
+
+As a FinFocus user managing multiple plugins, I want `plugin list` to display
+which plugins support batch cost queries so I can understand each plugin's
+capabilities and verify batch support is active.
+
+**Why this priority**: Users need visibility into plugin capabilities to
+understand what features are available. Without this, batch cost support is
+invisible and users cannot troubleshoot or verify plugin configuration.
+
+**Independent Test**: Can be fully tested by running `finfocus plugin list`
+with a plugin that reports batch cost capability and verifying the output
+includes the "BATCH_COST" label.
+
+**Acceptance Scenarios**:
+
+1. **Given** a plugin that reports batch cost capability, **When** the user
+   runs `finfocus plugin list`, **Then** "BATCH_COST" appears in the
+   capabilities column for that plugin.
+2. **Given** a plugin that reports batch cost capability, **When** the user
+   runs `finfocus plugin list --output json`, **Then** "BATCH_COST" appears
+   in the capabilities array for that plugin.
+3. **Given** a plugin that does NOT report batch cost capability, **When** the
+   user runs `finfocus plugin list`, **Then** "BATCH_COST" does NOT appear in
+   the capabilities column for that plugin.
+
+---
+
+### User Story 2 - Router Recognizes Batch Cost Capability (Priority: P2)
+
+As a FinFocus user with multiple plugins configured for the same resource
+types, I want the router to recognize which plugins support batch cost queries
+so that batch-capable plugins can be preferred when processing large resource
+sets.
+
+**Why this priority**: Routing awareness enables future optimization where
+batch-capable plugins handle bulk queries more efficiently. This is a
+foundation for batch cost processing but does not change current routing
+behavior.
+
+**Independent Test**: Can be tested by verifying the router detects batch cost
+capability from plugin metadata and makes it available for selection logic.
+
+**Acceptance Scenarios**:
+
+1. **Given** a plugin that reports batch cost capability, **When** the router
+   evaluates plugin capabilities, **Then** batch cost capability is detected
+   and available for routing decisions.
+2. **Given** two plugins matching the same resource type where one supports
+   batch cost and one does not, **When** the router selects a plugin, **Then**
+   both plugins remain valid candidates (batch cost is a hint, not a hard
+   filter).
+
+---
+
+### Edge Cases
+
+- What happens when a plugin reports an unknown or unrecognized capability
+  value? The system should handle it gracefully without crashing and display
+  the raw numeric value or skip it.
+- What happens when the upstream spec dependency has not been upgraded and the
+  batch cost enum value is not yet defined? The system should still function
+  correctly for all existing capabilities.
+- What happens when a plugin reports batch cost capability alongside all other
+  existing capabilities? All capabilities should display correctly without
+  truncation or formatting issues.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST recognize the batch cost capability value and map it
+  to the display name "BATCH_COST".
+- **FR-002**: The `plugin list` table output MUST include "BATCH_COST" in the
+  capabilities column for any plugin that reports this capability.
+- **FR-003**: The `plugin list --output json` output MUST include "BATCH_COST"
+  in the capabilities array for any plugin that reports this capability.
+- **FR-004**: The router MUST be able to detect whether a plugin supports
+  batch cost capability when evaluating plugin selection.
+- **FR-005**: The capability mapping MUST be consistent between table output,
+  JSON output, and router detection (single source of truth for the name).
+- **FR-006**: System MUST handle the batch cost capability value without
+  errors even if no plugins currently report it.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All existing plugin capabilities continue to display correctly
+  with no regressions in table or JSON output.
+- **SC-002**: "BATCH_COST" capability appears in plugin list output (both
+  table and JSON formats) when reported by a plugin.
+- **SC-003**: Router correctly identifies batch-cost-capable plugins without
+  altering existing plugin selection behavior or priority ordering.
+- **SC-004**: All unit tests pass and code passes linting validation
+  (`make test && make lint`).
+
+## Assumptions
+
+- The finfocus-spec dependency will be upgraded to v0.5.7 (issue #844) before
+  this feature is implemented, making the `PLUGIN_CAPABILITY_BATCH_COST = 12`
+  enum value available in generated code.
+- Batch cost capability is an optimization hint for routing, not a hard
+  requirement. Existing routing behavior remains unchanged for this feature.
+- The capability display name follows the existing convention of uppercase
+  snake case without the `PLUGIN_CAPABILITY_` prefix (e.g., "BATCH_COST").
+
+## Dependencies
+
+- **Blocked by**: Issue #844 (upgrade finfocus-spec to v0.5.7)
+- **Related to**: Issue #846 (BatchCost RPC consumer uses this capability for
+  detection)

--- a/specs/605-batch-cost-capability/tasks.md
+++ b/specs/605-batch-cost-capability/tasks.md
@@ -1,0 +1,119 @@
+# Tasks: Recognize Batch Cost Capability
+
+**Input**: Design documents from `/specs/605-batch-cost-capability/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Tests**: Per Constitution Principle II (Test-Driven Development), tests are
+MANDATORY and must be written BEFORE implementation. All code changes must
+maintain minimum 80% test coverage (95% for critical paths).
+
+**Completeness**: Per Constitution Principle VI (Implementation Completeness),
+all tasks MUST be fully implemented. Stub functions, placeholders, and TODO
+comments are strictly forbidden.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+## User Story 1 — Already Implemented
+
+> **US1 (Plugin List Display)** requires no new code. Research confirmed that
+> `ConvertCapabilities()` in `internal/pluginhost/host.go:194-195` already maps
+> `PLUGIN_CAPABILITY_BATCH_COST` → `"batch_cost"`, and `plugin list` display
+> is capability-agnostic. Existing test `TestConvertCapabilities` in
+> `internal/pluginhost/host_test.go` already covers batch\_cost. FR-001,
+> FR-002, FR-003 are satisfied by existing code.
+
+---
+
+## Phase 1: User Story 2 — Router Recognizes Batch Cost Capability (Priority: P2)
+
+**Goal**: Add `FeatureBatchCost` to the router's feature/capability mapping so
+the router can detect and match plugins that support batch cost queries.
+
+**Independent Test**: Run `go test -v -run TestBatchCost ./internal/router/...`
+and verify new feature constant is recognized, maps correctly to proto enum,
+and normalizes in both PascalCase and snake\_case forms.
+
+### Tests for User Story 2 (TDD — write first)
+
+- [X] T001 [P] [US2] Add `TestIsValidFeature` case for `"BatchCost"` and update `TestValidFeatures` count from 6 to 7 with `FeatureBatchCost` in expected slice in `internal/router/features_test.go`
+- [X] T002 [P] [US2] Add `TestFeatureFromMethod` case for `"BatchCost"` → `FeatureBatchCost` in `internal/router/features_test.go`
+- [X] T003 [P] [US2] Add test cases for `capabilityEnumFromFeature` (BatchCost → PLUGIN_CAPABILITY_BATCH_COST) and `capabilityEnumFromString` ("BatchCost" and "batch_cost") in `internal/router/router_test.go`
+
+### Implementation for User Story 2
+
+- [X] T004 [US2] Add `FeatureBatchCost Feature = "BatchCost"` constant with godoc, append to `ValidFeatures()` return slice, and add `"BatchCost": FeatureBatchCost` to `methodToFeature` map in `internal/router/features.go`
+- [X] T005 [US2] Add `case FeatureBatchCost` → `PLUGIN_CAPABILITY_BATCH_COST` in `capabilityEnumFromFeature()` and add `case "BatchCost", "batch_cost"` → `PLUGIN_CAPABILITY_BATCH_COST` in `capabilityEnumFromString()` in `internal/router/router.go`
+
+**Checkpoint**: Router recognizes BatchCost as a valid feature and correctly
+maps it between Feature constants, proto enums, and display strings.
+
+---
+
+## Phase 2: Validation
+
+**Purpose**: Verify all changes pass quality gates
+
+- [X] T006 Run `make test` to verify all unit tests pass with no regressions
+- [X] T007 Run `make lint` to verify linting passes
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (US2)**: No setup or foundational prerequisites — changes are
+  additive to existing router code
+- **Phase 2 (Validation)**: Depends on Phase 1 completion
+
+### Within Phase 1
+
+- T001, T002, T003 (tests) can run in parallel — different test functions
+- T004 must complete before T005 (T005 references the constant from T004)
+- T001+T002 target `features_test.go`, T003 targets `router_test.go`
+- Tests should be written first (TDD), then implementation (T004, T005)
+
+### Parallel Opportunities
+
+- T001, T002, T003 are all [P] — write all test cases in parallel
+- T004 and T005 are sequential (same dependency chain)
+
+---
+
+## Parallel Example: User Story 2
+
+```text
+# Write all tests in parallel (TDD):
+T001: Update TestIsValidFeature + TestValidFeatures in features_test.go
+T002: Add TestFeatureFromMethod case in features_test.go
+T003: Add capabilityEnum mapping tests in router_test.go
+
+# Then implement sequentially:
+T004: Add constant + ValidFeatures() + methodToFeature in features.go
+T005: Add switch cases in router.go
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (this feature is small enough for single delivery)
+
+1. Write tests (T001-T003) — verify they fail
+2. Implement (T004-T005) — verify tests pass
+3. Validate (T006-T007) — `make test && make lint`
+
+---
+
+## Notes
+
+- US1 requires zero code changes (already implemented in pluginhost)
+- All production changes are in `internal/router/` (2 files)
+- All test changes are in `internal/router/` (2 files)
+- Follow the `FeatureBudgets` pattern exactly — it was the most recent addition
+- The `sync.Once` cache in `validFeatureNameSet()` is initialized lazily, so
+  adding to `ValidFeatures()` is safe without any cache invalidation


### PR DESCRIPTION
## Summary

- Adds `FeatureBatchCost` constant and maps it through all capability resolution functions so the router can detect and route to plugins advertising `BATCH_COST` capability
- Follows the established `FeatureBudgets` pattern exactly: constant, `ValidFeatures()`, `methodToFeature`, and both `capabilityEnumFromFeature`/`capabilityEnumFromString` switch statements
- `config routes list` and `config routes test` automatically pick up the new feature via `ValidFeatures()` — no CLI changes needed

## Test plan

- [x] `TestIsValidFeature` includes `"BatchCost"` case
- [x] `TestValidFeatures` expects 7 features (was 6)
- [x] `TestFeatureFromMethod` maps `"BatchCost"` method
- [x] `TestCapabilityEnumFromFeature_BatchCost` verifies Feature → proto enum mapping
- [x] `TestCapabilityEnumFromString_BatchCost` verifies both PascalCase and snake_case string inputs
- [x] `make lint` passes with zero issues
- [x] `make test` passes (pre-existing unrelated failure in `TestPluginListCmd_TableOutputUnchanged` only)

## Changes

### Modified files

- `internal/router/features.go` - Add `FeatureBatchCost` constant, append to `ValidFeatures()`, add `"BatchCost"` entry in `methodToFeature` map
- `internal/router/router.go` - Add `FeatureBatchCost` case in `capabilityEnumFromFeature()` and `"BatchCost"`, `"batch_cost"` cases in `capabilityEnumFromString()`
- `internal/router/features_test.go` - Update expected feature count to 7, add BatchCost test cases
- `internal/router/router_test.go` - Add capability enum mapping tests for BatchCost feature

Closes #848