### PR TITLE
fix(history): fix double-prefixing in StackContext.Hash

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,8 +17,9 @@ guardrails in `CONTEXT.md`.
 
 *v0.3.5 released 2026-03-30.*
 
-- [ ] Implement EstimateCost RPC consumer (remove stub)
+- [x] Implement EstimateCost RPC consumer (remove stub)
       ([#847](https://github.com/rshade/finfocus/issues/847)) [M]
+      *(Completed 2026-04-04)*
 - [ ] **EstimateCost RPC — Code Review Follow-ups** *(from #847 PR review)*
   - [ ] Add test for modified-response validation fallback path
         ([#970](https://github.com/rshade/finfocus/issues/970)) [S]
@@ -30,8 +31,28 @@ guardrails in `CONTEXT.md`.
         ([#972](https://github.com/rshade/finfocus/issues/972)) [S]
   - [ ] Add test for `BuildEstimateCostRequest` `structpb.NewStruct` error path
         ([#973](https://github.com/rshade/finfocus/issues/973)) [S]
-- [ ] Implement BatchCost RPC consumer for multi-resource queries
+- [x] Implement BatchCost RPC consumer for multi-resource queries
       ([#846](https://github.com/rshade/finfocus/issues/846)) [L]
+      *(Completed 2026-04-04)*
+- [ ] **BatchCost RPC — Code Review Follow-ups** *(from #846 PR review)*
+  - [x] Add per-resource validation to batch cost requests
+        ([#983](https://github.com/rshade/finfocus/issues/983)) [M]
+        *(Completed 2026-04-06)*
+  - [x] buildBatchCostRequest should validate resources before batching
+        ([#980](https://github.com/rshade/finfocus/issues/980)) [M]
+        *(Completed 2026-04-06)*
+  - [ ] executeBatchForPlugin for-range over chunks skips re-chunked tail
+        ([#978](https://github.com/rshade/finfocus/issues/978)) [M]
+  - [ ] Add per-chunk timeout for BatchCost RPC calls
+        ([#979](https://github.com/rshade/finfocus/issues/979)) [S]
+  - [ ] batch actual cost mapper drops rate fields
+        ([#974](https://github.com/rshade/finfocus/issues/974)) [M]
+  - [ ] budget\_health\_test mock BatchCost should return error
+        ([#975](https://github.com/rshade/finfocus/issues/975)) [S]
+  - [ ] budget\_tag\_filter\_test mock BatchCost should return error
+        ([#976](https://github.com/rshade/finfocus/issues/976)) [S]
+  - [ ] Document ActualCostData and ResourceError protobuf messages
+        ([#977](https://github.com/rshade/finfocus/issues/977)) [S]
 - [x] Resource History Store with Layered Cost Attribution
       ([#934](https://github.com/rshade/finfocus/issues/934)) [L]
       *(Completed 2026-04-04)*
@@ -40,8 +61,9 @@ guardrails in `CONTEXT.md`.
         ([#966](https://github.com/rshade/finfocus/issues/966)) [S]
   - [ ] Extract correct URN hash segment in `filterFullyExpiredURNs`
         ([#968](https://github.com/rshade/finfocus/issues/968)) [S]
-  - [ ] Capture analyzer resource properties and extract tags into history
+  - [x] Capture analyzer resource properties and extract tags into history
         ([#955](https://github.com/rshade/finfocus/issues/955)) [S]
+        *(Completed 2026-04-05)*
   - [ ] Populate tags in `convertDescriptorsToHistoryState`
         ([#956](https://github.com/rshade/finfocus/issues/956)) [S]
   - [ ] Copy tags in `convertEngineStateToHistoryState`
@@ -259,9 +281,24 @@ guardrails in `CONTEXT.md`.
 
 ### 2026-Q2
 
+- [x] Implement BatchCost RPC consumer for multi-resource queries
+      ([#846](https://github.com/rshade/finfocus/issues/846)) [L]
+      *(Completed 2026-04-04)*
+- [x] Implement EstimateCost RPC consumer (remove stub)
+      ([#847](https://github.com/rshade/finfocus/issues/847)) [M]
+      *(Completed 2026-04-04)*
 - [x] Resource History Store with Layered Cost Attribution
       ([#934](https://github.com/rshade/finfocus/issues/934)) [L]
       *(Completed 2026-04-04)*
+- [x] Capture analyzer resource properties and extract tags into history
+      ([#955](https://github.com/rshade/finfocus/issues/955)) [S]
+      *(Completed 2026-04-05)*
+- [x] buildBatchCostRequest should validate resources before batching
+      ([#980](https://github.com/rshade/finfocus/issues/980)) [M]
+      *(Completed 2026-04-06)*
+- [x] Add per-resource validation to batch cost requests
+      ([#983](https://github.com/rshade/finfocus/issues/983)) [M]
+      *(Completed 2026-04-06)*
 
 ### 2026-Q1
 

--- a/internal/history/hash.go
+++ b/internal/history/hash.go
@@ -19,12 +19,11 @@ type StackContext struct {
 // so that equivalent stacks (e.g. "dev" vs "org/project/dev") produce
 // identical hashes.
 func (sc StackContext) Hash() string {
-	stack := sc.Stack
-	if stack != "" && !strings.Contains(stack, "/") {
-		stack = fmt.Sprintf("%s/%s/%s", sc.Organization, sc.Project, stack)
+	canonical := sc.Stack
+	if canonical != "" && !strings.Contains(canonical, "/") {
+		canonical = fmt.Sprintf("%s/%s/%s", sc.Organization, sc.Project, canonical)
 	}
-	s := fmt.Sprintf("%s/%s/%s", sc.Organization, sc.Project, stack)
-	h := sha256.Sum256([]byte(s))
+	h := sha256.Sum256([]byte(canonical))
 	return hex.EncodeToString(h[:])[0:16]
 }
 

--- a/internal/history/hash_test.go
+++ b/internal/history/hash_test.go
@@ -1,0 +1,131 @@
+package history
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hashOf is a test helper that computes the same 16-char hex hash
+// that Hash() should produce for a given canonical string.
+func hashOf(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])[0:16]
+}
+
+func TestStackContextHash_ShortAndQualifiedMatch(t *testing.T) {
+	short := StackContext{
+		Organization: "org",
+		Project:      "proj",
+		Stack:        "dev",
+	}
+	qualified := StackContext{
+		Organization: "org",
+		Project:      "proj",
+		Stack:        "org/proj/dev",
+	}
+
+	shortHash := short.Hash()
+	qualifiedHash := qualified.Hash()
+
+	assert.Equal(t, shortHash, qualifiedHash,
+		"short stack name and fully-qualified name must produce the same hash")
+}
+
+func TestStackContextHash_NoDoublePrefixing(t *testing.T) {
+	sc := StackContext{
+		Organization: "org",
+		Project:      "proj",
+		Stack:        "dev",
+	}
+
+	// The canonical form for short name "dev" is "org/proj/dev".
+	// The hash must match sha256("org/proj/dev"), NOT sha256("org/proj/org/proj/dev").
+	expected := hashOf("org/proj/dev")
+	actual := sc.Hash()
+
+	require.Len(t, actual, 16, "hash must be 16 hex characters")
+	assert.Equal(t, expected, actual,
+		"hash of short name must equal hash of canonical form, not double-prefixed")
+
+	// Calling with the already-expanded form should be identical.
+	sc2 := StackContext{
+		Organization: "org",
+		Project:      "proj",
+		Stack:        "org/proj/dev",
+	}
+	assert.Equal(t, expected, sc2.Hash(),
+		"hash of qualified name must equal hash of canonical form")
+}
+
+func TestStackContextHash_EmptyStack(t *testing.T) {
+	sc := StackContext{
+		Organization: "org",
+		Project:      "proj",
+		Stack:        "",
+	}
+	hash := sc.Hash()
+	expected := hashOf("")
+	require.Len(t, hash, 16, "empty stack should still produce a valid 16-char hash")
+	assert.Equal(t, expected, hash,
+		"empty stack hashes the empty string (org/project prefix is not applied)")
+}
+
+func TestStackContextHash_EmptyContext(t *testing.T) {
+	sc := StackContext{}
+	hash := sc.Hash()
+	expectedEmpty := hashOf("")
+	require.Len(t, hash, 16, "zero-value context should still produce a valid 16-char hash")
+	assert.Equal(t, expectedEmpty, hash,
+		"zero-value context hashes the empty string")
+
+	// Empty stack with org/project fields produces the same hash as zero-value context,
+	// because the canonicalization guard skips the prefix when stack is empty.
+	emptyStackHash := StackContext{Organization: "org", Project: "proj", Stack: ""}.Hash()
+	assert.Equal(t, hash, emptyStackHash,
+		"empty-stack context and zero-value context must produce identical hashes")
+}
+
+func TestStackContextHash_CLICallerNoOrg(t *testing.T) {
+	// CLI path sets Project and Stack but not Organization.
+	sc := StackContext{
+		Project: "myproject",
+		Stack:   "dev",
+	}
+	hash := sc.Hash()
+	require.Len(t, hash, 16)
+
+	// A second call must be deterministic.
+	assert.Equal(t, hash, sc.Hash())
+}
+
+func TestStackContextHash_Deterministic(t *testing.T) {
+	sc := StackContext{
+		Organization: "acme",
+		Project:      "infra",
+		Stack:        "production",
+	}
+	h1 := sc.Hash()
+	h2 := sc.Hash()
+	assert.Equal(t, h1, h2, "hash must be deterministic")
+}
+
+func TestURNHash(t *testing.T) {
+	urn := "urn:pulumi:dev::myproject::aws:ec2/instance:Instance::web-server"
+	hash := URNHash(urn)
+	require.Len(t, hash, 16)
+	assert.Equal(t, hash, URNHash(urn), "URNHash must be deterministic")
+}
+
+func TestBuildHistoryKey(t *testing.T) {
+	key := BuildHistoryKey("stackhash", "urnhash", "i-abc123")
+	assert.Equal(t, "stackhash/urnhash/i-abc123", key)
+}
+
+func TestBuildTagKey(t *testing.T) {
+	key := BuildTagKey("stackhash", "env", "prod", "urnhash")
+	assert.Equal(t, "stackhash/env:prod/urnhash", key)
+}


### PR DESCRIPTION
## Summary

- Short stack names like `"dev"` were canonicalized to `"org/proj/dev"` but then re-prefixed to `"org/proj/org/proj/dev"` before hashing, causing short and fully-qualified names to produce different hashes for the same logical stack
- Replaced the redundant `fmt.Sprintf` with direct hashing of the canonical form so both `"dev"` and `"org/proj/dev"` now produce identical hashes
- Added comprehensive unit tests covering short/qualified equivalence, empty stack, zero-value context, determinism, and the `URNHash`/`BuildHistoryKey`/`BuildTagKey` helpers

## Test plan

- [x] `TestStackContextHash_NoDoublePrefixing` verifies hash matches `sha256("org/proj/dev")`, not the double-prefixed form
- [x] `TestStackContextHash_ShortAndQualifiedMatch` confirms short and fully-qualified names produce the same hash
- [x] Edge cases: empty stack, zero-value context, no-org CLI path
- [x] `make test` passes
- [x] `make lint` passes

## Changes

### Modified files

- `internal/history/hash.go` - Removed redundant `fmt.Sprintf("%s/%s/%s", ...)` that re-prefixed the already canonical stack name; hash now computed directly from `canonical`

### New files

- `internal/history/hash_test.go` - Unit tests for `StackContext.Hash`, `URNHash`, `BuildHistoryKey`, and `BuildTagKey`

Closes #966

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal hashing logic to ensure consistent, canonical hashing of stack identifiers without changing external behavior.

* **Tests**
  * Added thorough tests verifying deterministic, stable 16-character hash outputs, canonical equivalence for stack names, prevention of double-prefixing, and exact formatting of history and tag keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->