### PR TITLE
fix(engine): preserve original property types in mergePropertiesWithO…

### DIFF
--- a/internal/engine/estimate.go
+++ b/internal/engine/estimate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 	"time"
 
@@ -378,8 +379,41 @@ func (e *Engine) estimateCostFallback(
 	}, nil
 }
 
-// mergePropertiesWithOverrides creates a shallow copy of properties with string
-// overrides applied. The returned map is safe to mutate without affecting the originals.
+// coerceOverrideValue attempts to convert an override string to match the type
+// of the original property value. If the original is nil or the parse fails,
+// the raw string is returned unchanged.
+func coerceOverrideValue(override string, original any) any {
+	if original == nil {
+		return override
+	}
+
+	switch original.(type) {
+	case float64:
+		if v, err := strconv.ParseFloat(override, 64); err == nil {
+			return v
+		}
+	case int:
+		if v, err := strconv.Atoi(override); err == nil {
+			return v
+		}
+	case int64:
+		if v, err := strconv.ParseInt(override, 10, 64); err == nil {
+			return v
+		}
+	case bool:
+		if v, err := strconv.ParseBool(override); err == nil {
+			return v
+		}
+	}
+
+	return override
+}
+
+// mergePropertiesWithOverrides creates a shallow copy of properties with
+// overrides applied. Override values are coerced to match the original
+// property's type when possible (float64, int, int64, bool). New keys
+// that do not exist in properties remain as strings. The returned map
+// is safe to mutate without affecting the originals.
 func mergePropertiesWithOverrides(
 	properties map[string]any,
 	overrides map[string]string,
@@ -389,7 +423,7 @@ func mergePropertiesWithOverrides(
 		merged[k] = v
 	}
 	for k, v := range overrides {
-		merged[k] = v
+		merged[k] = coerceOverrideValue(v, properties[k])
 	}
 	return merged
 }

--- a/internal/engine/estimate_test.go
+++ b/internal/engine/estimate_test.go
@@ -898,3 +898,130 @@ func TestTryEstimateCostRPC_CurrencyMismatchFallsBack(t *testing.T) {
 	require.NotNil(t, result)
 	assert.True(t, result.UsedFallback, "currency mismatch should cause fallback")
 }
