### PR TITLE
docs: clarify budget status visibility in overview output modes

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+FinFocus — Cloud Infrastructure Cost Estimation
+Copyright 2025-2026 Richard Shade
+
+Licensed under the Apache License, Version 2.0.

--- a/cmd/finfocus/main.go
+++ b/cmd/finfocus/main.go
@@ -1,3 +1,6 @@
+// Copyright 2025-2026 Richard Shade. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE for details.
+
 // Package main provides the finfocus CLI tool for calculating cloud infrastructure costs.
 // It supports both projected costs from Pulumi infrastructure definitions and actual historical
 // costs from cloud provider APIs via a plugin-based architecture.

--- a/docs/commands/overview.md
+++ b/docs/commands/overview.md
@@ -35,6 +35,9 @@ the command auto-detects your Pulumi project and stack from the current director
 | `--yes`, `-y` | Skip confirmation prompts | false |
 | `--cache-ttl` | Cache TTL in seconds; 0 disables caching | 0 (disabled) |
 | `--no-pagination` | Disable pagination (plain mode only) | false |
+| `--exit-on-threshold` | Exit non-zero when budget threshold exceeded | false |
+| `--exit-code` | Exit code for threshold breach (0-255) | 1 |
+| `--budget-scope` | Filter budget scopes: global, provider, tag, type | All |
 
 ## Auto-Detection
 
@@ -171,6 +174,36 @@ Press Enter on a resource to see a detailed breakdown including:
 - Cost drift analysis with extrapolation
 - Optimization recommendations with estimated savings
 
+## Budget Status
+
+The overview command displays budget health information differently depending on
+the output mode.
+
+### Visibility by Output Mode
+
+| Mode | Budget Shown | Details |
+|------|-------------|---------|
+| Interactive TUI | Footer bar + detail view | Color-coded health badge, spend/limit, utilization %. Press Enter for per-budget breakdown with forecasts and triggered alerts |
+| Plain (`--plain`) | Not rendered | Budget enforcement available via `--exit-on-threshold` |
+| JSON (`--output json`) | `budgets` array in output | Full budget health objects with utilization, forecasted spend, triggered thresholds |
+| NDJSON (`--output ndjson`) | Not included | NDJSON is resource-scoped; budgets are stack-scoped |
+
+### Budget Flags
+
+| Flag | Description | Applies To |
+|------|-------------|-----------|
+| `--exit-on-threshold` | Exit non-zero when budget threshold exceeded | Plain, JSON |
+| `--exit-code` | Exit code when threshold exceeded (0-255) | Plain, JSON |
+| `--budget-scope` | Filter budget scopes (global, provider, tag, type) | All modes |
+
+### Why is budget status missing in plain or NDJSON mode?
+
+Plain mode focuses on the resource table for piping and CI/CD use. Use
+`--exit-on-threshold` for budget enforcement in non-interactive environments.
+NDJSON emits one object per resource and budgets are stack-scoped, so they
+do not fit the per-line streaming model. Use `--output json` or the interactive
+TUI to see full budget details.
+
 ## Output formats
 
 ### Table (default)
@@ -221,6 +254,16 @@ Structured JSON object:
     "potentialSavings": 500.00,
     "currency": "USD"
   },
+  "budgets": [
+    {
+      "budgetID": "global",
+      "health": "WARNING",
+      "utilization": 85.2,
+      "limit": 5000.00,
+      "currentSpend": 4260.00,
+      "forecastedSpend": 5800.00
+    }
+  ],
   "errors": [ ... ]
 }
 ```

--- a/docs/guides/budgets.md
+++ b/docs/guides/budgets.md
@@ -472,6 +472,24 @@ Overall Health: CRITICAL
 
 ---
 
+## Budget Visibility in Overview
+
+The `finfocus overview` command shows budget status differently per output mode:
+
+- **Interactive TUI**: Budget footer with health badge loads asynchronously below
+  the resource table. Press Enter on a resource for per-budget detail with forecasts
+  and triggered alerts.
+- **JSON** (`--output json`): Full budget data in the top-level `budgets` array.
+- **NDJSON** (`--output ndjson`): Budgets are excluded — NDJSON is resource-scoped
+  and budgets are stack-scoped.
+- **Plain** (`--plain`): Budget status is not rendered in the table. Use
+  `--exit-on-threshold` for CI/CD enforcement.
+
+See [overview command — Budget Status](../commands/overview.md#budget-status) for
+the complete visibility matrix and flag reference.
+
+---
+
 ## Troubleshooting
 
 Common issues and solutions for budget configuration.
@@ -524,6 +542,7 @@ Ensure you have the correct schema directive and your indentation is correct:
 
 **CLI Reference:**
 
+- [overview](../commands/overview.md) - Unified cost dashboard with budget status
 - [cost projected](../reference/cli-commands.md#cost-projected) - Estimate projected costs
 - [cost recommendations](../reference/cli-commands.md#cost-recommendations) - Display recommendations
 
@@ -537,6 +556,6 @@ Ensure you have the correct schema directive and your indentation is correct:
 
 ---
 
-**Last Updated**: 2026-01-27
-**FinFocus Version**: v0.3.0
+**Last Updated**: 2026-03-30
+**FinFocus Version**: v0.3.4
 **Feedback**: [Open an issue](https://github.com/rshade/finfocus/issues/new) to improve this guide

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,3 +1,6 @@
+// Copyright 2025-2026 Richard Shade. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE for details.
+
 package engine
 
 import (

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -1,3 +1,6 @@
+// Copyright 2025-2026 Richard Shade. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE for details.
+
 package pluginhost
 
 import (


### PR DESCRIPTION
fixes #855

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for new budget management CLI options (--exit-on-threshold, --exit-code, --budget-scope).
  * Documented how budget status is displayed across different output modes (interactive TUI, JSON, plain text, NDJSON).

* **Chores**
  * Added Apache License 2.0 headers to project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->