### PR TITLE
feat(engine): implement EstimateCost RPC consumer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -470,6 +470,7 @@ on projected costs. The `p` key triggers on-demand preview; when it completes,
 ## Recent Changes
 
 - 608-resource-history-store: Added Go 1.25.8 (see `go.mod`) + BoltDB (`go.etcd.io/bbolt` — already in `go.mod`).
+- 608-estimate-cost-rpc: Added Go 1.25.8 (see `go.mod`) + finfocus-spec v0.6.0 (proto definitions), gRPC, Cobra, zerolog
 - 607-state-only-flag: Added Go 1.25.8 (see `go.mod`) + Cobra (CLI framework), Bubble Tea (TUI), zerolog (logging)
 - 606-cache-expires-at: Added Go 1.25.8 (see `go.mod`) + finfocus-spec v0.6.0 (provides `expires_at` proto fields), BoltDB (cache storage), zerolog (logging)
 
@@ -477,4 +478,6 @@ on projected costs. The `p` key triggers on-demand preview; when it completes,
 
 - Go 1.25.8 (see `go.mod`) + BoltDB (`go.etcd.io/bbolt` — already in `go.mod`) (608-resource-history-store)
 - BoltDB at `~/.finfocus/history/history.db` (separate from cache) (608-resource-history-store)
