### PR TITLE
fix: adding logo-readme.png

### DIFF
--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -4,8 +4,6 @@ description: Cost visibility for Pulumi infrastructure. Calculate projected and 
 template: splash
 hero:
   tagline: Cost visibility for Pulumi infrastructure. Calculate projected and actual costs.
-  image:
-    file: ../../assets/logo-readme.png
   actions:
     - text: Get Started
       link: /finfocus/getting-started/quickstart/


### PR DESCRIPTION

This pull request makes a minor update to the documentation splash page by removing the logo image from the hero section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the hero image from the documentation homepage while preserving all text content and action links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->