### PR TITLE
docs: update README badges, SEO metadata, and version references

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,25 @@
 
 
 [![CI](https://github.com/rshade/finfocus/actions/workflows/ci.yml/badge.svg)](https://github.com/rshade/finfocus/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/badge/coverage-61%25-yellow)](https://github.com/rshade/finfocus/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/rshade/finfocus/graph/badge.svg)](https://codecov.io/gh/rshade/finfocus)
 [![Go Report Card](https://goreportcard.com/badge/github.com/rshade/finfocus)](https://goreportcard.com/report/github.com/rshade/finfocus)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/rshade/finfocus)](https://github.com/rshade/finfocus/blob/main/go.mod)
+[![Release](https://img.shields.io/github/v/release/rshade/finfocus)](https://github.com/rshade/finfocus/releases/latest)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
 
 **Cloud cost analysis for Pulumi infrastructure** - Calculate projected and actual infrastructure costs without modifying your Pulumi programs.
 
 FinFocus is a CLI tool that analyzes Pulumi infrastructure definitions to provide accurate cost estimates, budget enforcement, and historical cost tracking through a flexible plugin-based architecture.
+
+## Why FinFocus?
+
+Cloud cost surprises are the norm. Teams deploy infrastructure with Pulumi but have no visibility into what it will cost until the bill arrives. FinFocus closes that gap:
+
+- **Shift-left on costs** — See projected costs *before* you deploy, directly from `pulumi preview` output
+- **No code changes required** — Works with any existing Pulumi project via JSON export
+- **Budget guardrails** — Enforce spending limits in CI/CD pipelines with non-zero exit codes
+- **Plugin architecture** — Swap pricing sources without changing your workflow
+- **Single dashboard** — Interactive TUI combining actual spend, projected costs, drift analysis, and recommendations
 
 ## Key Features
 
@@ -51,21 +63,21 @@ make build
 
 ```bash
 # Linux (amd64)
-curl -L https://github.com/rshade/finfocus/releases/download/v0.3.1/finfocus-v0.3.1-linux-amd64.tar.gz -o finfocus.tar.gz
+curl -L https://github.com/rshade/finfocus/releases/download/v0.3.3/finfocus-v0.3.3-linux-amd64.tar.gz -o finfocus.tar.gz
 tar -xzf finfocus.tar.gz
 chmod +x finfocus
 sudo mv finfocus /usr/local/bin/
 
 # macOS (Apple Silicon)
-curl -L https://github.com/rshade/finfocus/releases/download/v0.3.1/finfocus-v0.3.1-macos-arm64.tar.gz -o finfocus.tar.gz
+curl -L https://github.com/rshade/finfocus/releases/download/v0.3.3/finfocus-v0.3.3-macos-arm64.tar.gz -o finfocus.tar.gz
 tar -xzf finfocus.tar.gz && chmod +x finfocus && sudo mv finfocus /usr/local/bin/
 
 # macOS (Intel)
-curl -L https://github.com/rshade/finfocus/releases/download/v0.3.1/finfocus-v0.3.1-macos-amd64.tar.gz -o finfocus.tar.gz
+curl -L https://github.com/rshade/finfocus/releases/download/v0.3.3/finfocus-v0.3.3-macos-amd64.tar.gz -o finfocus.tar.gz
 tar -xzf finfocus.tar.gz && chmod +x finfocus && sudo mv finfocus /usr/local/bin/
 
 # Windows (PowerShell) - installs to a user-local directory, no admin rights required
-Invoke-WebRequest -Uri "https://github.com/rshade/finfocus/releases/download/v0.3.1/finfocus-v0.3.1-windows-amd64.zip" -OutFile finfocus.zip
+Invoke-WebRequest -Uri "https://github.com/rshade/finfocus/releases/download/v0.3.3/finfocus-v0.3.3-windows-amd64.zip" -OutFile finfocus.zip
 Expand-Archive finfocus.zip -DestinationPath .
 $installDir = "$env:LocalAppData\Programs\finfocus"
 New-Item -ItemType Directory -Force -Path $installDir | Out-Null

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -10,6 +10,7 @@ gem 'jekyll-theme-minimal', '~> 0.2'
 # Jekyll plugins
 gem 'jekyll-include-cache', '~> 0.2'
 gem 'jekyll-sitemap', '~> 1.4'
+gem 'jekyll-seo-tag', '~> 2.8'
 
 # Markdown processing
 gem 'kramdown', '~> 2.4'

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -63,6 +63,7 @@ exclude:
 plugins:
   - jekyll-include-cache
   - jekyll-sitemap
+  - jekyll-seo-tag
 
 # Google Analytics (optional, uncomment to enable)
 # google_analytics_id: UA-XXXXXXXXX-X
@@ -146,7 +147,7 @@ full_rebuild: false
 future: false
 
 # Custom variables
-version: "0.3.0"
+version: "0.3.3"
 status: "Released"
 
 # Navigation (optional, if using custom nav)

--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -3,6 +3,8 @@
 <meta property="og:description" content="{{ page.description | default: site.description }}" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ page.url | absolute_url }}" />
+<meta property="og:image" content="{{ '/assets/logo-readme.png' | absolute_url }}" />
 <meta name="twitter:card" content="summary" />
+<meta name="twitter:image" content="{{ '/assets/logo-readme.png' | absolute_url }}" />
 <meta name="twitter:title" content="{{ page.title | default: site.title }}" />
 <meta name="twitter:description" content="{{ page.description | default: site.description }}" />

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -138,6 +138,6 @@ The greenops package converts carbon footprint metrics (kg CO2e) to human-readab
 
 ---
 
-**Last Updated:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-**This file is automatically updated by GitHub Actions.**
+**Last Updated:** 2026-03-25
+**Update this file when documentation structure changes.**
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://rshade.github.io/finfocus/sitemap.xml


### PR DESCRIPTION

## Summary

- Replace static coverage badge with dynamic Codecov badge and add Go version and release badges to README
- Add "Why FinFocus?" section to README explaining the value proposition
- Update all download URLs from v0.3.1 to v0.3.3
- Add jekyll-seo-tag plugin and Open Graph image metadata for better social sharing previews
- Add robots.txt with sitemap reference for search engine crawling
- Fix llms.txt to use static date instead of unresolved shell expression

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [ ] Verify docs site builds with `make docs-build`

## Changes

### New files

- `docs/robots.txt` - Search engine crawling rules with sitemap reference

### Modified files

- `README.md` - Codecov badge, Go version/release badges, "Why FinFocus?" section, download URLs bumped to v0.3.3
- `docs/Gemfile` - Added jekyll-seo-tag gem dependency
- `docs/_config.yml` - Enabled jekyll-seo-tag plugin, version bumped to 0.3.3
- `docs/_includes/head-custom.html` - Added og:image and twitter:image meta tags
- `docs/llms.txt` - Fixed date format (was unresolved `$(date)` expression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added social preview image metadata for the docs site.
  * Added site crawler/sitemap configuration (robots).
  * Added Jekyll SEO tag support for improved site metadata.

* **Documentation**
  * Updated installation instructions to v0.3.3.
  * Updated documentation site version to v0.3.3.
  * Replaced Coverage badge with Codecov badge.
  * Fixed documentation "Last Updated" timestamp and guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->