+- Go 1.25.8 (see `go.mod`) + finfocus-spec v0.6.0 (proto definitions), gRPC, Cobra, zerolog (608-estimate-cost-rpc)
+- N/A (no new persistent state) (608-estimate-cost-rpc)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,10 +19,22 @@ guardrails in `CONTEXT.md`.
 
 - [ ] Implement EstimateCost RPC consumer (remove stub)
       ([#847](https://github.com/rshade/finfocus/issues/847)) [M]
+- [ ] **EstimateCost RPC — Code Review Follow-ups** *(from #847 PR review)*
+  - [ ] Add test for modified-response validation fallback path
+        ([#970](https://github.com/rshade/finfocus/issues/970)) [S]
+  - [ ] Fix type loss in `mergePropertiesWithOverrides` (overrides written as
+        strings)
+        ([#971](https://github.com/rshade/finfocus/issues/971)) [M]
+  - [ ] Add missing `.Ctx(ctx)` and component fields to `tryEstimateCostRPC`
+        warning logs
+        ([#972](https://github.com/rshade/finfocus/issues/972)) [S]
+  - [ ] Add test for `BuildEstimateCostRequest` `structpb.NewStruct` error path
+        ([#973](https://github.com/rshade/finfocus/issues/973)) [S]
 - [ ] Implement BatchCost RPC consumer for multi-resource queries
       ([#846](https://github.com/rshade/finfocus/issues/846)) [L]
-- [ ] Resource History Store with Layered Cost Attribution
+- [x] Resource History Store with Layered Cost Attribution
       ([#934](https://github.com/rshade/finfocus/issues/934)) [L]
+      *(Completed 2026-04-04)*
 - [ ] **Resource History Store — Code Review Follow-ups** *(from #934 PR review)*
   - [ ] Fix double-prefixing in `StackContext.Hash`
         ([#966](https://github.com/rshade/finfocus/issues/966)) [S]
@@ -244,6 +256,12 @@ guardrails in `CONTEXT.md`.
     a plugin-returned cost exceeds the user-defined threshold.
 
 ## Completed Milestones
+
+### 2026-Q2
+
+- [x] Resource History Store with Layered Cost Attribution
+      ([#934](https://github.com/rshade/finfocus/issues/934)) [L]
+      *(Completed 2026-04-04)*
 
 ### 2026-Q1
 

--- a/internal/engine/budget_engine_test.go
+++ b/internal/engine/budget_engine_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 
@@ -95,6 +97,14 @@ func (m *mockCostSourceClient) Supports(
 	_ ...grpc.CallOption,
 ) (*pbc.SupportsResponse, error) {
 	return &pbc.SupportsResponse{Supported: true}, nil
+}
+
+func (m *mockCostSourceClient) EstimateCost(
+	_ context.Context,
+	_ *pbc.EstimateCostRequest,
+	_ ...grpc.CallOption,
+) (*pbc.EstimateCostResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "EstimateCost not implemented")
 }
 
 func TestEngine_GetBudgets(t *testing.T) {

--- a/internal/engine/estimate.go
+++ b/internal/engine/estimate.go
@@ -4,14 +4,38 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
+	"math"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 	"github.com/rshade/finfocus/internal/logging"
 	"github.com/rshade/finfocus/internal/pluginhost"
+	"github.com/rshade/finfocus/internal/proto"
+)
+
+// combinedDeltaProperty is the sentinel name used for multi-property deltas
+// where per-property attribution is not possible.
+const combinedDeltaProperty = "combined"
+
+var (
+	// errNilEstimateResponse indicates a plugin returned a nil EstimateCostResponse.
+	errNilEstimateResponse = errors.New("plugin returned nil EstimateCost response")
+
+	// errNegativeEstimateCost indicates a plugin returned a negative CostMonthly value.
+	errNegativeEstimateCost = errors.New("plugin returned negative EstimateCost cost")
+
+	// errNonFiniteEstimateCost indicates a plugin returned NaN or Inf for CostMonthly.
+	errNonFiniteEstimateCost = errors.New("plugin returned non-finite EstimateCost cost (NaN or Inf)")
+
+	// errEmptyEstimateCurrency indicates a plugin returned an empty currency string.
+	errEmptyEstimateCurrency = errors.New("plugin returned empty currency in EstimateCost response")
+
+	// errCurrencyMismatch indicates baseline and modified responses have different currencies.
+	errCurrencyMismatch = errors.New("currency mismatch between baseline and modified EstimateCost responses")
 )
 
 // EstimateCost performs what-if cost analysis with property overrides.
@@ -64,6 +88,11 @@ func (e *Engine) EstimateCost(
 		return nil, err
 	}
 
+	// Validate that at least one property override is provided
+	if len(request.PropertyOverrides) == 0 {
+		return nil, errors.New("property overrides are required for cost estimation")
+	}
+
 	// Try EstimateCost RPC on available plugins
 	for _, client := range e.clients {
 		log.Debug().
@@ -72,10 +101,7 @@ func (e *Engine) EstimateCost(
 			Str("plugin", client.Name).
 			Msg("attempting EstimateCost RPC")
 
-		// Apply per-resource timeout for plugin calls
-		resourceCtx, resourceCancel := context.WithTimeout(ctx, perResourceTimeout)
-		result, err := e.tryEstimateCostRPC(resourceCtx, client, request)
-		resourceCancel()
+		result, err := e.tryEstimateCostRPC(ctx, client, request)
 
 		if err != nil {
 			// Check if the error is Unimplemented - if so, try fallback
@@ -159,40 +185,132 @@ func (e *Engine) EstimateCost(
 	return result, nil
 }
 
+// validateEstimateResponse checks that a plugin's EstimateCostResponse is usable.
+func validateEstimateResponse(resp *pbc.EstimateCostResponse) error {
+	if resp == nil {
+		return errNilEstimateResponse
+	}
+	cost := resp.GetCostMonthly()
+	if math.IsNaN(cost) || math.IsInf(cost, 0) {
+		return errNonFiniteEstimateCost
+	}
+	if cost < 0 {
+		return errNegativeEstimateCost
+	}
+	if resp.GetCurrency() == "" {
+		return errEmptyEstimateCurrency
+	}
+	return nil
+}
+
 // tryEstimateCostRPC attempts to call the EstimateCost RPC on a plugin.
+// It calls the RPC twice: once with original properties (baseline) and once
+// with overrides applied (modified), then computes deltas.
 func (e *Engine) tryEstimateCostRPC(
-	_ context.Context,
-	_ *pluginhost.Client,
-	_ *EstimateRequest,
+	ctx context.Context,
+	client *pluginhost.Client,
+	request *EstimateRequest,
 ) (*EstimateResult, error) {
-	// The EstimateCost RPC is not yet defined in finfocus-spec v0.5.6
-	// When the RPC is added to the spec, this method should:
-	// 1. Build the proto request using proto.BuildEstimateCostRequest
-	// 2. Call client.API.EstimateCost(ctx, protoReq)
-	// 3. Convert the response to EstimateResult
-	return nil, status.Error(codes.Unimplemented, "EstimateCost RPC not yet implemented in plugins")
+	log := logging.FromContext(ctx)
+	resourceType := request.Resource.Type
+
+	baselineReq, err := proto.BuildEstimateCostRequest(resourceType, request.Resource.Properties)
+	if err != nil {
+		return nil, fmt.Errorf("build baseline request: %w", err)
+	}
+
+	baselineCtx, baselineCancel := context.WithTimeout(ctx, perResourceTimeout)
+	baselineResp, err := client.API.EstimateCost(baselineCtx, baselineReq)
+	baselineCancel()
+	if err != nil {
+		return nil, err
+	}
+
+	if err = validateEstimateResponse(baselineResp); err != nil {
+		log.Warn().Str("plugin", client.Name).Err(err).Msg("invalid baseline response")
+		return nil, err
+	}
+
+	modifiedProps := mergePropertiesWithOverrides(request.Resource.Properties, request.PropertyOverrides)
+
+	modifiedReq, err := proto.BuildEstimateCostRequest(resourceType, modifiedProps)
+	if err != nil {
+		return nil, fmt.Errorf("build modified request: %w", err)
+	}
+
+	modifiedCtx, modifiedCancel := context.WithTimeout(ctx, perResourceTimeout)
+	modifiedResp, err := client.API.EstimateCost(modifiedCtx, modifiedReq)
+	modifiedCancel()
+	if err != nil {
+		return nil, err
+	}
+
+	if err = validateEstimateResponse(modifiedResp); err != nil {
+		log.Warn().Str("plugin", client.Name).Err(err).Msg("invalid modified response")
+		return nil, err
+	}
+
+	// Guard against cross-currency delta computation
+	if baselineResp.GetCurrency() != modifiedResp.GetCurrency() {
+		log.Warn().
+			Str("plugin", client.Name).
+			Str("baseline_currency", baselineResp.GetCurrency()).
+			Str("modified_currency", modifiedResp.GetCurrency()).
+			Msg("currency mismatch between baseline and modified responses")
+		return nil, errCurrencyMismatch
+	}
+
+	baseline := estimateResponseToCostResult(baselineResp, request.Resource)
+	modified := estimateResponseToCostResult(modifiedResp, request.Resource)
+	totalChange := modified.Monthly - baseline.Monthly
+
+	return &EstimateResult{
+		Resource:     request.Resource,
+		Baseline:     baseline,
+		Modified:     modified,
+		TotalChange:  totalChange,
+		Deltas:       buildCostDeltas(request.PropertyOverrides, request.Resource.Properties, totalChange),
+		UsedFallback: false,
+	}, nil
+}
+
+// estimateResponseToCostResult converts a pbc.EstimateCostResponse to an engine CostResult.
+func estimateResponseToCostResult(resp *pbc.EstimateCostResponse, resource *ResourceDescriptor) *CostResult {
+	currency := resp.GetCurrency()
+	if currency == "" {
+		currency = defaultCurrency
+	}
+
+	monthly := resp.GetCostMonthly()
+	hourly := monthly / hoursPerMonth
+
+	var notes []string
+	if resp.GetPricingCategory() != pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_UNSPECIFIED {
+		notes = append(notes, "Pricing: "+resp.GetPricingCategory().String())
+	}
+	if resp.GetSpotInterruptionRiskScore() > 0 {
+		notes = append(notes, fmt.Sprintf("Spot risk: %.2f", resp.GetSpotInterruptionRiskScore()))
+	}
+
+	return &CostResult{
+		ResourceType: resource.Type,
+		ResourceID:   resource.ID,
+		Currency:     currency,
+		Monthly:      monthly,
+		Hourly:       hourly,
+		Notes:        strings.Join(notes, "; "),
+	}
 }
 
 // estimateCostFallback calculates cost estimation using two GetProjectedCost calls.
-//
-// This fallback strategy:
-// 1. Calls GetProjectedCost with original properties -> baseline
-// 2. Merges property overrides into resource properties
-// 3. Calls GetProjectedCost with modified properties -> modified
-// 4. Calculates the delta
-//
-// Note: When multiple properties are overridden simultaneously, the fallback
-// cannot provide accurate per-property delta breakdown. In this case, it reports
-// a single "combined" delta representing the total change.
-//
-//nolint:funlen // Function has clear sections for baseline, modified, and delta calculations.
+// When multiple properties are overridden simultaneously, it reports a single
+// "combined" delta since per-property attribution is not possible via this path.
 func (e *Engine) estimateCostFallback(
 	ctx context.Context,
 	request *EstimateRequest,
 ) (*EstimateResult, error) {
 	log := logging.FromContext(ctx)
 
-	// Get baseline cost with original properties
 	baselineResources := []ResourceDescriptor{*request.Resource}
 	baselineResults, err := e.GetProjectedCost(ctx, baselineResources)
 	if err != nil {
@@ -213,23 +331,13 @@ func (e *Engine) estimateCostFallback(
 		}
 	}
 
-	// Create modified resource with overrides applied
-	// IMPORTANT: Deep copy the properties map to avoid modifying the original
 	modifiedResource := *request.Resource
-	modifiedResource.Properties = make(map[string]interface{})
-	for key, value := range request.Resource.Properties {
-		modifiedResource.Properties[key] = value
-	}
-	for key, value := range request.PropertyOverrides {
-		modifiedResource.Properties[key] = value
-	}
+	modifiedResource.Properties = mergePropertiesWithOverrides(request.Resource.Properties, request.PropertyOverrides)
 
-	// Validate the modified resource to ensure overrides don't violate constraints
 	if validateErr := modifiedResource.Validate(); validateErr != nil {
 		return nil, fmt.Errorf("modified resource validation failed: %w", validateErr)
 	}
 
-	// Get modified cost with overrides applied
 	modifiedResources := []ResourceDescriptor{modifiedResource}
 	modifiedResults, err := e.GetProjectedCost(ctx, modifiedResources)
 	if err != nil {
@@ -250,37 +358,7 @@ func (e *Engine) estimateCostFallback(
 		}
 	}
 
-	// Calculate total change
 	totalChange := modified.Monthly - baseline.Monthly
-
-	// Build deltas - for fallback, we can only report a combined delta
-	var deltas []CostDelta
-	if len(request.PropertyOverrides) == 1 {
-		// Single property change - we can attribute the delta to it
-		for key, newValue := range request.PropertyOverrides {
-			// Get original value from the ORIGINAL resource (not modified)
-			originalValue := ""
-			if request.Resource.Properties != nil {
-				if v, ok := request.Resource.Properties[key]; ok {
-					originalValue = formatPropertyValue(v)
-				}
-			}
-			deltas = append(deltas, CostDelta{
-				Property:      key,
-				OriginalValue: originalValue,
-				NewValue:      newValue,
-				CostChange:    totalChange,
-			})
-		}
-	} else if len(request.PropertyOverrides) > 1 {
-		// Multiple properties - report as combined
-		deltas = append(deltas, CostDelta{
-			Property:      "combined",
-			OriginalValue: "",
-			NewValue:      "",
-			CostChange:    totalChange,
-		})
-	}
 
 	log.Debug().
 		Ctx(ctx).
@@ -295,25 +373,52 @@ func (e *Engine) estimateCostFallback(
 		Baseline:     baseline,
 		Modified:     modified,
 		TotalChange:  totalChange,
-		Deltas:       deltas,
+		Deltas:       buildCostDeltas(request.PropertyOverrides, request.Resource.Properties, totalChange),
 		UsedFallback: true,
 	}, nil
 }
 
-// formatPropertyValue converts a property value to a string representation.
-func formatPropertyValue(v interface{}) string {
-	switch val := v.(type) {
-	case string:
-		return val
-	case int:
-		return strconv.Itoa(val)
-	case int64:
-		return strconv.FormatInt(val, 10)
-	case float64:
-		return fmt.Sprintf("%g", val)
-	case bool:
-		return strconv.FormatBool(val)
-	default:
-		return fmt.Sprintf("%v", v)
+// mergePropertiesWithOverrides creates a shallow copy of properties with string
+// overrides applied. The returned map is safe to mutate without affecting the originals.
+func mergePropertiesWithOverrides(
+	properties map[string]any,
+	overrides map[string]string,
+) map[string]any {
+	merged := make(map[string]any, len(properties)+len(overrides))
+	for k, v := range properties {
+		merged[k] = v
 	}
+	for k, v := range overrides {
+		merged[k] = v
+	}
+	return merged
+}
+
+// buildCostDeltas constructs per-property delta entries from overrides and a total cost change.
+// Single-override requests get an attributed delta; multi-override requests get a "combined" entry.
+func buildCostDeltas(
+	overrides map[string]string,
+	originalProperties map[string]any,
+	totalChange float64,
+) []CostDelta {
+	if len(overrides) == 1 {
+		for key, newValue := range overrides {
+			originalValue := ""
+			if originalProperties != nil {
+				if v, ok := originalProperties[key]; ok {
+					originalValue = ConvertValueToString(v)
+				}
+			}
+			return []CostDelta{{
+				Property:      key,
+				OriginalValue: originalValue,
+				NewValue:      newValue,
+				CostChange:    totalChange,
+			}}
+		}
+	}
+	if len(overrides) > 1 {
+		return []CostDelta{{Property: combinedDeltaProperty, CostChange: totalChange}}
+	}
+	return nil
 }

--- a/internal/engine/estimate_test.go
+++ b/internal/engine/estimate_test.go
@@ -3,12 +3,89 @@ package engine
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
+	"github.com/rshade/finfocus/internal/pluginhost"
+	"github.com/rshade/finfocus/internal/proto"
 )
+
+// estimateMockPlugin implements proto.CostSourceClient with a configurable
+// EstimateCost function for testing tryEstimateCostRPC.
+type estimateMockPlugin struct {
+	estimateCostFunc func(ctx context.Context, in *pbc.EstimateCostRequest, opts ...grpc.CallOption) (*pbc.EstimateCostResponse, error)
+}
+
+func (m *estimateMockPlugin) Name(
+	_ context.Context, _ *proto.Empty, _ ...grpc.CallOption,
+) (*proto.NameResponse, error) {
+	return &proto.NameResponse{Name: "estimate-mock"}, nil
+}
+
+func (m *estimateMockPlugin) GetProjectedCost(
+	_ context.Context, _ *proto.GetProjectedCostRequest, _ ...grpc.CallOption,
+) (*proto.GetProjectedCostResponse, error) {
+	return &proto.GetProjectedCostResponse{}, nil
+}
+
+func (m *estimateMockPlugin) GetActualCost(
+	_ context.Context, _ *proto.GetActualCostRequest, _ ...grpc.CallOption,
+) (*proto.GetActualCostResponse, error) {
+	return &proto.GetActualCostResponse{}, nil
+}
+
+func (m *estimateMockPlugin) GetRecommendations(
+	_ context.Context, _ *proto.GetRecommendationsRequest, _ ...grpc.CallOption,
+) (*proto.GetRecommendationsResponse, error) {
+	return &proto.GetRecommendationsResponse{}, nil
+}
+
+func (m *estimateMockPlugin) GetPluginInfo(
+	_ context.Context, _ *proto.Empty, _ ...grpc.CallOption,
+) (*pbc.GetPluginInfoResponse, error) {
+	return &pbc.GetPluginInfoResponse{}, nil
+}
+
+func (m *estimateMockPlugin) DryRun(
+	_ context.Context, _ *pbc.DryRunRequest, _ ...grpc.CallOption,
+) (*pbc.DryRunResponse, error) {
+	return &pbc.DryRunResponse{}, nil
+}
+
+func (m *estimateMockPlugin) GetBudgets(
+	_ context.Context, _ *pbc.GetBudgetsRequest, _ ...grpc.CallOption,
+) (*pbc.GetBudgetsResponse, error) {
+	return &pbc.GetBudgetsResponse{}, nil
+}
+
+func (m *estimateMockPlugin) DismissRecommendation(
+	_ context.Context, _ *proto.DismissRecommendationRequest, _ ...grpc.CallOption,
+) (*proto.DismissRecommendationResponse, error) {
+	return &proto.DismissRecommendationResponse{Success: true}, nil
+}
+
+func (m *estimateMockPlugin) Supports(
+	_ context.Context, _ *pbc.SupportsRequest, _ ...grpc.CallOption,
+) (*pbc.SupportsResponse, error) {
+	return &pbc.SupportsResponse{Supported: true}, nil
+}
+
+func (m *estimateMockPlugin) EstimateCost(
+	ctx context.Context, in *pbc.EstimateCostRequest, opts ...grpc.CallOption,
+) (*pbc.EstimateCostResponse, error) {
+	if m.estimateCostFunc != nil {
+		return m.estimateCostFunc(ctx, in, opts...)
+	}
+	return nil, status.Error(codes.Unimplemented, "EstimateCost not implemented")
+}
 
 // errNoSpec is a sentinel error for missing specs in tests.
 var errNoSpec = errors.New("no spec available")
@@ -78,12 +155,11 @@ func TestEstimateCost_Fallback(t *testing.T) {
 		require.NotNil(t, result)
 
 		assert.True(t, result.UsedFallback)
-		// Multiple overrides should result in a "combined" delta
 		assert.Len(t, result.Deltas, 1)
-		assert.Equal(t, "combined", result.Deltas[0].Property)
+		assert.Equal(t, combinedDeltaProperty, result.Deltas[0].Property)
 	})
 
-	t.Run("no property overrides", func(t *testing.T) {
+	t.Run("no property overrides returns validation error", func(t *testing.T) {
 		engine := New(nil, &mockSpecLoader{})
 
 		request := &EstimateRequest{
@@ -99,13 +175,9 @@ func TestEstimateCost_Fallback(t *testing.T) {
 		}
 
 		result, err := engine.EstimateCost(context.Background(), request)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-
-		// With no overrides, baseline and modified should be the same
-		assert.Equal(t, result.Baseline.Monthly, result.Modified.Monthly)
-		assert.Equal(t, 0.0, result.TotalChange)
-		assert.Empty(t, result.Deltas)
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "property overrides")
 	})
 }
 
@@ -131,61 +203,6 @@ func TestEstimateCost_ResourceValidation(t *testing.T) {
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "resource type is required")
 	})
-}
-
-// TestEstimateCost_TotalChange tests that TotalChange is correctly calculated.
-func TestEstimateCost_TotalChange(t *testing.T) {
-	t.Run("total change equals modified minus baseline", func(t *testing.T) {
-		engine := New(nil, &mockSpecLoader{})
-
-		request := &EstimateRequest{
-			Resource: &ResourceDescriptor{
-				Provider: "aws",
-				Type:     "aws:ec2:Instance",
-				ID:       "i-123",
-				Properties: map[string]interface{}{
-					"instanceType": "t3.micro",
-				},
-			},
-			PropertyOverrides: map[string]string{
-				"instanceType": "m5.large",
-			},
-		}
-
-		result, err := engine.EstimateCost(context.Background(), request)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-
-		// TotalChange should be Modified.Monthly - Baseline.Monthly
-		expectedChange := result.Modified.Monthly - result.Baseline.Monthly
-		assert.Equal(t, expectedChange, result.TotalChange)
-	})
-}
-
-// TestFormatPropertyValue tests the property value formatting helper.
-func TestFormatPropertyValue(t *testing.T) {
-	tests := []struct {
-		name     string
-		value    interface{}
-		expected string
-	}{
-		{"string value", "t3.micro", "t3.micro"},
-		{"int value", 42, "42"},
-		{"int64 value", int64(1000), "1000"},
-		{"float64 value", 3.14, "3.14"},
-		{"bool true", true, "true"},
-		{"bool false", false, "false"},
-		{"nil value", nil, "<nil>"},
-		{"slice value", []string{"a", "b"}, "[a b]"},
-		{"map value", map[string]string{"key": "val"}, "map[key:val]"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := formatPropertyValue(tt.value)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
 }
 
 // TestEstimateCost_Context tests context cancellation handling.
@@ -308,8 +325,8 @@ func BenchmarkEstimateCost_MultipleOverrides(b *testing.B) {
 	}
 }
 
-// BenchmarkEstimateCost_NoOverrides benchmarks baseline-only estimation (no property changes).
-func BenchmarkEstimateCost_NoOverrides(b *testing.B) {
+// BenchmarkEstimateCost_MinimalOverride benchmarks estimation with a single minimal property change.
+func BenchmarkEstimateCost_MinimalOverride(b *testing.B) {
 	engine := New(nil, &mockSpecLoader{})
 
 	request := &EstimateRequest{
@@ -321,7 +338,9 @@ func BenchmarkEstimateCost_NoOverrides(b *testing.B) {
 				"instanceType": "t3.micro",
 			},
 		},
-		PropertyOverrides: map[string]string{},
+		PropertyOverrides: map[string]string{
+			"instanceType": "t3.small",
+		},
 	}
 
 	b.ResetTimer()
@@ -380,4 +399,496 @@ func TestEstimateCost_PerformanceWithin5Seconds(t *testing.T) {
 	slowPercentage := float64(slowCount) / float64(iterations) * 100
 	assert.LessOrEqual(t, slowPercentage, 10.0,
 		"more than 10%% of requests exceeded 5 second SLA")
+}
+
+// TestTryEstimateCostRPC_Success verifies the RPC path returns correct baseline/modified
+// costs and TotalChange when the plugin implements EstimateCost.
+func TestTryEstimateCostRPC_Success(t *testing.T) {
+	callCount := 0
+	var firstRequest, secondRequest *pbc.EstimateCostRequest
+	mock := &estimateMockPlugin{
+		estimateCostFunc: func(_ context.Context, in *pbc.EstimateCostRequest, _ ...grpc.CallOption) (*pbc.EstimateCostResponse, error) {
+			callCount++
+			// First call = baseline (original properties), second = modified
+			if callCount == 1 {
+				firstRequest = in
+				return &pbc.EstimateCostResponse{
+					Currency:    "USD",
+					CostMonthly: 10.0,
+				}, nil
+			}
+			secondRequest = in
+			return &pbc.EstimateCostResponse{
+				Currency:    "USD",
+				CostMonthly: 25.0,
+			}, nil
+		},
+	}
+
+	clients := []*pluginhost.Client{{Name: "test-plugin", API: mock}}
+	eng := New(clients, &mockSpecLoader{})
+
+	request := &EstimateRequest{
+		Resource: &ResourceDescriptor{
+			Provider:   "aws",
+			Type:       "aws:ec2/instance:Instance",
+			ID:         "i-123",
+			Properties: map[string]interface{}{"instanceType": "t3.micro"},
+		},
+		PropertyOverrides: map[string]string{"instanceType": "m5.large"},
+	}
+
+	result, err := eng.EstimateCost(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.False(t, result.UsedFallback, "should NOT use fallback when RPC succeeds")
+	assert.Equal(t, 2, callCount, "should call EstimateCost twice (baseline + modified)")
+	require.NotNil(t, result.Baseline)
+	require.NotNil(t, result.Modified)
+	assert.Equal(t, 10.0, result.Baseline.Monthly)
+	assert.Equal(t, 25.0, result.Modified.Monthly)
+	assert.InDelta(t, 15.0, result.TotalChange, 0.001)
+
+	// Verify baseline request carries original properties
+	require.NotNil(t, firstRequest, "baseline request should have been captured")
+	require.NotNil(t, firstRequest.GetAttributes(), "baseline request should have attributes")
+	baselineAttrs := firstRequest.GetAttributes().AsMap()
+	assert.Equal(t, "t3.micro", baselineAttrs["instanceType"],
+		"baseline request should contain original instanceType")
+
+	// Verify modified request carries merged overrides
+	require.NotNil(t, secondRequest, "modified request should have been captured")
+	require.NotNil(t, secondRequest.GetAttributes(), "modified request should have attributes")
+	modifiedAttrs := secondRequest.GetAttributes().AsMap()
+	assert.Equal(t, "m5.large", modifiedAttrs["instanceType"],
+		"modified request should contain overridden instanceType")
+}
+
+// TestTryEstimateCostRPC_SinglePropertyDelta verifies that a single override
+// produces one CostDelta entry with the correct property name and cost change.
+func TestTryEstimateCostRPC_SinglePropertyDelta(t *testing.T) {
+	callCount := 0
+	mock := &estimateMockPlugin{
+		estimateCostFunc: func(_ context.Context, _ *pbc.EstimateCostRequest, _ ...grpc.CallOption) (*pbc.EstimateCostResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return &pbc.EstimateCostResponse{Currency: "USD", CostMonthly: 50.0}, nil
+			}
+			return &pbc.EstimateCostResponse{Currency: "USD", CostMonthly: 120.0}, nil
+		},
+	}
+
+	clients := []*pluginhost.Client{{Name: "test-plugin", API: mock}}
+	eng := New(clients, &mockSpecLoader{})
+
+	request := &EstimateRequest{
+		Resource: &ResourceDescriptor{
+			Provider:   "aws",
+			Type:       "aws:ec2/instance:Instance",
+			ID:         "i-456",
+			Properties: map[string]interface{}{"instanceType": "t3.small"},
+		},
+		PropertyOverrides: map[string]string{"instanceType": "m5.xlarge"},
+	}
+
+	result, err := eng.EstimateCost(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.Len(t, result.Deltas, 1)
+	assert.Equal(t, "instanceType", result.Deltas[0].Property)
+	assert.Equal(t, "t3.small", result.Deltas[0].OriginalValue)
+	assert.Equal(t, "m5.xlarge", result.Deltas[0].NewValue)
+	assert.InDelta(t, 70.0, result.Deltas[0].CostChange, 0.001)
+}
+
+// TestTryEstimateCostRPC_MultiPropertyCombinedDelta verifies that multiple
+// overrides produce a single "combined" delta entry.
+func TestTryEstimateCostRPC_MultiPropertyCombinedDelta(t *testing.T) {
+	callCount := 0
+	mock := &estimateMockPlugin{
+		estimateCostFunc: func(_ context.Context, _ *pbc.EstimateCostRequest, _ ...grpc.CallOption) (*pbc.EstimateCostResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return &pbc.EstimateCostResponse{Currency: "USD", CostMonthly: 30.0}, nil
+			}
+			return &pbc.EstimateCostResponse{Currency: "USD", CostMonthly: 80.0}, nil
+		},
+	}
+
+	clients := []*pluginhost.Client{{Name: "test-plugin", API: mock}}
+	eng := New(clients, &mockSpecLoader{})
+
+	request := &EstimateRequest{
+		Resource: &ResourceDescriptor{
+			Provider:   "aws",
+			Type:       "aws:ec2/instance:Instance",
+			ID:         "i-789",
+			Properties: map[string]interface{}{"instanceType": "t3.micro", "volumeSize": 8},
+		},
+		PropertyOverrides: map[string]string{
+			"instanceType": "m5.large",
+			"volumeSize":   "100",
+		},
+	}
+
+	result, err := eng.EstimateCost(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.Len(t, result.Deltas, 1)
+	assert.Equal(t, combinedDeltaProperty, result.Deltas[0].Property)
+	assert.InDelta(t, 50.0, result.Deltas[0].CostChange, 0.001)
+}
+
+// TestTryEstimateCostRPC_NilResponse verifies that a nil response from the
+// plugin causes an error (not a panic).
+func TestTryEstimateCostRPC_NilResponse(t *testing.T) {
+	mock := &estimateMockPlugin{
+		estimateCostFunc: func(_ context.Context, _ *pbc.EstimateCostRequest, _ ...grpc.CallOption) (*pbc.EstimateCostResponse, error) {
+			// Simulate a plugin returning a nil response (no proto, no error).
+			// validateEstimateResponse catches this and returns errNilEstimateResponse.
+			var resp *pbc.EstimateCostResponse
+			return resp, nil
+		},
+	}
+
+	clients := []*pluginhost.Client{{Name: "test-plugin", API: mock}}
+	eng := New(clients, &mockSpecLoader{})
+
+	request := &EstimateRequest{
+		Resource: &ResourceDescriptor{
+			Provider:   "aws",
+			Type:       "aws:ec2/instance:Instance",
+			ID:         "i-nil",
+			Properties: map[string]interface{}{"instanceType": "t3.micro"},
+		},
+		PropertyOverrides: map[string]string{"instanceType": "m5.large"},
+	}
+
+	// nil response should cause the plugin to be skipped (error logged),
+	// falling through to fallback
+	result, err := eng.EstimateCost(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.UsedFallback, "nil RPC response should trigger fallback")
+}
+
+// TestTryEstimateCostRPC_NegativeCost verifies that a negative CostMonthly
+// from the plugin causes the RPC result to be rejected.
+func TestTryEstimateCostRPC_NegativeCost(t *testing.T) {
+	mock := &estimateMockPlugin{
+		estimateCostFunc: func(_ context.Context, _ *pbc.EstimateCostRequest, _ ...grpc.CallOption) (*pbc.EstimateCostResponse, error) {
+			return &pbc.EstimateCostResponse{
+				Currency:    "USD",
+				CostMonthly: -5.0,
+			}, nil
+		},
+	}
+
+	clients := []*pluginhost.Client{{Name: "test-plugin", API: mock}}
+	eng := New(clients, &mockSpecLoader{})
+
+	request := &EstimateRequest{
+		Resource: &ResourceDescriptor{
+			Provider:   "aws",
+			Type:       "aws:ec2/instance:Instance",
+			ID:         "i-neg",
+			Properties: map[string]interface{}{"instanceType": "t3.micro"},
+		},
+		PropertyOverrides: map[string]string{"instanceType": "m5.large"},
+	}
+
+	// Negative cost should cause the plugin to be skipped, falling to fallback
+	result, err := eng.EstimateCost(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.UsedFallback, "negative cost should trigger fallback")
+}
+
+// TestTryEstimateCostRPC_EmptyCurrency verifies that an empty currency
+// in the plugin response causes RPC rejection and engine falls back.
+func TestTryEstimateCostRPC_EmptyCurrency(t *testing.T) {
+	mock := &estimateMockPlugin{
+		estimateCostFunc: func(_ context.Context, _ *pbc.EstimateCostRequest, _ ...grpc.CallOption) (*pbc.EstimateCostResponse, error) {
+			return &pbc.EstimateCostResponse{
+				Currency:    "",
+				CostMonthly: 10.0,
+			}, nil
+		},
+	}
+
+	clients := []*pluginhost.Client{{Name: "test-plugin", API: mock}}
+	eng := New(clients, &mockSpecLoader{})
+
+	request := &EstimateRequest{
+		Resource: &ResourceDescriptor{
+			Provider:   "aws",
+			Type:       "aws:ec2/instance:Instance",
+			ID:         "i-empty-cur",
+			Properties: map[string]interface{}{"instanceType": "t3.micro"},
+		},
+		PropertyOverrides: map[string]string{"instanceType": "m5.large"},
+	}
+
+	result, err := eng.EstimateCost(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.UsedFallback, "empty currency should cause RPC rejection and fallback")
+}
+
+// TestTryEstimateCostRPC_CurrencyPassthrough verifies that a non-USD currency
+// from the plugin is preserved without conversion.
+func TestTryEstimateCostRPC_CurrencyPassthrough(t *testing.T) {
+	mock := &estimateMockPlugin{
+		estimateCostFunc: func(_ context.Context, _ *pbc.EstimateCostRequest, _ ...grpc.CallOption) (*pbc.EstimateCostResponse, error) {
+			return &pbc.EstimateCostResponse{
+				Currency:    "EUR",
+				CostMonthly: 10.0,
+			}, nil
+		},
+	}
+
+	clients := []*pluginhost.Client{{Name: "test-plugin", API: mock}}
+	eng := New(clients, &mockSpecLoader{})
+
+	request := &EstimateRequest{
+		Resource: &ResourceDescriptor{
+			Provider:   "aws",
+			Type:       "aws:ec2/instance:Instance",
+			ID:         "i-eur",
+			Properties: map[string]interface{}{"instanceType": "t3.micro"},
+		},
+		PropertyOverrides: map[string]string{"instanceType": "m5.large"},
+	}
+
+	result, err := eng.EstimateCost(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.False(t, result.UsedFallback)
+	assert.Equal(t, "EUR", result.Baseline.Currency)
+	assert.Equal(t, "EUR", result.Modified.Currency)
+}
+
+// TestTryEstimateCostRPC_NilExpiresAt verifies that ExpiresAt remains nil
+// since the EstimateCostResponse proto lacks an expires_at field.
+func TestTryEstimateCostRPC_NilExpiresAt(t *testing.T) {
+	mock := &estimateMockPlugin{
+		estimateCostFunc: func(_ context.Context, _ *pbc.EstimateCostRequest, _ ...grpc.CallOption) (*pbc.EstimateCostResponse, error) {
+			return &pbc.EstimateCostResponse{
+				Currency:    "USD",
+				CostMonthly: 10.0,
+			}, nil
+		},
+	}
+
+	clients := []*pluginhost.Client{{Name: "test-plugin", API: mock}}
+	eng := New(clients, &mockSpecLoader{})
+
+	request := &EstimateRequest{
+		Resource: &ResourceDescriptor{
+			Provider:   "aws",
+			Type:       "aws:ec2/instance:Instance",
+			ID:         "i-exp",
+			Properties: map[string]interface{}{"instanceType": "t3.micro"},
+		},
+		PropertyOverrides: map[string]string{"instanceType": "m5.large"},
+	}
+
+	result, err := eng.EstimateCost(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.False(t, result.UsedFallback)
+	assert.Nil(t, result.Baseline.ExpiresAt, "ExpiresAt should be nil: EstimateCostResponse proto lacks expires_at")
+	assert.Nil(t, result.Modified.ExpiresAt, "ExpiresAt should be nil: EstimateCostResponse proto lacks expires_at")
+}
+
+// TestEstimateCost_FallbackOnUnimplemented verifies that when a plugin returns
+// Unimplemented for EstimateCost, the engine falls back to double-GetProjectedCost
+// and sets UsedFallback = true.
+func TestEstimateCost_FallbackOnUnimplemented(t *testing.T) {
+	mock := &estimateMockPlugin{
+		estimateCostFunc: func(_ context.Context, _ *pbc.EstimateCostRequest, _ ...grpc.CallOption) (*pbc.EstimateCostResponse, error) {
+			return nil, status.Error(codes.Unimplemented, "EstimateCost not implemented")
+		},
+	}
+
+	clients := []*pluginhost.Client{{Name: "unimpl-plugin", API: mock}}
+	eng := New(clients, &mockSpecLoader{})
+
+	request := &EstimateRequest{
+		Resource: &ResourceDescriptor{
+			Provider:   "aws",
+			Type:       "aws:ec2/instance:Instance",
+			ID:         "i-fallback",
+			Properties: map[string]interface{}{"instanceType": "t3.micro"},
+		},
+		PropertyOverrides: map[string]string{"instanceType": "m5.large"},
+	}
+
+	result, err := eng.EstimateCost(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.True(t, result.UsedFallback, "should use fallback when plugin returns Unimplemented")
+	require.NotNil(t, result.Baseline)
+	require.NotNil(t, result.Modified)
+	require.Len(t, result.Deltas, 1)
+	assert.Equal(t, "instanceType", result.Deltas[0].Property)
+}
+
+// TestEstimateCost_MultiPlugin_FirstUnimplemented verifies that when the first
+// plugin returns Unimplemented but the second implements the RPC, the engine
+// uses the second plugin's response with UsedFallback = false.
+func TestEstimateCost_MultiPlugin_FirstUnimplemented(t *testing.T) {
+	unimplMock := &estimateMockPlugin{
+		estimateCostFunc: func(_ context.Context, _ *pbc.EstimateCostRequest, _ ...grpc.CallOption) (*pbc.EstimateCostResponse, error) {
+			return nil, status.Error(codes.Unimplemented, "EstimateCost not implemented")
+		},
+	}
+
+	callCount := 0
+	implMock := &estimateMockPlugin{
+		estimateCostFunc: func(_ context.Context, _ *pbc.EstimateCostRequest, _ ...grpc.CallOption) (*pbc.EstimateCostResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return &pbc.EstimateCostResponse{Currency: "USD", CostMonthly: 20.0}, nil
+			}
+			return &pbc.EstimateCostResponse{Currency: "USD", CostMonthly: 45.0}, nil
+		},
+	}
+
+	clients := []*pluginhost.Client{
+		{Name: "unimpl-plugin", API: unimplMock},
+		{Name: "impl-plugin", API: implMock},
+	}
+	eng := New(clients, &mockSpecLoader{})
+
+	request := &EstimateRequest{
+		Resource: &ResourceDescriptor{
+			Provider:   "aws",
+			Type:       "aws:ec2/instance:Instance",
+			ID:         "i-multi",
+			Properties: map[string]interface{}{"instanceType": "t3.micro"},
+		},
+		PropertyOverrides: map[string]string{"instanceType": "m5.large"},
+	}
+
+	result, err := eng.EstimateCost(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.False(t, result.UsedFallback, "should NOT use fallback when second plugin implements RPC")
+	assert.Equal(t, 2, callCount, "second plugin should be called twice (baseline + modified)")
+	require.NotNil(t, result.Baseline)
+	require.NotNil(t, result.Modified)
+	assert.Equal(t, 20.0, result.Baseline.Monthly)
+	assert.Equal(t, 45.0, result.Modified.Monthly)
+	assert.InDelta(t, 25.0, result.TotalChange, 0.001)
+}
+
+// TestValidateEstimateResponse_NaN verifies that NaN CostMonthly is rejected.
+func TestValidateEstimateResponse_NaN(t *testing.T) {
+	resp := &pbc.EstimateCostResponse{Currency: "USD", CostMonthly: math.NaN()}
+	err := validateEstimateResponse(resp)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNonFiniteEstimateCost)
+}
+
+// TestValidateEstimateResponse_Inf verifies that Inf CostMonthly is rejected.
+func TestValidateEstimateResponse_Inf(t *testing.T) {
+	resp := &pbc.EstimateCostResponse{Currency: "USD", CostMonthly: math.Inf(1)}
+	err := validateEstimateResponse(resp)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNonFiniteEstimateCost)
+}
+
+// TestValidateEstimateResponse_NegativeInf verifies that -Inf CostMonthly is rejected.
+func TestValidateEstimateResponse_NegativeInf(t *testing.T) {
+	resp := &pbc.EstimateCostResponse{Currency: "USD", CostMonthly: math.Inf(-1)}
+	err := validateEstimateResponse(resp)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNonFiniteEstimateCost)
+}
+
+// TestValidateEstimateResponse_EmptyCurrency verifies that empty currency is rejected.
+func TestValidateEstimateResponse_EmptyCurrency(t *testing.T) {
+	resp := &pbc.EstimateCostResponse{Currency: "", CostMonthly: 10.0}
+	err := validateEstimateResponse(resp)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errEmptyEstimateCurrency)
+}
+
+// TestValidateEstimateResponse_Valid verifies that a valid response passes.
+func TestValidateEstimateResponse_Valid(t *testing.T) {
+	resp := &pbc.EstimateCostResponse{Currency: "USD", CostMonthly: 10.0}
+	err := validateEstimateResponse(resp)
+	require.NoError(t, err)
+}
+
+// TestTryEstimateCostRPC_NaNFallsBackToFallback verifies that NaN CostMonthly
+// from a plugin causes RPC rejection and engine falls back.
+func TestTryEstimateCostRPC_NaNFallsBackToFallback(t *testing.T) {
+	mock := &estimateMockPlugin{
+		estimateCostFunc: func(_ context.Context, _ *pbc.EstimateCostRequest, _ ...grpc.CallOption) (*pbc.EstimateCostResponse, error) {
+			return &pbc.EstimateCostResponse{
+				Currency:    "USD",
+				CostMonthly: math.NaN(),
+			}, nil
+		},
+	}
+
+	clients := []*pluginhost.Client{{Name: "test-plugin", API: mock}}
+	eng := New(clients, &mockSpecLoader{})
+
+	request := &EstimateRequest{
+		Resource: &ResourceDescriptor{
+			Provider:   "aws",
+			Type:       "aws:ec2/instance:Instance",
+			ID:         "i-nan",
+			Properties: map[string]interface{}{"instanceType": "t3.micro"},
+		},
+		PropertyOverrides: map[string]string{"instanceType": "m5.large"},
+	}
+
+	result, err := eng.EstimateCost(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.UsedFallback, "NaN response should cause fallback")
+}
+
+// TestTryEstimateCostRPC_CurrencyMismatchFallsBack verifies that differing
+// currencies between baseline and modified responses cause fallback.
+func TestTryEstimateCostRPC_CurrencyMismatchFallsBack(t *testing.T) {
+	callCount := 0
+	mock := &estimateMockPlugin{
+		estimateCostFunc: func(_ context.Context, _ *pbc.EstimateCostRequest, _ ...grpc.CallOption) (*pbc.EstimateCostResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return &pbc.EstimateCostResponse{Currency: "USD", CostMonthly: 10.0}, nil
+			}
+			return &pbc.EstimateCostResponse{Currency: "EUR", CostMonthly: 9.0}, nil
+		},
+	}
+
+	clients := []*pluginhost.Client{{Name: "test-plugin", API: mock}}
+	eng := New(clients, &mockSpecLoader{})
+
+	request := &EstimateRequest{
+		Resource: &ResourceDescriptor{
+			Provider:   "aws",
+			Type:       "aws:ec2/instance:Instance",
+			ID:         "i-mismatch",
+			Properties: map[string]interface{}{"instanceType": "t3.micro"},
+		},
+		PropertyOverrides: map[string]string{"instanceType": "m5.large"},
+	}
+
+	result, err := eng.EstimateCost(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.UsedFallback, "currency mismatch should cause fallback")
 }

--- a/internal/proto/adapter.go
+++ b/internal/proto/adapter.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
@@ -19,11 +20,6 @@ import (
 	"github.com/rshade/finfocus/internal/awsutil"
 	"github.com/rshade/finfocus/internal/logging"
 	"github.com/rshade/finfocus/internal/skus"
-)
-
-// ErrEstimateCostNotSupported indicates the EstimateCost RPC is not yet implemented.
-var ErrEstimateCostNotSupported = errors.New(
-	"EstimateCost RPC not yet implemented in finfocus-spec v0.5.6",
 )
 
 // ErrPropertiesMultiResource indicates Properties cannot be used with multiple ResourceIDs
@@ -705,6 +701,11 @@ type CostSourceClient interface {
 		in *pbc.SupportsRequest,
 		opts ...grpc.CallOption,
 	) (*pbc.SupportsResponse, error)
+	EstimateCost(
+		ctx context.Context,
+		in *pbc.EstimateCostRequest,
+		opts ...grpc.CallOption,
+	) (*pbc.EstimateCostResponse, error)
 }
 
 // NewCostSourceClient creates a new cost source client using the real proto client.
@@ -800,6 +801,14 @@ func (c *clientAdapter) Supports(
 	opts ...grpc.CallOption,
 ) (*pbc.SupportsResponse, error) {
 	return c.client.Supports(ctx, in, opts...)
+}
+
+func (c *clientAdapter) EstimateCost(
+	ctx context.Context,
+	in *pbc.EstimateCostRequest,
+	opts ...grpc.CallOption,
+) (*pbc.EstimateCostResponse, error) {
+	return c.client.EstimateCost(ctx, in, opts...)
 }
 
 // resolveSKUAndRegion determines the SKU and region for a resource using provider-specific
@@ -1274,63 +1283,28 @@ func aggregateImpactMetrics(result *ActualCostResult, pbcResults []*pbc.ActualCo
 	}
 }
 
-// EstimateCostRequest represents the internal request for what-if cost estimation.
-type EstimateCostRequest struct {
-	// Resource is the base resource descriptor
-	Resource *ResourceDescriptor `json:"resource,omitempty"`
-
-	// PropertyOverrides are the changes to evaluate
-	PropertyOverrides map[string]string `json:"propertyOverrides,omitempty"`
-
-	// UsageProfile optionally provides context (dev, prod, etc.)
-	UsageProfile string `json:"usageProfile,omitempty"`
-}
-
-// EstimateCostResponse contains the results of a cost estimation.
-type EstimateCostResponse struct {
-	// Baseline is the cost with original properties
-	Baseline *CostResult `json:"baseline,omitempty"`
-
-	// Modified is the cost with property overrides applied
-	Modified *CostResult `json:"modified,omitempty"`
-
-	// Deltas contains per-property cost impact breakdown
-	Deltas []*CostDelta `json:"deltas,omitempty"`
-}
-
-// CostDelta represents the cost impact of a single property change.
-type CostDelta struct {
-	// Property is the name of the property that was changed
-	Property string `json:"property"`
-
-	// OriginalValue is the value before the change
-	OriginalValue string `json:"originalValue"`
-
-	// NewValue is the value after the change
-	NewValue string `json:"newValue"`
-
-	// CostChange is the monthly cost difference
-	// Positive = increase, negative = savings
-	CostChange float64 `json:"costChange"`
-}
-
-// BuildEstimateCostRequest constructs an EstimateCostRequest proto message.
-//
-// This is the adapter layer function that converts engine-level types to
-// proto-level types for gRPC communication with plugins.
-//
-// Parameters:
-//   - resource: The ResourceDescriptor to estimate costs for
-//   - overrides: Property overrides to apply for the modified calculation
-//
-// Returns:
-//   - *EstimateCostRequest: The internal request (nil when RPC not implemented)
-//   - error: ErrEstimateCostNotSupported until the RPC is implemented
+// BuildEstimateCostRequest constructs a pbc.EstimateCostRequest proto message.
+// Called twice per estimation: once for baseline properties, once for modified.
 func BuildEstimateCostRequest(
-	_ *ResourceDescriptor,
-	_ map[string]string,
-) (*EstimateCostRequest, error) {
-	return nil, ErrEstimateCostNotSupported
+	resourceType string,
+	properties map[string]any,
+) (*pbc.EstimateCostRequest, error) {
+	if resourceType == "" {
+		return nil, errors.New("resource type must not be empty")
+	}
+
+	if properties == nil {
+		properties = map[string]any{}
+	}
+	attrs, err := structpb.NewStruct(properties)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert properties to proto struct: %w", err)
+	}
+
+	return &pbc.EstimateCostRequest{
+		ResourceType: resourceType,
+		Attributes:   attrs,
+	}, nil
 }
 
 func (c *clientAdapter) GetRecommendations(

--- a/internal/proto/adapter_test.go
+++ b/internal/proto/adapter_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
@@ -62,6 +63,11 @@ type mockCostSourceClient struct {
 		in *pbc.SupportsRequest,
 		opts ...grpc.CallOption,
 	) (*pbc.SupportsResponse, error)
+	estimateCostFunc func(
+		ctx context.Context,
+		in *pbc.EstimateCostRequest,
+		opts ...grpc.CallOption,
+	) (*pbc.EstimateCostResponse, error)
 }
 
 func (m *mockCostSourceClient) Name(
@@ -161,6 +167,17 @@ func (m *mockCostSourceClient) Supports(
 		return m.supportsFunc(ctx, in, opts...)
 	}
 	return &pbc.SupportsResponse{Supported: true}, nil
+}
+
+func (m *mockCostSourceClient) EstimateCost(
+	ctx context.Context,
+	in *pbc.EstimateCostRequest,
+	opts ...grpc.CallOption,
+) (*pbc.EstimateCostResponse, error) {
+	if m.estimateCostFunc != nil {
+		return m.estimateCostFunc(ctx, in, opts...)
+	}
+	return nil, status.Error(codes.Unimplemented, "EstimateCost not implemented")
 }
 
 // T020: Unit test for DryRun wrapper.
@@ -3643,4 +3660,37 @@ func TestClientAdapter_GetActualCost_ExpiresAt(t *testing.T) {
 		assert.WithinDuration(t, onlyTS, *resp.Results[0].ExpiresAt, time.Second,
 			"should use the only non-nil expires_at")
 	})
+}
+
+func TestBuildEstimateCostRequest_ValidResource(t *testing.T) {
+	properties := map[string]any{
+		"instanceType": "m5.large",
+		"region":       "us-east-1",
+	}
+
+	req, err := BuildEstimateCostRequest("aws:ec2/instance:Instance", properties)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Equal(t, "aws:ec2/instance:Instance", req.GetResourceType())
+	require.NotNil(t, req.GetAttributes())
+
+	expected, err := structpb.NewStruct(properties)
+	require.NoError(t, err)
+	assert.Equal(t, expected.AsMap(), req.GetAttributes().AsMap())
+}
+
+func TestBuildEstimateCostRequest_EmptyType(t *testing.T) {
+	req, err := BuildEstimateCostRequest("", map[string]any{"key": "val"})
+	require.Error(t, err)
+	assert.Nil(t, req)
+	assert.Contains(t, err.Error(), "resource type must not be empty")
+}
+
+func TestBuildEstimateCostRequest_NilProperties(t *testing.T) {
+	req, err := BuildEstimateCostRequest("aws:ec2/instance:Instance", nil)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Equal(t, "aws:ec2/instance:Instance", req.GetResourceType())
+	require.NotNil(t, req.GetAttributes())
+	assert.Empty(t, req.GetAttributes().AsMap())
 }

--- a/specs/608-estimate-cost-rpc/checklists/requirements.md
+++ b/specs/608-estimate-cost-rpc/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: EstimateCost RPC Consumer
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec references specific function names (`tryEstimateCostRPC`,
+  `BuildEstimateCostRequest`, `CostSourceClient`) because this is a stub
+  replacement — the functions already exist, the spec describes what they
+  should do rather than how.
+- The dependency on #844 (finfocus-spec v0.5.7) appears already satisfied
+  since `go.mod` shows v0.6.0. Should be confirmed before implementation.
+- All items pass validation. Spec is ready for `/speckit.clarify` or
+  `/speckit.plan`.

--- a/specs/608-estimate-cost-rpc/contracts/estimate-rpc-mapping.md
+++ b/specs/608-estimate-cost-rpc/contracts/estimate-rpc-mapping.md
@@ -1,0 +1,114 @@
+# Contract: EstimateCost RPC Mapping
+
+**Feature**: 608-estimate-cost-rpc
+**Date**: 2026-03-31
+
+## Overview
+
+This document maps the gRPC contract between finfocus-core (consumer) and
+plugins (implementor) for the `EstimateCost` RPC.
+
+## gRPC Method
+
+```text
+Service: finfocus.v1.CostSourceService
+Method:  EstimateCost
+Full:    /finfocus.v1.CostSourceService/EstimateCost
+```
+
+## Request/Response Contract
+
+### Request (core → plugin)
+
+```protobuf
+message EstimateCostRequest {
+  string resource_type = 1;        // e.g., "aws:ec2/instance:Instance"
+  google.protobuf.Struct attributes = 2;  // Resource properties
+}
+```
+
+### Response (plugin → core)
+
+```protobuf
+message EstimateCostResponse {
+  string currency = 1;                              // ISO 4217
+  double cost_monthly = 2;                           // Monthly cost (730h)
+  FocusPricingCategory pricing_category = 3;         // Standard/Committed/Dynamic
+  double spot_interruption_risk_score = 4;           // 0.0-1.0
+}
+```
+
+## Core Consumer Contract
+
+### Interface Addition
+
+```go
+// Added to CostSourceClient interface in internal/proto/adapter.go
+EstimateCost(ctx context.Context, in *pbc.EstimateCostRequest,
+    opts ...grpc.CallOption) (*pbc.EstimateCostResponse, error)
+```
+
+### Adapter Implementation
+
+```go
+// clientAdapter delegates directly to generated client
+func (c *clientAdapter) EstimateCost(
+    ctx context.Context,
+    in *pbc.EstimateCostRequest,
+    opts ...grpc.CallOption,
+) (*pbc.EstimateCostResponse, error) {
+    return c.client.EstimateCost(ctx, in, opts...)
+}
+```
+
+### Request Builder
+
+```go
+// BuildEstimateCostRequest constructs a proto request from engine types.
+// Called twice per estimation: once for baseline, once for modified.
+func BuildEstimateCostRequest(
+    resource *ResourceDescriptor,
+    properties map[string]interface{},
+) (*pbc.EstimateCostRequest, error)
+```
+
+## Error Handling Contract
+
+### gRPC Status Codes
+
+| Code | Condition | Core Action |
+|------|-----------|-------------|
+| `OK` | Success | Map response to CostResult |
+| `UNIMPLEMENTED` | Plugin lacks EstimateCost | Fall through to next plugin; if all unimplemented, use fallback |
+| `INVALID_ARGUMENT` | Bad resource type or attributes | Log, try next plugin |
+| `NOT_FOUND` | Unknown resource type | Log, try next plugin |
+| `DEADLINE_EXCEEDED` | Timeout | Log, try next plugin |
+| `UNAVAILABLE` | Plugin down | Log, try next plugin |
+
+### Fallback Chain
+
+```text
+For each plugin:
+  1. Try EstimateCost RPC (baseline + modified)
+  2. If Unimplemented → continue to next plugin
+  3. If other error → log, continue to next plugin
+  4. If success → return EstimateResult(UsedFallback=false)
+
+If all plugins exhausted:
+  5. Use estimateCostFallback (double GetProjectedCost)
+  6. Return EstimateResult(UsedFallback=true)
+```
+
+## Two-Call Strategy
+
+Since the proto provides single-resource estimation (not baseline/modified
+pairs), the engine calls the RPC twice per what-if analysis:
+
+```text
+Call 1: EstimateCost(resource_type, original_properties) → baseline
+Call 2: EstimateCost(resource_type, merged_properties)   → modified
+Delta:  modified.CostMonthly - baseline.CostMonthly
+```
+
+Property merging: deep copy original properties, overlay overrides (same
+logic as `estimateCostFallback` at `estimate.go:217-225`).

--- a/specs/608-estimate-cost-rpc/data-model.md
+++ b/specs/608-estimate-cost-rpc/data-model.md
@@ -1,0 +1,107 @@
+# Data Model: EstimateCost RPC Consumer
+
+**Feature**: 608-estimate-cost-rpc
+**Date**: 2026-03-31
+
+## Entity Overview
+
+This feature connects existing entities — no new data models are introduced.
+The key mapping is between engine-level types and proto-level types.
+
+## Proto Types (finfocus-spec v0.6.0, read-only)
+
+### pbc.EstimateCostRequest
+
+```text
+EstimateCostRequest
+├── ResourceType    string           # Pulumi type token
+└── Attributes      *structpb.Struct # Resource properties
+```
+
+### pbc.EstimateCostResponse
+
+```text
+EstimateCostResponse
+├── Currency                  string                # ISO 4217
+├── CostMonthly               float64               # Monthly cost (730h)
+├── PricingCategory            FocusPricingCategory  # Standard/Committed/Dynamic
+└── SpotInterruptionRiskScore  float64               # 0.0-1.0
+```
+
+## Engine Types (existing, unchanged)
+
+### engine.EstimateRequest (types.go:606)
+
+```text
+EstimateRequest
+├── Resource           *ResourceDescriptor  # Base resource
+└── PropertyOverrides  map[string]string    # Changes to evaluate
+```
+
+### engine.EstimateResult (types.go:559)
+
+```text
+EstimateResult
+├── Resource      *ResourceDescriptor
+├── Baseline      *CostResult          # Cost with original properties
+├── Modified      *CostResult          # Cost with overrides applied
+├── TotalChange   float64              # Modified.Monthly - Baseline.Monthly
+├── Deltas        []CostDelta          # Per-property cost impact
+└── UsedFallback  bool                 # false when RPC succeeded
+```
+
+### engine.CostResult (types.go — relevant fields)
+
+```text
+CostResult
+├── Currency       string
+├── MonthlyCost    float64    # Mapped from pbc.CostMonthly
+├── HourlyCost     float64    # Derived: CostMonthly / 730
+├── Notes          string
+├── CostBreakdown  map[string]float64
+├── Sustainability map[string]SustainabilityMetric
+└── ExpiresAt      *time.Time  # Not on EstimateCostResponse proto
+```
+
+## Type Mapping: Proto → Engine
+
+### EstimateCostResponse → CostResult
+
+| Proto Field | Engine Field | Transformation |
+|-------------|-------------|----------------|
+| `Currency` | `Currency` | Direct copy |
+| `CostMonthly` | `MonthlyCost` | Direct copy |
+| `CostMonthly` | `HourlyCost` | `CostMonthly / 730` |
+| `PricingCategory` | `Notes` | Append category name |
+| `SpotInterruptionRiskScore` | `Notes` | Append if > 0 |
+| (not present) | `ExpiresAt` | nil (EstimateCost proto lacks expires_at) |
+
+### ResourceDescriptor → EstimateCostRequest
+
+| Engine Field | Proto Field | Transformation |
+|-------------|-------------|----------------|
+| `Type` | `ResourceType` | Direct copy |
+| `Properties` | `Attributes` | `structpb.NewStruct(properties)` |
+
+## Types Removed (dead code)
+
+These internal adapter types become unused after stub replacement:
+
+- `proto.EstimateCostRequest` (adapter.go:1277) — replaced by `pbc.EstimateCostRequest`
+- `proto.EstimateCostResponse` (adapter.go:1289) — engine uses `EstimateResult` directly
+- `proto.CostDelta` (adapter.go:1301) — duplicates `engine.CostDelta`
+- `proto.ErrEstimateCostNotSupported` (adapter.go:24) — sentinel error for stub
+
+## Validation Rules
+
+### BuildEstimateCostRequest Input Validation
+
+- `ResourceDescriptor` MUST NOT be nil
+- `ResourceDescriptor.Type` MUST NOT be empty
+- `Properties` MAY be nil (treated as empty struct)
+
+### EstimateCostResponse Output Validation
+
+- Response MUST NOT be nil
+- `CostMonthly` MUST be >= 0 (negative costs are invalid)
+- `Currency` SHOULD NOT be empty (default to "USD" if missing)

--- a/specs/608-estimate-cost-rpc/plan.md
+++ b/specs/608-estimate-cost-rpc/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: EstimateCost RPC Consumer
+
+**Branch**: `608-estimate-cost-rpc` | **Date**: 2026-03-31 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/608-estimate-cost-rpc/spec.md`
+
+## Summary
+
+Replace stubbed `tryEstimateCostRPC` and `BuildEstimateCostRequest` with real
+implementations that call the plugin's `EstimateCost` gRPC RPC. The actual
+proto (finfocus-spec v0.6.0) provides a simple single-resource estimation
+interface (`ResourceType` + `Attributes` -> `CostMonthly`), so the "what-if"
+comparison logic (baseline vs modified) lives in the engine, calling the RPC
+twice per estimation.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.8 (see `go.mod`)
+**Primary Dependencies**: finfocus-spec v0.6.0 (proto definitions), gRPC, Cobra, zerolog
+**Storage**: N/A (no new persistent state)
+**Testing**: `go test` with testify assertions, mocked gRPC clients
+**Target Platform**: Linux (amd64, arm64), macOS (amd64, arm64), Windows (amd64)
+**Project Type**: Single CLI binary with gRPC plugin architecture
+**Performance Goals**: EstimateCost calls should complete within `perResourceTimeout` (existing)
+**Constraints**: No new dependencies; reuses existing adapter patterns
+**Scale/Scope**: 4 files modified, ~150-200 lines of new code + tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **Plugin-First Architecture**: This replaces a stub that delegates to
+  plugins via gRPC. Core remains provider-agnostic; estimation logic is
+  executed by the plugin.
+- [x] **Test-Driven Development**: Tests planned for all new code paths:
+  successful RPC, unimplemented fallback, validation errors, nil response
+  handling. 80%+ coverage target. No TUI changes.
+- [x] **Cross-Platform Compatibility**: No platform-specific code. Uses
+  standard gRPC and protobuf types.
+- [x] **Documentation Integrity**: CHANGELOG update planned. No new exported
+  API surface requiring README changes. Existing `cost estimate` docs remain
+  valid.
+- [x] **Protocol Stability**: Consumes existing `EstimateCost` RPC from
+  finfocus-spec v0.6.0. No protocol changes.
+- [x] **Implementation Completeness**: Removes stubs and sentinel error.
+  Constitution Principle VI is the primary driver — replacing
+  `ErrEstimateCostNotSupported` with real behavior.
+- [x] **Persistence Model**: No persistent state changes. No new BoltDB stores.
+- [x] **Quality Gates**: `make test && make lint` required before completion.
+- [x] **Multi-Repo Coordination**: Consumes finfocus-spec v0.6.0 (already in
+  `go.mod`). No spec-side changes needed. Plugin implementations unaffected
+  (they already implement or don't implement EstimateCost).
+
+**Violations Requiring Justification**: None.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/608-estimate-cost-rpc/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── estimate-rpc-mapping.md
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+internal/proto/
+├── adapter.go           # MODIFIED: Add EstimateCost to CostSourceClient,
+│                        #   implement clientAdapter.EstimateCost,
+│                        #   replace BuildEstimateCostRequest stub,
+│                        #   remove ErrEstimateCostNotSupported
+├── adapter_test.go      # MODIFIED: Add tests, update mock
+
+internal/engine/
+├── estimate.go          # MODIFIED: Replace tryEstimateCostRPC stub
+├── estimate_test.go     # MODIFIED: Add RPC success/fallback tests
+```
+
+**Structure Decision**: This modifies existing files only — no new files needed.
+The adapter pattern is established; we add one more method following the same
+conventions as `GetProjectedCost`, `DismissRecommendation`, etc.
+
+## Key Technical Decisions
+
+### Proto Shape Mismatch
+
+The actual `pbc.EstimateCostRequest` (v0.6.0) is simpler than the original
+design document (`specs/223-cost-estimate/contracts/estimate-rpc.md`):
+
+| Aspect | Original Design | Actual Proto (v0.6.0) |
+|--------|----------------|----------------------|
+| Request | ResourceDescriptor + property_overrides + UsageProfile | ResourceType + Attributes (structpb.Struct) |
+| Response | baseline + modified + deltas[] | Currency + CostMonthly + PricingCategory + SpotRisk |
+
+**Impact**: The "what-if" comparison (baseline vs modified) stays in the engine.
+`tryEstimateCostRPC` calls the plugin's `EstimateCost` **twice** — once with
+original properties, once with overrides applied — then computes deltas.
+
+### Interface Method Signature
+
+Follow the pattern of `GetBudgets`, `DryRun`, `Supports` — pass `pbc` types
+directly since the proto is simple and no internal wrapper is needed:
+
+```go
+EstimateCost(ctx context.Context, in *pbc.EstimateCostRequest,
+    opts ...grpc.CallOption) (*pbc.EstimateCostResponse, error)
+```
+
+### BuildEstimateCostRequest Redesign
+
+The function signature changes to build a `pbc.EstimateCostRequest` (not the
+internal `EstimateCostRequest`). It takes a `ResourceDescriptor` and builds
+the proto using `structpb.NewStruct` for the Attributes field. The caller
+invokes it twice (baseline + modified).
+
+### Internal Types Cleanup
+
+The internal `EstimateCostRequest`, `EstimateCostResponse`, and `CostDelta`
+types in `adapter.go:1277-1315` become unused after the stub is removed.
+They should be removed to avoid dead code.

--- a/specs/608-estimate-cost-rpc/quickstart.md
+++ b/specs/608-estimate-cost-rpc/quickstart.md
@@ -1,0 +1,66 @@
+# Quickstart: EstimateCost RPC Consumer
+
+**Feature**: 608-estimate-cost-rpc
+**Date**: 2026-03-31
+
+## What Changed
+
+The `cost estimate` command now calls plugins via the `EstimateCost` gRPC RPC
+when available. Previously, the engine always used a fallback strategy (calling
+`GetProjectedCost` twice). Now, plugins that implement `EstimateCost` are
+called directly for more accurate estimates.
+
+## User-Facing Behavior
+
+**No CLI changes.** The `finfocus cost estimate` command works the same way.
+The difference is internal — the engine prefers the `EstimateCost` RPC over
+the fallback path.
+
+### With a Plugin That Implements EstimateCost
+
+```bash
+finfocus cost estimate \
+  --provider aws \
+  --resource-type ec2:Instance \
+  --property instanceType=m5.large
+```
+
+The engine calls the plugin's `EstimateCost` RPC twice (baseline + modified)
+and computes the delta. Output is the same format.
+
+### With a Plugin That Does NOT Implement EstimateCost
+
+```bash
+finfocus cost estimate \
+  --provider aws \
+  --resource-type ec2:Instance \
+  --property instanceType=m5.large
+```
+
+The engine falls back to double `GetProjectedCost` calls. The
+`UsedFallback` flag in JSON output indicates which path was taken.
+
+## For Plugin Developers
+
+If your plugin already implements `EstimateCost` in the
+`CostSourceService` gRPC service, no changes are needed. The core will
+now actually call it.
+
+If your plugin does NOT implement `EstimateCost`, it continues to work via
+the fallback path. The core handles `Unimplemented` gracefully.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `internal/proto/adapter.go` | Added `EstimateCost` to `CostSourceClient` interface; implemented `clientAdapter.EstimateCost`; replaced `BuildEstimateCostRequest` stub; removed `ErrEstimateCostNotSupported` and dead internal types |
+| `internal/engine/estimate.go` | Replaced `tryEstimateCostRPC` stub with real two-call implementation |
+| `internal/proto/adapter_test.go` | Updated mocks, added tests |
+| `internal/engine/estimate_test.go` | Added RPC success/fallback/error tests |
+
+## Verification
+
+```bash
+make test   # All tests pass
+make lint   # No lint errors
+```

--- a/specs/608-estimate-cost-rpc/research.md
+++ b/specs/608-estimate-cost-rpc/research.md
@@ -1,0 +1,139 @@
+# Research: EstimateCost RPC Consumer
+
+**Feature**: 608-estimate-cost-rpc
+**Date**: 2026-03-31
+
+## Research Question 1: Proto Type Shape
+
+**Task**: Determine the exact fields on `pbc.EstimateCostRequest` and
+`pbc.EstimateCostResponse` in finfocus-spec v0.6.0.
+
+**Decision**: Use the actual proto types as-is.
+
+**Findings**:
+
+### EstimateCostRequest (costsource.pb.go:3558)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ResourceType` | `string` | Pulumi resource type (e.g., `aws:ec2/instance:Instance`) |
+| `Attributes` | `*structpb.Struct` | Resource properties as structured JSON |
+
+### EstimateCostResponse (costsource.pb.go:3637)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Currency` | `string` | ISO 4217 code (e.g., `USD`) |
+| `CostMonthly` | `float64` | Estimated monthly cost (730h basis) |
+| `PricingCategory` | `FocusPricingCategory` | Standard/Committed/Dynamic |
+| `SpotInterruptionRiskScore` | `float64` | 0.0-1.0 spot risk score |
+
+**Rationale**: The proto is simpler than the original design document. It
+provides a single estimation (not a baseline/modified pair), so the comparison
+logic must live in the engine.
+
+**Alternatives considered**: Wrapping proto types in internal types (rejected —
+adds unnecessary indirection since proto is simple enough to use directly,
+following the `GetBudgets`/`DryRun`/`Supports` pattern).
+
+## Research Question 2: Attributes Field Construction
+
+**Task**: Determine how to convert `map[string]interface{}` (engine
+`ResourceDescriptor.Properties`) to `*structpb.Struct` (proto request).
+
+**Decision**: Use `structpb.NewStruct()` from `google.golang.org/protobuf`.
+
+**Findings**:
+
+- `structpb.NewStruct(m map[string]interface{})` handles the conversion
+- Already imported via `google.golang.org/protobuf/types/known/timestamppb`
+  in the same package
+- Need to add `"google.golang.org/protobuf/types/known/structpb"` import
+- For `map[string]string` (property overrides), convert to
+  `map[string]interface{}` before calling `structpb.NewStruct`
+
+**Rationale**: Standard protobuf approach. No custom serialization needed.
+
+**Alternatives considered**: Manual `structpb.Value` construction (rejected —
+more code, same result).
+
+## Research Question 3: Two-Call Strategy in tryEstimateCostRPC
+
+**Task**: Determine the correct flow for what-if comparison using a
+single-estimation proto.
+
+**Decision**: `tryEstimateCostRPC` calls `EstimateCost` twice (baseline +
+modified) and computes the delta.
+
+**Findings**:
+
+The flow is:
+
+1. Build baseline proto request from `request.Resource.Properties`
+2. Call `client.API.EstimateCost(ctx, baselineReq)` → baseline response
+3. Deep copy resource properties, merge `request.PropertyOverrides`
+4. Build modified proto request from merged properties
+5. Call `client.API.EstimateCost(ctx, modifiedReq)` → modified response
+6. Convert both responses to `engine.CostResult`
+7. Compute `TotalChange = modified.Monthly - baseline.Monthly`
+8. Build per-property deltas (single-property: attributed; multi-property:
+   combined — same logic as `estimateCostFallback`)
+9. Return `*EstimateResult` with `UsedFallback = false`
+
+**Rationale**: Mirrors the existing `estimateCostFallback` strategy but uses
+`EstimateCost` instead of `GetProjectedCost`. The advantage is that
+`EstimateCost` is purpose-built for single-resource estimation with arbitrary
+attributes, while `GetProjectedCost` requires a `ResourceDescriptor` with
+SKU/region resolution.
+
+**Alternatives considered**:
+- Single RPC call returning baseline+modified (rejected — proto doesn't
+  support it)
+- Delegating delta computation to plugin (rejected — proto doesn't support it)
+
+## Research Question 4: Internal Type Cleanup
+
+**Task**: Determine which internal types in `adapter.go` become dead code.
+
+**Decision**: Remove `EstimateCostRequest`, `EstimateCostResponse`, and
+`CostDelta` from `adapter.go`. Also remove `ErrEstimateCostNotSupported`.
+
+**Findings**:
+
+- `EstimateCostRequest` (adapter.go:1277) — was designed for the original
+  spec; `BuildEstimateCostRequest` now returns `*pbc.EstimateCostRequest`
+- `EstimateCostResponse` (adapter.go:1289) — never used outside the stub;
+  engine uses `EstimateResult` directly
+- `CostDelta` (adapter.go:1301) — duplicates `engine.CostDelta` (types.go:591);
+  engine type is authoritative
+- `ErrEstimateCostNotSupported` (adapter.go:24-27) — sentinel error for the
+  stub; no longer needed
+
+**Rationale**: Dead code violates constitution Principle VI. Removing these
+types eliminates confusion about which types are authoritative (engine types
+are).
+
+**Alternatives considered**: Keeping internal types as a mapping layer
+(rejected — adds indirection without value since proto types are used
+directly for the interface method).
+
+## Research Question 5: Mock Updates
+
+**Task**: Identify all mock implementations that need `EstimateCost` added.
+
+**Decision**: Update `CostSourceClient` interface and all mock
+implementations.
+
+**Findings**:
+
+Mocks that implement `CostSourceClient`:
+- `adapter_test.go` — test mocks within the proto package
+- `internal/engine/estimate_test.go` — engine test mocks
+- Any other test files using the interface
+
+The `mockPbcCostSourceServiceClient` in `adapter_test.go:3105` already has
+`EstimateCost` (implements the generated `pbc.CostSourceServiceClient`).
+Only the internal `CostSourceClient` interface mocks need the new method.
+
+**Rationale**: Adding a method to an interface is a compile-breaking change.
+All implementors must be updated.

--- a/specs/608-estimate-cost-rpc/spec.md
+++ b/specs/608-estimate-cost-rpc/spec.md
@@ -1,0 +1,237 @@
+# Feature Specification: Implement EstimateCost RPC Consumer (Remove Stub)
+
+**Feature Branch**: `608-estimate-cost-rpc`
+**Created**: 2026-03-30
+**Status**: Draft
+**Input**: GitHub Issue #847: Replace `tryEstimateCostRPC` and `BuildEstimateCostRequest` stubs with real gRPC implementations
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Plugin-Powered What-If Estimation (Priority: P1)
+
+A developer runs `finfocus cost estimate` with property overrides and the
+engine calls the plugin's `EstimateCost` RPC directly. The plugin returns
+baseline cost, modified cost, and per-property deltas — all computed
+server-side with the plugin's pricing data.
+
+**Why this priority**: This is the core value — enabling plugins to provide
+accurate, server-side cost estimates rather than relying on local YAML specs or
+the less precise double-`GetProjectedCost` fallback. It unblocks the entire
+estimation pipeline for plugins that implement the RPC.
+
+**Independent Test**: Can be fully tested by calling `EstimateCost` on the
+engine with a mock plugin that implements the RPC, verifying that the response
+contains baseline, modified, and delta data from the plugin (not from the
+fallback path).
+
+**Acceptance Scenarios**:
+
+1. **Given** a plugin that implements `EstimateCost`, **When** the engine calls
+   `tryEstimateCostRPC` with a valid request containing resource descriptor and
+   property overrides, **Then** the engine returns an `EstimateResult` with
+   baseline and modified costs from the plugin, and `UsedFallback` is false.
+
+2. **Given** a plugin that returns per-property deltas in its response,
+   **When** the engine processes the `EstimateCostResponse`, **Then** the
+   `EstimateResult.Deltas` slice contains one `CostDelta` per overridden
+   property with correct cost change values.
+
+3. **Given** a plugin that returns a valid `EstimateCostResponse`, **When**
+   the engine converts the response to `CostResult`, **Then** `ExpiresAt` is
+   nil (the `EstimateCostResponse` proto lacks `expires_at`) and the existing
+   cache machinery uses default TTL behavior.
+
+---
+
+### User Story 2 - Graceful Fallback to Double-GetProjectedCost (Priority: P2)
+
+A developer runs `finfocus cost estimate` but the plugin does not implement
+`EstimateCost` (returns `Unimplemented`). The engine transparently falls back
+to the existing double-`GetProjectedCost` strategy.
+
+**Why this priority**: Backward compatibility is essential. Existing plugins
+that do not implement the new RPC must continue to work without degradation.
+The existing fallback path must remain functional.
+
+**Independent Test**: Can be fully tested by calling `EstimateCost` with a mock
+plugin that returns `Unimplemented` and verifying the engine produces a result
+with `UsedFallback = true`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a plugin that returns `Unimplemented` for `EstimateCost`, **When**
+   the engine calls `tryEstimateCostRPC`, **Then** the engine falls through to
+   `estimateCostFallback` and returns a valid `EstimateResult` with
+   `UsedFallback = true`.
+
+2. **Given** multiple plugins where the first returns `Unimplemented` and the
+   second implements the RPC, **When** the engine iterates plugins, **Then** the
+   engine uses the second plugin's RPC response (not the fallback).
+
+---
+
+### User Story 3 - Adapter Builds Valid Proto Requests (Priority: P1)
+
+The adapter layer correctly converts engine-level `EstimateRequest` into the
+gRPC-level `EstimateCostRequest` proto message, populating resource descriptor,
+property overrides, and usage profile.
+
+**Why this priority**: Without correct request construction, the RPC call sends
+empty or malformed data to plugins. This is a prerequisite for Story 1.
+
+**Independent Test**: Can be fully tested by calling `BuildEstimateCostRequest`
+with various input combinations and verifying the resulting proto message has
+correct fields populated.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource descriptor with provider, type, SKU, and region,
+   **When** `BuildEstimateCostRequest` is called, **Then** the returned proto
+   request has all fields populated correctly.
+
+2. **Given** properties with multiple key-value pairs, **When**
+   `BuildEstimateCostRequest` is called, **Then** the proto request's
+   `Attributes` struct contains all entries as structpb values.
+
+3. **Given** a nil resource descriptor, **When** `BuildEstimateCostRequest` is
+   called, **Then** an appropriate validation error is returned.
+
+---
+
+### User Story 4 - Interface Completeness (Priority: P1)
+
+The `CostSourceClient` interface includes `EstimateCost` so that all adapter
+and mock implementations can delegate to the gRPC method.
+
+**Why this priority**: The interface is the contract that binds the engine to
+plugin communication. Without this method, the adapter cannot call the RPC.
+
+**Independent Test**: Can be fully tested by verifying that `clientAdapter`
+satisfies `CostSourceClient` at compile time and that the method delegates to
+the underlying gRPC client.
+
+**Acceptance Scenarios**:
+
+1. **Given** the `CostSourceClient` interface, **When** compiled, **Then** it
+   includes an `EstimateCost` method with the correct signature.
+
+2. **Given** a `clientAdapter` instance, **When** `EstimateCost` is called,
+   **Then** it delegates to the underlying `pbc.CostSourceServiceClient`.
+
+---
+
+### Edge Cases
+
+- What happens when the plugin returns a nil `EstimateCostResponse`? The
+  engine must return an error for the nil response.
+- What happens when `PropertyOverrides` is empty? The engine should reject
+  the request at validation (no meaningful comparison without overrides).
+- What happens when plugin returns deltas that don't match the requested
+  overrides? The engine should use whatever the plugin provides without
+  revalidating delta keys.
+- What happens when multiple plugins are available and the first times out?
+  The engine already handles this — it logs and tries the next plugin.
+- What happens when the plugin returns a cost in a different currency than
+  expected? The engine should pass through the plugin's currency without
+  conversion (consistent with existing behavior).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST add `EstimateCost` method to the `CostSourceClient`
+  interface with the correct gRPC signature.
+- **FR-002**: System MUST implement `clientAdapter.EstimateCost` to delegate to
+  the underlying `pbc.CostSourceServiceClient.EstimateCost`.
+- **FR-003**: System MUST replace `BuildEstimateCostRequest` stub with real
+  request construction that maps `ResourceDescriptor` and property overrides to
+  the proto `EstimateCostRequest` message.
+- **FR-004**: System MUST replace `tryEstimateCostRPC` stub with real
+  implementation that builds the proto request, calls the adapter, and converts
+  the response to `EstimateResult`.
+- **FR-005**: System MUST remove the `ErrEstimateCostNotSupported` sentinel
+  error from the adapter package.
+- **FR-006**: System MUST preserve the existing fallback behavior — when a
+  plugin returns `Unimplemented`, the engine falls through to
+  `estimateCostFallback`.
+- **FR-007**: System MUST handle the absence of `expires_at` on
+  `EstimateCostResponse` by leaving `CostResult.ExpiresAt` nil, allowing the
+  existing cache machinery to use default TTL behavior.
+- **FR-008**: System MUST validate the `EstimateCostResponse` — return errors
+  for nil response or negative `CostMonthly`, and default `Currency` to "USD"
+  when empty.
+- **FR-009**: System MUST update all mock implementations to satisfy the
+  expanded `CostSourceClient` interface.
+
+### Key Entities
+
+- **EstimateCostRequest (proto)**: gRPC request containing resource descriptor,
+  property overrides, and optional usage profile. Sent to plugin.
+- **EstimateCostResponse (proto)**: gRPC response containing baseline cost,
+  modified cost, and per-property deltas. Received from plugin.
+- **EstimateRequest (engine)**: Internal engine-level request structure
+  (already exists in `types.go`).
+- **EstimateResult (engine)**: Internal engine-level result structure (already
+  exists in `types.go`).
+- **CostSourceClient (adapter)**: Interface that wraps the gRPC client — must
+  gain `EstimateCost` method.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users running `cost estimate` with a plugin that implements
+  `EstimateCost` receive per-property cost deltas directly from the plugin
+  without using the fallback path.
+- **SC-002**: Users running `cost estimate` with a plugin that does NOT
+  implement `EstimateCost` experience no change in behavior — the existing
+  fallback continues to work.
+- **SC-003**: All existing tests continue to pass after the stub is replaced.
+- **SC-004**: New tests achieve 80% or higher coverage on changed code,
+  including success path, unimplemented fallback, validation errors, and
+  timeout handling.
+- **SC-005**: The `ErrEstimateCostNotSupported` sentinel error is fully removed
+  from the codebase with no references remaining.
+- **SC-006**: `make test && make lint` pass with zero errors.
+
+## Assumptions
+
+- finfocus-spec v0.6.0 (already in `go.mod`) includes the `EstimateCost` RPC
+  definition with `EstimateCostRequest` and `EstimateCostResponse` proto
+  messages.
+- The existing `estimateCostFallback` function is correct and does not need
+  modification.
+- The existing engine loop in `EstimateCost` (lines 68-132 of `estimate.go`)
+  already handles `Unimplemented`, timeout, and cancellation — only
+  `tryEstimateCostRPC` needs replacement.
+- Plugin capability checking (via `Supports` RPC) is handled at the router
+  level, not within `tryEstimateCostRPC` itself.
+- No CLI changes are needed — the `cost estimate` command already calls
+  `engine.EstimateCost`.
+
+## Scope Boundaries
+
+**In scope**:
+
+- Adapter interface expansion (`CostSourceClient.EstimateCost`)
+- Adapter implementation (`clientAdapter.EstimateCost`)
+- Request builder (`BuildEstimateCostRequest`)
+- Engine RPC caller (`tryEstimateCostRPC`)
+- Sentinel error removal
+- Unit tests for all new code paths
+
+**Out of scope**:
+
+- CLI changes (already wired)
+- Plugin-side implementation (plugins implement their own `EstimateCost`)
+- New capabilities or features beyond replacing the stub
+- Cache layer changes (TTL handling reuses existing patterns)
+- Router capability checks (already handled by router)
+
+## Dependencies
+
+- **Blocked by**: Issue #844 (upgrade finfocus-spec to v0.5.7) — however,
+  finfocus-spec v0.6.0 is already in `go.mod`, so this dependency may already
+  be satisfied.
+- **Related**: Issue #846 (BatchCost supports `COST_QUERY_TYPE_ESTIMATE`)
+- **Related**: Issue #845 (cache `expires_at` handling)

--- a/specs/608-estimate-cost-rpc/tasks.md
+++ b/specs/608-estimate-cost-rpc/tasks.md
@@ -1,0 +1,245 @@
+# Tasks: EstimateCost RPC Consumer
+
+**Input**: Design documents from `/specs/608-estimate-cost-rpc/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Per Constitution Principle II (Test-Driven Development), tests are
+MANDATORY and must be written BEFORE implementation. All code changes must
+maintain minimum 80% test coverage (95% for critical paths).
+
+**Completeness**: Per Constitution Principle VI (Implementation Completeness),
+all tasks MUST be fully implemented. Stub functions, placeholders, and TODO
+comments are strictly forbidden.
+
+**Documentation**: Per Constitution Principle IV (Documentation Integrity),
+documentation (CHANGELOG) MUST be updated concurrently with implementation.
+
+**Organization**: Tasks are grouped by user story to enable independent
+implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Verify proto types are available and the build compiles cleanly
+before making changes.
+
+- [X] T001 Verify `pbc.EstimateCostRequest` and `pbc.EstimateCostResponse` exist in finfocus-spec v0.6.0 by running `go doc` or grep on the generated proto package
+- [X] T002 Verify `structpb.NewStruct` is available by checking the `google.golang.org/protobuf/types/known/structpb` import compiles in `internal/proto/`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Expand the `CostSourceClient` interface and update ALL mock
+implementations. This MUST complete before any user story work because adding
+a method to an interface is a compile-breaking change.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T003 Add `EstimateCost` method to the `CostSourceClient` interface in `internal/proto/adapter.go` with signature: `EstimateCost(ctx context.Context, in *pbc.EstimateCostRequest, opts ...grpc.CallOption) (*pbc.EstimateCostResponse, error)`
+- [X] T004 Implement `clientAdapter.EstimateCost` in `internal/proto/adapter.go` that delegates to `c.client.EstimateCost(ctx, in, opts...)`
+- [X] T005 [P] Add `EstimateCost` stub method to `mockCostSourceClient` in `internal/proto/adapter_test.go` (function-based mock pattern: add `estimateCostFunc` field + method that calls it or returns `Unimplemented`)
+- [X] T006 [P] Add `EstimateCost` stub method to `mockCostSourceClient` in `internal/engine/budget_engine_test.go` (returns `Unimplemented` status error)
+- [X] T007 [P] Add `EstimateCost` stub method to `mockCostSourceClient` in `test/integration/budget_health_test.go` (returns `Unimplemented` status error)
+- [X] T008 Run `go build ./...` to confirm all mock implementations satisfy the expanded interface
+
+**Checkpoint**: Project compiles with expanded interface. All existing tests still pass.
+
+---
+
+## Phase 3: User Story 3 — Adapter Builds Valid Proto Requests (Priority: P1, Prerequisite for US1)
+
+**Goal**: Replace the `BuildEstimateCostRequest` stub with real request
+construction that maps `ResourceDescriptor` + properties to
+`pbc.EstimateCostRequest`.
+
+**Independent Test**: Call `BuildEstimateCostRequest` with various input
+combinations and verify the resulting proto message has correct fields.
+
+### Tests for User Story 3 (MANDATORY — TDD Required)
+
+> **CONSTITUTION REQUIREMENT: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T009 [P] [US3] Write test `TestBuildEstimateCostRequest_ValidResource` in `internal/proto/adapter_test.go` — given a `ResourceDescriptor` with Type and Properties, verify returned `pbc.EstimateCostRequest` has `ResourceType` and `Attributes` populated correctly
+- [X] T010 [P] [US3] Write test `TestBuildEstimateCostRequest_NilResource` in `internal/proto/adapter_test.go` — given nil resource, verify error is returned
+- [X] T011 [P] [US3] Write test `TestBuildEstimateCostRequest_EmptyType` in `internal/proto/adapter_test.go` — given resource with empty Type, verify error is returned
+- [X] T012 [P] [US3] Write test `TestBuildEstimateCostRequest_NilProperties` in `internal/proto/adapter_test.go` — given resource with nil Properties, verify request is built with empty Attributes struct
+
+### Implementation for User Story 3
+
+- [X] T013 [US3] Replace `BuildEstimateCostRequest` stub in `internal/proto/adapter.go` — change signature to accept `(resource *ResourceDescriptor, properties map[string]interface{}) (*pbc.EstimateCostRequest, error)`, add `structpb` import, validate inputs, use `structpb.NewStruct(properties)` to build Attributes
+- [X] T014 [US3] Remove dead internal types from `internal/proto/adapter.go`: `EstimateCostRequest` (line ~1277), `EstimateCostResponse` (line ~1289), `CostDelta` (line ~1301)
+- [X] T015 [US3] Remove `ErrEstimateCostNotSupported` sentinel error from `internal/proto/adapter.go` (line ~24) and verify no remaining references
+
+**Checkpoint**: `BuildEstimateCostRequest` produces valid `pbc.EstimateCostRequest` messages. All T009-T012 tests pass.
+
+---
+
+## Phase 4: User Story 1 — Plugin-Powered What-If Estimation (Priority: P1)
+
+**Goal**: Replace the `tryEstimateCostRPC` stub with real implementation that
+calls the plugin's `EstimateCost` RPC twice (baseline + modified), converts
+responses to `CostResult`, and computes deltas.
+
+**Independent Test**: Call `EstimateCost` on the engine with a mock plugin that
+implements the RPC, verifying that the response contains baseline, modified,
+and delta data from the plugin (not from the fallback path).
+
+### Tests for User Story 1 (MANDATORY — TDD Required)
+
+> **CONSTITUTION REQUIREMENT: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T016 [P] [US1] Write test `TestTryEstimateCostRPC_Success` in `internal/engine/estimate_test.go` — mock plugin returns valid `EstimateCostResponse` for both calls, verify `EstimateResult` has correct baseline/modified costs, `TotalChange` is the delta, and `UsedFallback` is false
+- [X] T017 [P] [US1] Write test `TestTryEstimateCostRPC_SinglePropertyDelta` in `internal/engine/estimate_test.go` — single override produces one `CostDelta` entry with correct property name and cost change
+- [X] T018 [P] [US1] Write test `TestTryEstimateCostRPC_MultiPropertyCombinedDelta` in `internal/engine/estimate_test.go` — multiple overrides produce a "combined" delta (same as fallback behavior)
+- [X] T019 [P] [US1] Write test `TestTryEstimateCostRPC_NilResponse` in `internal/engine/estimate_test.go` — plugin returns nil response, verify error is returned
+- [X] T020 [P] [US1] Write test `TestTryEstimateCostRPC_NegativeCost` in `internal/engine/estimate_test.go` — plugin returns negative `CostMonthly`, verify error is returned
+- [X] T021 [P] [US1] Write test `TestTryEstimateCostRPC_EmptyCurrency` in `internal/engine/estimate_test.go` — plugin returns empty currency, verify default "USD" is used
+- [X] T021a [P] [US1] Write test `TestTryEstimateCostRPC_CurrencyPassthrough` in `internal/engine/estimate_test.go` — plugin returns non-USD currency (e.g., "EUR"), verify currency is preserved without conversion
+- [X] T021b [P] [US1] Write test `TestTryEstimateCostRPC_NilExpiresAt` in `internal/engine/estimate_test.go` — verify response conversion leaves `CostResult.ExpiresAt` nil since `EstimateCostResponse` proto lacks `expires_at`
+- [X] T021c [P] [US1] Write test `TestEstimateCost_EmptyOverrides` in `internal/engine/estimate_test.go` — call `EstimateCost` with empty `PropertyOverrides` map, verify validation rejects the request (no meaningful comparison without overrides)
+
+### Implementation for User Story 1
+
+- [X] T022 [US1] Implement `tryEstimateCostRPC` in `internal/engine/estimate.go` — build baseline request via `proto.BuildEstimateCostRequest(resource, resource.Properties)`, call `client.API.EstimateCost(ctx, baselineReq)`, deep copy + merge overrides into properties, build modified request, call `client.API.EstimateCost(ctx, modifiedReq)`, convert both responses to `CostResult`, compute `TotalChange` and per-property deltas, return `EstimateResult` with `UsedFallback = false`
+- [X] T023 [US1] Implement response-to-CostResult conversion helper in `internal/engine/estimate.go` — map `CostMonthly` → `MonthlyCost`, derive `HourlyCost` (÷730), copy `Currency` (default "USD"), append `PricingCategory`/`SpotRisk` to Notes, validate non-nil response and non-negative cost
+
+**Checkpoint**: Engine calls plugin's `EstimateCost` RPC for what-if analysis. All T016-T021 tests pass. `UsedFallback` is false when RPC succeeds.
+
+---
+
+## Phase 5: User Story 2 — Graceful Fallback to Double-GetProjectedCost (Priority: P2)
+
+**Goal**: Verify that when a plugin returns `Unimplemented` for `EstimateCost`,
+the engine transparently falls back to the existing double-`GetProjectedCost`
+strategy with `UsedFallback = true`.
+
+**Independent Test**: Call `EstimateCost` with a mock plugin that returns
+`Unimplemented` and verify the engine produces a result with
+`UsedFallback = true`.
+
+### Tests for User Story 2 (MANDATORY — TDD Required)
+
+> **CONSTITUTION REQUIREMENT: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T024 [P] [US2] Write test `TestEstimateCost_FallbackOnUnimplemented` in `internal/engine/estimate_test.go` — mock plugin returns `Unimplemented` for `EstimateCost`, verify engine still returns valid `EstimateResult` via fallback with `UsedFallback = true`
+- [X] T025 [P] [US2] Write test `TestEstimateCost_MultiPlugin_FirstUnimplemented` in `internal/engine/estimate_test.go` — first plugin returns `Unimplemented`, second implements RPC, verify engine uses second plugin's response with `UsedFallback = false`
+
+### Implementation for User Story 2
+
+- [X] T026 [US2] Verify `tryEstimateCostRPC` correctly returns `Unimplemented` status error so the existing engine loop (estimate.go:80-118) can handle fallback — no new implementation code expected, this should already work from T022; confirm with tests
+
+**Checkpoint**: Plugins that don't implement `EstimateCost` fall through to the existing fallback. `UsedFallback = true` in fallback results.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Cleanup, validation, and documentation.
+
+- [X] T027 [P] Update CHANGELOG.md with entry for EstimateCost RPC consumer implementation (handled by release-please from conventional commit)
+- [X] T028 Run `make test` to verify all tests pass (unit + existing integration)
+- [X] T029 Run `make lint` to verify no lint errors
+- [X] T030 Verify no remaining references to `ErrEstimateCostNotSupported` in the codebase via grep
+- [X] T031 Verify no remaining references to dead internal types (`proto.EstimateCostRequest`, `proto.EstimateCostResponse`, `proto.CostDelta`) via grep
+- [X] T032 Run quickstart.md validation — run `finfocus cost estimate --help` to verify command is wired; with recorder plugin installed, run a cost estimate to verify fallback path executes without error
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories
+- **User Story 3 (Phase 3)**: Depends on Foundational — BLOCKS User Story 1
+- **User Story 1 (Phase 4)**: Depends on User Story 3 (`BuildEstimateCostRequest` is needed by `tryEstimateCostRPC`)
+- **User Story 2 (Phase 5)**: Depends on User Story 1 (verifies fallback behavior of the real implementation)
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Interface changes before implementation
+- Request building before RPC calling
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- T005, T006, T007 can run in parallel (different mock files)
+- T009, T010, T011, T012 can run in parallel (same file but independent test functions)
+- T016-T021c can run in parallel (independent test functions)
+- T024, T025 can run in parallel (independent test functions)
+- T027 can run in parallel with T028-T032
+
+---
+
+## Parallel Example: User Story 3 (Request Builder)
+
+```bash
+# Launch all tests together:
+Task: "TestBuildEstimateCostRequest_ValidResource in internal/proto/adapter_test.go"
+Task: "TestBuildEstimateCostRequest_NilResource in internal/proto/adapter_test.go"
+Task: "TestBuildEstimateCostRequest_EmptyType in internal/proto/adapter_test.go"
+Task: "TestBuildEstimateCostRequest_NilProperties in internal/proto/adapter_test.go"
+```
+
+## Parallel Example: User Story 1 (RPC Implementation)
+
+```bash
+# Launch all tests together:
+Task: "TestTryEstimateCostRPC_Success in internal/engine/estimate_test.go"
+Task: "TestTryEstimateCostRPC_SinglePropertyDelta in internal/engine/estimate_test.go"
+Task: "TestTryEstimateCostRPC_NilResponse in internal/engine/estimate_test.go"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 3 + 1)
+
+1. Complete Phase 1: Setup (verify proto types available)
+2. Complete Phase 2: Foundational (interface + mocks compile)
+3. Complete Phase 3: User Story 3 — `BuildEstimateCostRequest` works
+4. Complete Phase 4: User Story 1 — `tryEstimateCostRPC` works
+5. **STOP and VALIDATE**: `make test && make lint` pass
+
+### Incremental Delivery
+
+1. Setup + Foundational → Project compiles with expanded interface
+2. User Story 3 → Request builder works → Tests pass
+3. User Story 1 → Full RPC pipeline works → Tests pass (MVP!)
+4. User Story 2 → Fallback verified → Tests pass
+5. Polish → CHANGELOG, final validation
+
+### Key Files Modified
+
+| File | Tasks | Change Summary |
+|------|-------|---------------|
+| `internal/proto/adapter.go` | T003, T004, T013, T014, T015 | Interface + clientAdapter + request builder + dead code removal |
+| `internal/proto/adapter_test.go` | T005, T009-T012 | Mock update + request builder tests |
+| `internal/engine/estimate.go` | T022, T023 | Real `tryEstimateCostRPC` + response conversion |
+| `internal/engine/estimate_test.go` | T016-T021c, T024-T025 | RPC success/fallback/error/edge-case tests |
+| `internal/engine/budget_engine_test.go` | T006 | Mock `EstimateCost` stub |
+| `test/integration/budget_health_test.go` | T007 | Mock `EstimateCost` stub |
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- User Story 4 (Interface Completeness) is handled in Phase 2 as foundational work (no story label per template rules)
+- User Story 3 (Request Builder) is ordered before User Story 1 because US1 depends on it
+- The existing `estimateCostFallback` function is NOT modified
+- ~150-200 lines of new code + tests (per plan.md estimate)
+- FR-007 (expires_at) is a confirmed no-op: proto lacks the field, ExpiresAt stays nil, covered by T021b
+- FR-008 (response validation) covers nil response (T019), negative cost (T020), empty currency (T021)

--- a/test/integration/budget_health_test.go
+++ b/test/integration/budget_health_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 
@@ -96,6 +98,14 @@ func (m *mockCostSourceClient) Supports(
 	_ ...grpc.CallOption,
 ) (*pbc.SupportsResponse, error) {
 	return &pbc.SupportsResponse{Supported: true}, nil
+}
+
+func (m *mockCostSourceClient) EstimateCost(
+	_ context.Context,
+	_ *pbc.EstimateCostRequest,
+	_ ...grpc.CallOption,
+) (*pbc.EstimateCostResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "EstimateCost not implemented")
 }
 
 func TestBudgetHealth_EndToEnd(t *testing.T) {

--- a/test/integration/budget_tag_filter_test.go
+++ b/test/integration/budget_tag_filter_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 
@@ -95,6 +97,14 @@ func (m *mockTagFilterClient) Supports(
 	_ ...grpc.CallOption,
 ) (*pbc.SupportsResponse, error) {
 	return &pbc.SupportsResponse{Supported: true}, nil
+}
+
+func (m *mockTagFilterClient) EstimateCost(
+	_ context.Context,
+	_ *pbc.EstimateCostRequest,
+	_ ...grpc.CallOption,
+) (*pbc.EstimateCostResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "EstimateCost not implemented")
 }
 
 // TestBudgetTagFilter_EndToEnd tests tag-based budget filtering (Issue #222).


### PR DESCRIPTION
## Summary

- Replace stubbed `tryEstimateCostRPC` and `BuildEstimateCostRequest` with real implementations that call plugins via gRPC
- Engine calls the `EstimateCost` RPC twice per what-if analysis: once with original properties (baseline), once with overrides applied (modified), then computes deltas
- Plugins returning `Unimplemented` gracefully fall back to the existing double-`GetProjectedCost` strategy
- Remove dead internal types (`EstimateCostRequest`, `EstimateCostResponse`, `CostDelta`) and the `ErrEstimateCostNotSupported` sentinel error from the adapter
- Add `EstimateCost` to the `CostSourceClient` interface with matching `clientAdapter` delegation

## Test plan

- [x] `make test` passes (0 failures)
- [x] `make lint` passes (0 issues)
- [x] `finfocus cost estimate --help` confirms CLI wiring
- [x] No remaining references to removed types or sentinel error
- [x] New tests cover: valid RPC, nil response, negative cost, empty currency, currency passthrough, nil ExpiresAt, empty overrides, single/multi property deltas, Unimplemented fallback, multi-plugin fallback

## Changes

### Modified files

- `internal/proto/adapter.go` - Add `EstimateCost` to `CostSourceClient` interface, implement `clientAdapter.EstimateCost`, replace `BuildEstimateCostRequest` stub with real request builder using `structpb.NewStruct`, remove dead internal types and sentinel error
- `internal/proto/adapter_test.go` - Update mock with `estimateCostFunc` field, add `BuildEstimateCostRequest` tests (valid resource, nil resource, empty type, nil properties)
- `internal/engine/estimate.go` - Replace `tryEstimateCostRPC` stub with two-call RPC implementation, add response validation and `estimateResponseToCostResult` conversion helper
- `internal/engine/estimate_test.go` - Add 12 new test cases covering RPC success, fallback, error handling, and edge cases
- `internal/engine/budget_engine_test.go` - Add `EstimateCost` stub to mock satisfying expanded interface
- `test/integration/budget_health_test.go` - Add `EstimateCost` stub to mock satisfying expanded interface
- `test/integration/budget_tag_filter_test.go` - Add `EstimateCost` stub to mock satisfying expanded interface

Closes #847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Estimation now performs baseline + modified plugin calls to produce detailed cost deltas (single-override or combined) with currency-aware totals.

* **Bug Fixes**
  * Requests without property overrides are rejected; invalid or cross-currency plugin responses trigger fallback/error handling and are validated.

* **Tests**
  * Expanded unit and integration tests covering RPC success/fallback paths, delta shaping, currency handling, multi-plugin behavior, and response validation.

* **Documentation**
  * Release notes and active technologies updated to list the new estimation entry and tech stack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->