+
+func TestCoerceOverrideValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		override string
+		original any
+		expected any
+	}{
+		{"float64 integer string", "100", float64(8), float64(100)},
+		{"float64 decimal string", "3.14", float64(2.0), float64(3.14)},
+		{"float64 invalid string", "m5.large", float64(8), "m5.large"},
+		{"int coercion", "42", int(10), int(42)},
+		{"int invalid string", "abc", int(10), "abc"},
+		{"int64 coercion", "999", int64(100), int64(999)},
+		{"int64 invalid string", "nope", int64(100), "nope"},
+		{"bool true", "true", false, true},
+		{"bool false", "false", true, false},
+		{"bool numeric 1", "1", false, true},
+		{"bool invalid", "maybe", true, "maybe"},
+		{"string original", "new", "old", "new"},
+		{"nil original", "value", nil, "value"},
+		{"map original", "value", map[string]any{"k": "v"}, "value"},
+		{"slice original", "value", []any{1, 2}, "value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := coerceOverrideValue(tt.override, tt.original)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMergePropertiesWithOverrides(t *testing.T) {
+	t.Run("override preserves float64 type", func(t *testing.T) {
+		properties := map[string]any{"volumeSize": float64(8)}
+		overrides := map[string]string{"volumeSize": "100"}
+
+		merged := mergePropertiesWithOverrides(properties, overrides)
+
+		require.Contains(t, merged, "volumeSize")
+		assert.IsType(t, float64(0), merged["volumeSize"])
+		assert.Equal(t, float64(100), merged["volumeSize"])
+	})
+
+	t.Run("override preserves bool type", func(t *testing.T) {
+		properties := map[string]any{"enabled": true}
+		overrides := map[string]string{"enabled": "false"}
+
+		merged := mergePropertiesWithOverrides(properties, overrides)
+
+		assert.IsType(t, false, merged["enabled"])
+		assert.Equal(t, false, merged["enabled"])
+	})
+
+	t.Run("override preserves string type", func(t *testing.T) {
+		properties := map[string]any{"instanceType": "t3.micro"}
+		overrides := map[string]string{"instanceType": "m5.large"}
+
+		merged := mergePropertiesWithOverrides(properties, overrides)
+
+		assert.Equal(t, "m5.large", merged["instanceType"])
+	})
+
+	t.Run("new key stays string", func(t *testing.T) {
+		properties := map[string]any{"existing": float64(1)}
+		overrides := map[string]string{"newKey": "value"}
+
+		merged := mergePropertiesWithOverrides(properties, overrides)
+
+		assert.Equal(t, "value", merged["newKey"])
+		assert.Equal(t, float64(1), merged["existing"])
+	})
+
+	t.Run("unparseable override stays string", func(t *testing.T) {
+		properties := map[string]any{"count": float64(5)}
+		overrides := map[string]string{"count": "many"}
+
+		merged := mergePropertiesWithOverrides(properties, overrides)
+
+		assert.Equal(t, "many", merged["count"])
+	})
+
+	t.Run("nil properties does not panic", func(t *testing.T) {
+		overrides := map[string]string{"key": "val"}
+
+		merged := mergePropertiesWithOverrides(nil, overrides)
+
+		assert.Equal(t, "val", merged["key"])
+	})
+
+	t.Run("empty overrides preserves originals", func(t *testing.T) {
+		properties := map[string]any{"a": float64(1)}
+
+		merged := mergePropertiesWithOverrides(properties, map[string]string{})
+
+		assert.Equal(t, float64(1), merged["a"])
+	})
+
+	t.Run("mixed types all preserved", func(t *testing.T) {
+		properties := map[string]any{
+			"num":  float64(8),
+			"flag": true,
+			"name": "foo",
+		}
+		overrides := map[string]string{
+			"num":  "16",
+			"flag": "false",
+			"name": "bar",
+		}
+
+		merged := mergePropertiesWithOverrides(properties, overrides)
+
+		assert.Equal(t, float64(16), merged["num"])
+		assert.Equal(t, false, merged["flag"])
+		assert.Equal(t, "bar", merged["name"])
+	})
+
+	t.Run("original map not mutated", func(t *testing.T) {
+		properties := map[string]any{"x": float64(1)}
+		overrides := map[string]string{"x": "2"}
+
+		_ = mergePropertiesWithOverrides(properties, overrides)
+
+		assert.Equal(t, float64(1), properties["x"])
+	})
+}


### PR DESCRIPTION
…verrides

## Summary

- Property overrides from CLI/config arrive as `map[string]string` but the original properties map contains typed values (float64, bool) from JSON unmarshaling. The merge function was blindly assigning string overrides, causing `structpb.NewStruct` to encode baseline requests with `NumberValue` but modified requests with `StringValue` for the same field. Plugins doing type assertions or numeric comparisons would get incorrect results or panics.
- Added `coerceOverrideValue` that inspects the original property's Go type and attempts `strconv` parsing (float64, int, int64, bool). Falls back to raw string for new keys, unknown types, or parse failures.

## Test plan

- [x] 15 table-driven tests for `coerceOverrideValue` covering all type branches, parse failures, nil, maps, and slices
- [x] 9 subtests for `mergePropertiesWithOverrides` covering type preservation, new keys, nil properties, and original map immutability
- [x] All existing estimate tests pass (no regressions)
- [x] `make test` passes
- [x] `make lint` passes with zero issues

## Changes

### Modified files

- `internal/engine/estimate.go` - Added `coerceOverrideValue` function and updated `mergePropertiesWithOverrides` to coerce override strings to match original property types; added `strconv` import
- `internal/engine/estimate_test.go` - Added `TestCoerceOverrideValue` and `TestMergePropertiesWithOverrides` test functions

Closes #971

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Property overrides now intelligently preserve the original data type of existing properties (numeric, boolean, or string). Types remain consistent during override operations, with automatic fallback to string values when type conversion isn't applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->