### PR TITLE
fix(cli): address CodeRabbit review findings and unblock red CI on main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,6 +481,25 @@ When no preview is provided, overview shows state resources with `*` footnote
 on projected costs. The `p` key triggers on-demand preview; when it completes,
 `ApplyChangesToRows()` and `ApplyPropertyDiffsToRows()` update rows in-place.
 
+### Integration Tests (`test/integration/`)
+
+- **The CLI helper must go through `ax.Execute`**: `helpers.CLIHelper.Execute`
+  runs commands via `ax.Execute`, the same entry point as `cmd/finfocus`. Calling
+  `cli.NewRootCmd().Execute()` directly does NOT mount the persistent agentic flags
+  (`--format`, `--dry-run`, `--yes`, `--idempotency-key`), so those flags fail with
+  "unknown flag" in integration tests while working in production and in unit tests
+  (which use `axtest.Run`). `ax.Execute` returns an exit code rather than an error,
+  so the helper converts non-zero codes back into an error from stderr
+- **Many integration tests do not isolate `HOME`**: tests that call
+  `helpers.NewCLIHelper(t)` without `WithEnv` read the developer's real
+  `~/.finfocus/config.hujson`. A local `cost.budgets` entry injects a "BUDGET STATUS"
+  banner into JSON/NDJSON output and fails ~48 tests locally. These pass in CI only
+  because the runner's HOME is empty. Always diff the integration failure *set*
+  against a pre-change baseline rather than comparing failure counts
+- **`config.yaml` fixtures are intentional**: most `config.yaml` references in
+  `test/integration/` write legacy YAML as *input* to exercise auto-migration. Only
+  assertions that `config init` *creates* a file should expect `config.hujson`
+
 ### GitHub Actions (`.github/workflows/`)
 
 - **OpenCode Action** (`sst/opencode/github@dev`) ONLY works with `issue_comment` events.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,6 +361,19 @@ Non-obvious behaviors that can cause subtle bugs if you don't know about them.
   `$PROJECT/.finfocus/config.hujson` + `.gitignore`. Outside Pulumi project → global init
 - **`config routes`**: `config routes list` shows effective routing source/path;
   `config routes test <type> [region]` simulates per-feature plugin selection without loading plugin binaries
+- **Unit tests leak into the real `~/.finfocus`**: any test that executes a
+  mutating command (`dismiss`, `snooze`, `config set`) writes to the developer's
+  and the CI runner's actual home unless it sets
+  `t.Setenv("FINFOCUS_HOME", t.TempDir())`. `NewDismissalStore("")` falls back to
+  `ResolveConfigDir()`, which honors `FINFOCUS_HOME` first. This has produced
+  tests that pass *only* because a sibling test seeded the shared store — green
+  as a package, red when run alone. Detect with
+  `HOME=$(mktemp -d) go test -run TestName ./internal/cli/`; a test that fails
+  in isolation but passes in the package is order-dependent, not flaky
+- **Validate `--output` before loading state**: commands that early-return on an
+  empty result (e.g. history's `len(events) == 0`) must reject an unknown format
+  *first*, or an invalid `--output` silently exits 0. See `config_routes.go`,
+  `analyzer_check.go`, `plugin_list.go` for the up-front pattern
 
 ### Registry (`internal/registry/`)
 

--- a/internal/cli/config_init.go
+++ b/internal/cli/config_init.go
@@ -63,12 +63,14 @@ func initProjectConfig(ctx context.Context, cmd *cobra.Command, projectDir strin
 
 	// Check if config already exists and force isn't set
 	if !force {
-		_, err := os.Stat(configPath)
-		if err == nil {
-			return errors.New("configuration file already exists, use --force to overwrite")
-		}
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("cannot access config path %s: %w", configPath, err)
+		for _, path := range []string{configPath, filepath.Join(projectDir, "config.yaml")} {
+			_, err := os.Stat(path)
+			if err == nil {
+				return errors.New("configuration file already exists, use --force to overwrite")
+			}
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("cannot access config path %s: %w", path, err)
+			}
 		}
 	}
 

--- a/internal/cli/config_init_test.go
+++ b/internal/cli/config_init_test.go
@@ -28,7 +28,7 @@ func setupConfigInitTest(t *testing.T) {
 }
 
 // TestConfigInit_InsidePulumiProject verifies that running "config init" inside
-// a directory containing Pulumi.yaml creates project-local .finfocus/config.yaml
+// a directory containing Pulumi.yaml creates project-local .finfocus/config.hujson
 // and .finfocus/.gitignore.
 func TestConfigInit_InsidePulumiProject(t *testing.T) {
 	setupConfigInitTest(t)
@@ -56,10 +56,10 @@ func TestConfigInit_InsidePulumiProject(t *testing.T) {
 	output := string(result.Stdout)
 	assert.Contains(t, output, "Configuration initialized at")
 
-	// Verify project-local config.yaml was created
+	// Verify project-local config.hujson was created
 	configPath := filepath.Join(tmpDir, ".finfocus", "config.hujson")
 	_, statErr := os.Stat(configPath)
-	require.NoError(t, statErr, ".finfocus/config.yaml should exist")
+	require.NoError(t, statErr, ".finfocus/config.hujson should exist")
 
 	// Verify .gitignore was created
 	gitignorePath := filepath.Join(tmpDir, ".finfocus", ".gitignore")
@@ -99,7 +99,7 @@ func TestConfigInit_ExistingGitignorePreserved(t *testing.T) {
 	globalDir := t.TempDir()
 	t.Setenv("FINFOCUS_HOME", globalDir)
 
-	// Execute config init with --force (should overwrite config.yaml but NOT .gitignore)
+	// Execute config init with --force (should overwrite config.hujson but NOT .gitignore)
 	cmd := cli.NewRootCmd("test")
 	result := axtest.Run(context.Background(), t, cmd, []string{"config", "init", "--force"})
 
@@ -142,13 +142,13 @@ func TestConfigInit_GlobalFlag(t *testing.T) {
 	// Verify global config was created in FINFOCUS_HOME
 	globalConfigPath := filepath.Join(globalDir, "config.hujson")
 	_, statErr := os.Stat(globalConfigPath)
-	require.NoError(t, statErr, "global config.yaml should exist in FINFOCUS_HOME")
+	require.NoError(t, statErr, "global config.hujson should exist in FINFOCUS_HOME")
 
 	// Verify NO project-local config was created
 	projectConfigPath := filepath.Join(tmpDir, ".finfocus", "config.hujson")
 	_, statErr = os.Stat(projectConfigPath)
 	assert.True(t, os.IsNotExist(statErr),
-		"project-local config.yaml should NOT exist when --global is used")
+		"project-local config.hujson should NOT exist when --global is used")
 }
 
 // TestConfigInit_OutsidePulumiProject verifies that running "config init" outside
@@ -179,11 +179,11 @@ func TestConfigInit_OutsidePulumiProject(t *testing.T) {
 	// Verify global config was created
 	globalConfigPath := filepath.Join(globalDir, "config.hujson")
 	_, statErr := os.Stat(globalConfigPath)
-	require.NoError(t, statErr, "global config.yaml should be created when outside Pulumi project")
+	require.NoError(t, statErr, "global config.hujson should be created when outside Pulumi project")
 }
 
 // TestConfigInit_ForceOverwritesConfig verifies that running "config init --force"
-// overwrites an existing config.yaml file with fresh defaults.
+// overwrites an existing config.hujson file with fresh defaults.
 func TestConfigInit_ForceOverwritesConfig(t *testing.T) {
 	setupConfigInitTest(t)
 
@@ -193,7 +193,7 @@ func TestConfigInit_ForceOverwritesConfig(t *testing.T) {
 	pulumiYAML := filepath.Join(tmpDir, "Pulumi.yaml")
 	require.NoError(t, os.WriteFile(pulumiYAML, []byte("name: test-project\nruntime: go\n"), 0o644))
 
-	// Create existing config.yaml with custom content
+	// Create existing config.hujson with custom content
 	finfocusDir := filepath.Join(tmpDir, ".finfocus")
 	require.NoError(t, os.MkdirAll(finfocusDir, 0o750))
 
@@ -217,10 +217,29 @@ func TestConfigInit_ForceOverwritesConfig(t *testing.T) {
 	output := string(result.Stdout)
 	assert.Contains(t, output, "Configuration initialized at")
 
-	// Verify config.yaml was overwritten (content should differ from original)
+	// Verify config.hujson was overwritten (content should differ from original)
 	newContent, readErr := os.ReadFile(existingConfig)
 	require.NoError(t, readErr)
 	assert.NotEqual(t, originalContent, string(newContent),
-		"config.yaml should be overwritten with new default content")
-	assert.NotEmpty(t, string(newContent), "config.yaml should not be empty after force init")
+		"config.hujson should be overwritten with new default content")
+	assert.NotEmpty(t, string(newContent), "config.hujson should not be empty after force init")
+}
+
+func TestConfigInit_LegacyProjectConfigPreserved(t *testing.T) {
+	setupConfigInitTest(t)
+	t.Setenv("FINFOCUS_HOME", t.TempDir())
+	projectDir := t.TempDir()
+	config.SetResolvedProjectDir(projectDir)
+	legacyPath := filepath.Join(projectDir, "config.yaml")
+	content := []byte("output:\n  default_format: json\n")
+	require.NoError(t, os.WriteFile(legacyPath, content, 0600))
+
+	cmd := cli.NewConfigInitCmd()
+	cmd.SetContext(context.Background())
+	err := cmd.RunE(cmd, nil)
+	require.ErrorContains(t, err, "configuration file already exists")
+	assert.NoFileExists(t, filepath.Join(projectDir, "config.hujson"))
+	got, err := os.ReadFile(legacyPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
 }

--- a/internal/cli/config_list.go
+++ b/internal/cli/config_list.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -35,9 +36,13 @@ func NewConfigListCmd() *cobra.Command {
   # --format json (the global agent-mode flag) also selects JSON style
   finfocus config list --format json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
 			style := as
 			if !cmd.Flags().Changed("as") {
-				if mode, ok := ax.ModeFromContext(cmd.Context()); ok && mode == ax.ModeJSON {
+				if mode, ok := ax.ModeFromContext(ctx); ok && mode == ax.ModeJSON {
 					style = outputFormatJSON
 				}
 			}
@@ -72,7 +77,7 @@ func NewConfigListCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&as, "as", "yaml", "output style (yaml, json)")
+	cmd.Flags().StringVarP(&as, "as", "f", "yaml", "output style (yaml, json)")
 
 	return cmd
 }

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,10 +1,13 @@
 package cli_test
 
 import (
+	"bytes"
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/rshade/ax-go"
 	"github.com/rshade/ax-go/axtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,8 +32,7 @@ func TestConfigInitCmd(t *testing.T) {
 	cleanup := setupTestConfig(t)
 	defer cleanup()
 
-	root := cli.NewRootCmd("test")
-	result := axtest.Run(context.Background(), t, root, []string{"config", "init"})
+	result := axtest.Run(context.Background(), t, cli.NewRootCmd("test"), []string{"config", "init"})
 
 	// Test successful init
 	require.Equal(t, 0, result.ExitCode)
@@ -41,7 +43,10 @@ func TestConfigInitCmd(t *testing.T) {
 
 	// Verify config can be read
 	cfg := config.New()
-	require.NotNil(t, cfg)
+	_, err := os.Stat(cfg.ConfigPath())
+	require.NoError(t, err)
+	require.NoError(t, cfg.Load())
+	assert.Equal(t, "table", cfg.Output.DefaultFormat)
 }
 
 func TestConfigInitCmdForce(t *testing.T) {
@@ -55,16 +60,14 @@ func TestConfigInitCmdForce(t *testing.T) {
 	err := cfg.Save()
 	require.NoError(t, err)
 
-	root := cli.NewRootCmd("test")
-
 	// Test without force flag should fail
-	result := axtest.Run(context.Background(), t, root, []string{"config", "init"})
+	result := axtest.Run(context.Background(), t, cli.NewRootCmd("test"), []string{"config", "init"})
 	assert.NotEqual(t, 0, result.ExitCode)
 	stderr := string(result.Stderr)
 	assert.Contains(t, stderr, "already exists")
 
 	// Test with force flag should succeed
-	result = axtest.Run(context.Background(), t, root, []string{"config", "init", "--force"})
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"), []string{"config", "init", "--force"})
 	assert.Equal(t, 0, result.ExitCode)
 	output := string(result.Stdout)
 	assert.Contains(t, output, "Configuration initialized successfully")
@@ -76,8 +79,7 @@ func TestConfigSetCmd(t *testing.T) {
 	cleanup := setupTestConfig(t)
 	defer cleanup()
 
-	root := cli.NewRootCmd("test")
-	result := axtest.Run(context.Background(), t, root,
+	result := axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "set", "output.default_format", "json"})
 
 	// Test setting output format
@@ -98,17 +100,15 @@ func TestConfigSetCmdErrors(t *testing.T) {
 	cleanup := setupTestConfig(t)
 	defer cleanup()
 
-	root := cli.NewRootCmd("test")
-
 	// Test invalid key
-	result := axtest.Run(context.Background(), t, root,
+	result := axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "set", "invalid.key", "value"})
 	assert.NotEqual(t, 0, result.ExitCode)
 	stderr := string(result.Stderr)
 	assert.Contains(t, stderr, "unknown configuration section")
 
 	// Test invalid precision value
-	result = axtest.Run(context.Background(), t, root,
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "set", "output.precision", "invalid"})
 	assert.NotEqual(t, 0, result.ExitCode)
 	stderr = string(result.Stderr)
@@ -127,16 +127,14 @@ func TestConfigGetCmd(t *testing.T) {
 	require.NoError(t, cfg.Set("plugins.aws.region", "us-west-2"))
 	require.NoError(t, cfg.Save())
 
-	root := cli.NewRootCmd("test")
-
 	// Test getting simple value
-	result := axtest.Run(context.Background(), t, root,
+	result := axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "get", "output.default_format"})
 	require.Equal(t, 0, result.ExitCode)
 	assert.Equal(t, "json\n", string(result.Stdout))
 
 	// Test getting plugin value
-	result = axtest.Run(context.Background(), t, root,
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "get", "plugins.aws.region"})
 	require.Equal(t, 0, result.ExitCode)
 	assert.Equal(t, "us-west-2\n", string(result.Stdout))
@@ -152,17 +150,15 @@ func TestConfigGetCmdErrors(t *testing.T) {
 	cfg := config.New()
 	require.NoError(t, cfg.Save())
 
-	root := cli.NewRootCmd("test")
-
 	// Test invalid key
-	result := axtest.Run(context.Background(), t, root,
+	result := axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "get", "invalid.key"})
 	assert.NotEqual(t, 0, result.ExitCode)
 	stderr := string(result.Stderr)
 	assert.Contains(t, stderr, "unknown configuration section")
 
 	// Test non-existent plugin
-	result = axtest.Run(context.Background(), t, root,
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "get", "plugins.nonexistent.key"})
 	assert.NotEqual(t, 0, result.ExitCode)
 	stderr = string(result.Stderr)
@@ -175,29 +171,22 @@ func TestConfigListCmd(t *testing.T) {
 	cleanup := setupTestConfig(t)
 	defer cleanup()
 
-	root := cli.NewRootCmd("test")
-
 	// Initialize config first
-	result := axtest.Run(context.Background(), t, root, []string{"config", "init"})
+	result := axtest.Run(context.Background(), t, cli.NewRootCmd("test"), []string{"config", "init"})
 	require.Equal(t, 0, result.ExitCode)
 
 	// Set some config values
-	result = axtest.Run(context.Background(), t, root,
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "set", "output.default_format", "json"})
 	require.Equal(t, 0, result.ExitCode)
 
-	result = axtest.Run(context.Background(), t, root,
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "set", "plugins.aws.region", "us-west-2"})
 	require.Equal(t, 0, result.ExitCode)
 
-	// Test YAML output. Pass --as explicitly rather than relying on the
-	// no-flag TTY-detection default: axtest.Run's stdout is a buffer, never a
-	// real terminal, so ax's mode resolution would otherwise fall back to
-	// JSON - and ax.WithStdoutIsTTY(true) does not reliably override that
-	// once a root command has already served an earlier axtest.Run call in
-	// this test (a reused-root quirk in ax-go, not something to work around
-	// here; --as sidesteps it since it doesn't depend on mode resolution).
-	result = axtest.Run(context.Background(), t, root, []string{"config", "list", "--as", "yaml"})
+	// Test the default output style on a terminal.
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
+		[]string{"config", "list"}, ax.WithStdoutIsTTY(true))
 	require.Equal(t, 0, result.ExitCode)
 
 	yamlOutput := string(result.Stdout)
@@ -207,16 +196,9 @@ func TestConfigListCmd(t *testing.T) {
 	assert.Contains(t, yamlOutput, "aws:")
 	assert.Contains(t, yamlOutput, "region: us-west-2")
 
-	// Test JSON output. Use --as (not --format) here: this root has already
-	// served a "config list --as yaml" call above, and Cobra flags carry
-	// their Changed() state across Execute() calls on a reused *cobra.Command
-	// (axtest.Run's own docs note this - "it does not reset flag values a
-	// previous call set"). Passing --format instead would leave --as's
-	// Changed() flag stuck true from the earlier call, short-circuiting
-	// config_list.go's mode-resolution fallback before --format is ever
-	// consulted. Re-asserting --as explicitly avoids relying on that fallback
-	// at all, on either call.
-	result = axtest.Run(context.Background(), t, root, []string{"config", "list", "--as", "json"})
+	// Test JSON output selected by the global mode flag.
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
+		[]string{"config", "list", "--format", "json"})
 	require.Equal(t, 0, result.ExitCode)
 
 	jsonOutput := string(result.Stdout)
@@ -235,10 +217,8 @@ func TestConfigListCmdErrors(t *testing.T) {
 	cfg := config.New()
 	require.NoError(t, cfg.Save())
 
-	root := cli.NewRootCmd("test")
-
 	// Test invalid format
-	result := axtest.Run(context.Background(), t, root,
+	result := axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "list", "--format", "invalid"})
 	assert.NotEqual(t, 0, result.ExitCode)
 	stderr := string(result.Stderr)
@@ -255,16 +235,14 @@ func TestConfigValidateCmd(t *testing.T) {
 	cfg := config.New()
 	require.NoError(t, cfg.Save())
 
-	root := cli.NewRootCmd("test")
-
 	// Test valid configuration
-	result := axtest.Run(context.Background(), t, root, []string{"config", "validate"})
+	result := axtest.Run(context.Background(), t, cli.NewRootCmd("test"), []string{"config", "validate"})
 	require.Equal(t, 0, result.ExitCode)
 	output := string(result.Stdout)
 	assert.Contains(t, output, "✅ Configuration is valid")
 
 	// Test with verbose flag
-	result = axtest.Run(context.Background(), t, root, []string{"config", "validate", "--verbose"})
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"), []string{"config", "validate", "--verbose"})
 	require.Equal(t, 0, result.ExitCode)
 
 	verboseOutput := string(result.Stdout)
@@ -288,10 +266,8 @@ func TestConfigValidateCmdErrors(t *testing.T) {
 	cfg.Output.DefaultFormat = "invalid"
 	require.NoError(t, cfg.Save())
 
-	root := cli.NewRootCmd("test")
-
 	// Test invalid configuration
-	result := axtest.Run(context.Background(), t, root, []string{"config", "validate"})
+	result := axtest.Run(context.Background(), t, cli.NewRootCmd("test"), []string{"config", "validate"})
 	assert.NotEqual(t, 0, result.ExitCode)
 	stderr := string(result.Stderr)
 	assert.Contains(t, stderr, "invalid output format")
@@ -303,39 +279,36 @@ func TestConfigCommandsIntegration(t *testing.T) {
 	cleanup := setupTestConfig(t)
 	defer cleanup()
 
-	root := cli.NewRootCmd("test")
-
 	// Test full workflow: init -> set -> get -> validate -> list
 
 	// 1. Initialize config
-	result := axtest.Run(context.Background(), t, root, []string{"config", "init"})
+	result := axtest.Run(context.Background(), t, cli.NewRootCmd("test"), []string{"config", "init"})
 	require.Equal(t, 0, result.ExitCode)
 
 	// 2. Set some values
-	result = axtest.Run(context.Background(), t, root,
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "set", "output.default_format", "json"})
 	require.Equal(t, 0, result.ExitCode)
 
-	result = axtest.Run(context.Background(), t, root,
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "set", "plugins.aws.region", "eu-west-1"})
 	require.Equal(t, 0, result.ExitCode)
 
 	// 3. Get values to verify
-	result = axtest.Run(context.Background(), t, root,
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "get", "output.default_format"})
 	require.Equal(t, 0, result.ExitCode)
 	assert.Equal(t, "json\n", string(result.Stdout))
 
 	// 4. Validate configuration
-	result = axtest.Run(context.Background(), t, root, []string{"config", "validate"})
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"), []string{"config", "validate"})
 	require.Equal(t, 0, result.ExitCode)
 	output := string(result.Stdout)
 	assert.Contains(t, output, "✅ Configuration is valid")
 
-	// 5. List all configuration (explicit --as yaml; see the comment in
-	// TestConfigListCmd on why the no-flag TTY-detection default isn't used
-	// here on a root command already reused by earlier calls in this test).
-	result = axtest.Run(context.Background(), t, root, []string{"config", "list", "--as", "yaml"})
+	// 5. List all configuration using the default terminal style.
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
+		[]string{"config", "list"}, ax.WithStdoutIsTTY(true))
 	require.Equal(t, 0, result.ExitCode)
 
 	listOutput := string(result.Stdout)
@@ -349,15 +322,13 @@ func TestConfigCmdWrongArgs(t *testing.T) {
 	cleanup := setupTestConfig(t)
 	defer cleanup()
 
-	root := cli.NewRootCmd("test")
-
 	// Test set command with wrong number of args
-	result := axtest.Run(context.Background(), t, root,
+	result := axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "set", "only-one-arg"})
 	assert.NotEqual(t, 0, result.ExitCode)
 
 	// Test get command with wrong number of args
-	result = axtest.Run(context.Background(), t, root, []string{"config", "get"})
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"), []string{"config", "get"})
 	assert.NotEqual(t, 0, result.ExitCode)
 }
 
@@ -373,10 +344,8 @@ func TestConfigGetCmdMapOutput(t *testing.T) {
 	require.NoError(t, cfg.Set("plugins.aws.account_id", "123456789"))
 	require.NoError(t, cfg.Save())
 
-	root := cli.NewRootCmd("test")
-
 	// Test getting plugin section (returns map)
-	result := axtest.Run(context.Background(), t, root,
+	result := axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "get", "plugins.aws"})
 	require.Equal(t, 0, result.ExitCode)
 
@@ -385,7 +354,7 @@ func TestConfigGetCmdMapOutput(t *testing.T) {
 	assert.Contains(t, mapOutput, "region:")
 
 	// Test getting all plugins (returns map of PluginConfig)
-	result = axtest.Run(context.Background(), t, root, []string{"config", "get", "plugins"})
+	result = axtest.Run(context.Background(), t, cli.NewRootCmd("test"), []string{"config", "get", "plugins"})
 	require.Equal(t, 0, result.ExitCode)
 
 	allPluginsOutput := string(result.Stdout)
@@ -404,12 +373,25 @@ func TestConfigGetCmdIntOutput(t *testing.T) {
 	require.NoError(t, cfg.Set("output.precision", "4"))
 	require.NoError(t, cfg.Save())
 
-	root := cli.NewRootCmd("test")
-
 	// Test getting integer value
-	result := axtest.Run(context.Background(), t, root,
+	result := axtest.Run(context.Background(), t, cli.NewRootCmd("test"),
 		[]string{"config", "get", "output.precision"})
 	require.Equal(t, 0, result.ExitCode)
 
 	assert.Contains(t, string(result.Stdout), "4")
+}
+
+func TestConfigListCmdDirectRun(t *testing.T) {
+	cleanup := setupTestConfig(t)
+	defer cleanup()
+	cmd := cli.NewConfigListCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	require.NoError(t, cmd.RunE(cmd, nil))
+	assert.Contains(t, output.String(), "output:")
+
+	require.NoError(t, cmd.Flags().Parse([]string{"-f", "json"}))
+	output.Reset()
+	require.NoError(t, cmd.RunE(cmd, nil))
+	assert.Contains(t, output.String(), `"output":`)
 }

--- a/internal/cli/cost_recommendations_dismiss.go
+++ b/internal/cli/cost_recommendations_dismiss.go
@@ -149,8 +149,11 @@ func executeDismiss(cmd *cobra.Command, recommendationID string, params dismissP
 	// Handle confirmation outcomes
 	switch outcome {
 	case ax.ConfirmationBlocked:
-		// ax.Confirm returned a ready error - just propagate it
-		return confirmErr
+		// ax.Confirm pairs Blocked with a non-nil error, which the check above
+		// already returned, so this branch is unreachable today. Fail closed if
+		// that contract ever changes: returning confirmErr here would be nil and
+		// would skip the mutation while exiting 0.
+		return errors.New("confirmation required: re-run with --yes")
 	case ax.ConfirmationPromptRequired:
 		// Need to do interactive prompt
 		cmd.PrintErrf("Dismiss recommendation %s?\n", recommendationID)
@@ -210,7 +213,12 @@ func executeDismiss(cmd *cobra.Command, recommendationID string, params dismissP
 		return nil
 	}
 
-	return ax.Perform(ctx, nil, commit)
+	rehearse := func(_ context.Context) error {
+		cmd.Printf("Would %s\n", confirmSubject)
+		return nil
+	}
+
+	return ax.Perform(ctx, rehearse, commit)
 }
 
 // executeSnooze handles the snooze subcommand logic.
@@ -248,8 +256,11 @@ func executeSnooze(cmd *cobra.Command, recommendationID string, params snoozePar
 	// Handle confirmation outcomes
 	switch outcome {
 	case ax.ConfirmationBlocked:
-		// ax.Confirm returned a ready error - just propagate it
-		return confirmErr
+		// ax.Confirm pairs Blocked with a non-nil error, which the check above
+		// already returned, so this branch is unreachable today. Fail closed if
+		// that contract ever changes: returning confirmErr here would be nil and
+		// would skip the mutation while exiting 0.
+		return errors.New("confirmation required: re-run with --yes")
 	case ax.ConfirmationPromptRequired:
 		// Need to do interactive prompt
 		cmd.PrintErrf("Snooze recommendation %s?\n", recommendationID)
@@ -311,7 +322,12 @@ func executeSnooze(cmd *cobra.Command, recommendationID string, params snoozePar
 		return nil
 	}
 
-	return ax.Perform(ctx, nil, commit)
+	rehearse := func(_ context.Context) error {
+		cmd.Printf("Would %s\n", confirmSubject)
+		return nil
+	}
+
+	return ax.Perform(ctx, rehearse, commit)
 }
 
 // loadDismissalStore creates and loads the dismissal store.

--- a/internal/cli/cost_recommendations_dismiss_test.go
+++ b/internal/cli/cost_recommendations_dismiss_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/rshade/finfocus/internal/config"
 )
 
 // findSubcommandLocal finds a subcommand by name in a cobra.Command.
@@ -117,6 +119,7 @@ func TestDismissCmd_ValidReasons(t *testing.T) {
 
 	for _, reason := range validReasons {
 		t.Run(reason, func(t *testing.T) {
+			t.Setenv("FINFOCUS_HOME", t.TempDir())
 			root := NewRootCmd("test-version")
 			result := axtest.Run(context.Background(), t, root,
 				[]string{"cost", "recommendations", "dismiss", "rec-123", "--reason", reason, "--force"})
@@ -214,6 +217,7 @@ func TestSnoozeCmd_RejectsPastDate(t *testing.T) {
 
 // T015: Test snooze accepts YYYY-MM-DD format.
 func TestSnoozeCmd_AcceptsYYYYMMDD(t *testing.T) {
+	t.Setenv("FINFOCUS_HOME", t.TempDir())
 	// Use valid future date in YYYY-MM-DD format
 	futureDate := time.Now().AddDate(0, 1, 0).Format("2006-01-02")
 	root := NewRootCmd("test-version")
@@ -229,6 +233,7 @@ func TestSnoozeCmd_AcceptsYYYYMMDD(t *testing.T) {
 
 // T015: Test snooze accepts RFC3339 format.
 func TestSnoozeCmd_AcceptsRFC3339(t *testing.T) {
+	t.Setenv("FINFOCUS_HOME", t.TempDir())
 	// Use valid future date in RFC3339 format
 	futureDate := time.Now().AddDate(0, 1, 0).Format(time.RFC3339)
 	root := NewRootCmd("test-version")
@@ -292,4 +297,36 @@ func TestSnoozeCmd_RejectsInvalidDateFormat(t *testing.T) {
 	// Should fail with date format error
 	stderr := string(result.Stderr)
 	assert.Contains(t, stderr, "invalid date format")
+}
+
+func TestRecommendationChangesDryRun(t *testing.T) {
+	until := time.Now().AddDate(0, 1, 0).Format("2006-01-02")
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "dismiss",
+			args: []string{"cost", "recommendations", "dismiss", "rec-preview", "--reason", "not-applicable"},
+			want: "Would dismiss recommendation rec-preview",
+		},
+		{
+			name: "snooze",
+			args: []string{"cost", "recommendations", "snooze", "rec-preview", "--until", until},
+			want: "Would snooze recommendation rec-preview until " + until,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("FINFOCUS_HOME", t.TempDir())
+			tt.args = append(tt.args, "--force", "--dry-run")
+			result := axtest.Run(context.Background(), t, NewRootCmd("test"), tt.args)
+			require.Zero(t, result.ExitCode, string(result.Stderr))
+			assert.Contains(t, string(result.Stdout), tt.want)
+			store, err := config.NewDismissalStore("")
+			require.NoError(t, err)
+			assert.NoFileExists(t, store.FilePath())
+		})
+	}
 }

--- a/internal/cli/cost_recommendations_history.go
+++ b/internal/cli/cost_recommendations_history.go
@@ -45,6 +45,15 @@ func executeHistory(cmd *cobra.Command, recommendationID string, output string) 
 	ctx := cmd.Context()
 	log := logging.FromContext(ctx)
 
+	// Validate before loading any state: a recommendation with no recorded
+	// history returns early below, which would otherwise let an invalid
+	// --output value exit 0 silently.
+	switch output {
+	case outputFormatTable, outputFormatJSON, outputFormatNDJSON:
+	default:
+		return fmt.Errorf("unsupported output format: %s (supported: table, json, ndjson)", output)
+	}
+
 	// Load dismissal store
 	store, err := loadDismissalStore()
 	if err != nil {
@@ -82,6 +91,8 @@ func executeHistory(cmd *cobra.Command, recommendationID string, output string) 
 	case outputFormatTable:
 		return renderHistoryTable(cmd, recommendationID, events)
 	default:
+		// Unreachable: the check at the top of this function rejects anything
+		// else. Fail closed if a format is allowed there without a render arm.
 		return fmt.Errorf("unsupported output format: %s", output)
 	}
 }

--- a/internal/cli/cost_recommendations_history_test.go
+++ b/internal/cli/cost_recommendations_history_test.go
@@ -125,6 +125,10 @@ func TestHistoryCmd_NoPluginConnectionRequired(t *testing.T) {
 
 // T026: Test history invalid output format.
 func TestHistoryCmd_InvalidOutputFormat(t *testing.T) {
+	// Isolate the dismissal store so the result never depends on state left in
+	// the real ~/.finfocus by other tests or by the developer's own runs.
+	t.Setenv("FINFOCUS_HOME", t.TempDir())
+
 	cmd := cli.NewCostRecommendationsCmd()
 	var outBuf, errBuf bytes.Buffer
 	cmd.SetOut(&outBuf)
@@ -134,9 +138,8 @@ func TestHistoryCmd_InvalidOutputFormat(t *testing.T) {
 	cmd.SetArgs([]string{"history", "rec-123", "--output", "xml"})
 	err := cmd.Execute()
 
-	// May fail with store error first, or with unsupported format error
-	// Either way, an error is expected since "xml" is not a valid format
+	// The format is rejected before any state is loaded, so this holds even
+	// though rec-123 has no recorded history in the isolated store.
 	require.Error(t, err, "invalid output format 'xml' should produce an error")
-	// The error could be about unsupported format or store loading (unit test env),
-	// either indicates the command did not silently succeed with an invalid format.
+	assert.Contains(t, err.Error(), "unsupported output format: xml")
 }

--- a/internal/cli/cost_recommendations_undismiss.go
+++ b/internal/cli/cost_recommendations_undismiss.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/rshade/ax-go"
@@ -57,8 +58,11 @@ func executeUndismiss(cmd *cobra.Command, recommendationID string, force bool) e
 	// Handle confirmation outcomes
 	switch outcome {
 	case ax.ConfirmationBlocked:
-		// ax.Confirm returned a ready error - just propagate it
-		return confirmErr
+		// ax.Confirm pairs Blocked with a non-nil error, which the check above
+		// already returned, so this branch is unreachable today. Fail closed if
+		// that contract ever changes: returning confirmErr here would be nil and
+		// would skip the mutation while exiting 0.
+		return errors.New("confirmation required: re-run with --yes")
 	case ax.ConfirmationPromptRequired:
 		// Need to do interactive prompt
 		cmd.PrintErrf("Undismiss recommendation %s?\n", recommendationID)
@@ -106,5 +110,10 @@ func executeUndismiss(cmd *cobra.Command, recommendationID string, force bool) e
 		return nil
 	}
 
-	return ax.Perform(ctx, nil, commit)
+	rehearse := func(_ context.Context) error {
+		cmd.Printf("Would %s\n", confirmSubject)
+		return nil
+	}
+
+	return ax.Perform(ctx, rehearse, commit)
 }

--- a/internal/cli/plugin_init_test.go
+++ b/internal/cli/plugin_init_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rshade/ax-go/axtest"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/rshade/finfocus/internal/cli"
 )
@@ -30,10 +31,11 @@ func TestPluginInitValidation(t *testing.T) {
 	// Set log level to error to avoid cluttering test output with debug logs
 	t.Setenv("FINFOCUS_LOG_LEVEL", "error")
 	testCases := []struct {
-		name      string
-		args      []string
-		opts      cli.PluginInitOptions
-		expectErr bool
+		name        string
+		args        []string
+		opts        cli.PluginInitOptions
+		wantErr     bool
+		errContains string
 	}{
 		{
 			name: "valid plugin name",
@@ -42,7 +44,7 @@ func TestPluginInitValidation(t *testing.T) {
 				Author:    "Test Author",
 				Providers: []string{"aws"},
 			},
-			expectErr: false,
+			wantErr: false,
 		},
 		{
 			name: "invalid plugin name with uppercase",
@@ -51,7 +53,8 @@ func TestPluginInitValidation(t *testing.T) {
 				Author:    "Test Author",
 				Providers: []string{"aws"},
 			},
-			expectErr: true,
+			wantErr:     true,
+			errContains: "invalid plugin name",
 		},
 		{
 			name: "invalid plugin name with underscore",
@@ -60,7 +63,8 @@ func TestPluginInitValidation(t *testing.T) {
 				Author:    "Test Author",
 				Providers: []string{"aws"},
 			},
-			expectErr: true,
+			wantErr:     true,
+			errContains: "invalid plugin name",
 		},
 		{
 			name: "empty providers",
@@ -69,7 +73,8 @@ func TestPluginInitValidation(t *testing.T) {
 				Author:    "Test Author",
 				Providers: []string{},
 			},
-			expectErr: true,
+			wantErr:     true,
+			errContains: "providers",
 		},
 	}
 
@@ -95,11 +100,11 @@ func TestPluginInitValidation(t *testing.T) {
 
 			result := axtest.Run(context.Background(), t, root, cmdArgs)
 
-			if tc.expectErr && result.ExitCode == 0 {
-				t.Errorf("Expected error (non-zero exit code), got exit code 0")
-			}
-			if !tc.expectErr && result.ExitCode != 0 {
-				t.Errorf("Expected no error, got exit code %d: %s", result.ExitCode, string(result.Stderr))
+			if tc.wantErr {
+				assert.NotZero(t, result.ExitCode)
+				assert.Contains(t, string(result.Stderr), tc.errContains)
+			} else {
+				assert.Zero(t, result.ExitCode, string(result.Stderr))
 			}
 		})
 	}

--- a/internal/cli/plugin_install.go
+++ b/internal/cli/plugin_install.go
@@ -181,6 +181,7 @@ func getPlatformString() string {
 // it returns the original install error wrapped with the plugin specifier. If the user declines an
 // interactive fallback, it returns an "installation aborted" error.
 func handleInstallError(
+	ctx context.Context,
 	cmd *cobra.Command,
 	installer *registry.Installer,
 	spec *registry.PluginSpecifier,
@@ -199,7 +200,7 @@ func handleInstallError(
 	}
 
 	// Try to find a fallback version
-	fallbackResult, fallbackErr := handleFallback(cmd.Context(), cmd, installer, spec, opts, progress, fallbackToLatest)
+	fallbackResult, fallbackErr := handleFallback(ctx, cmd, installer, spec, opts, progress, fallbackToLatest)
 	if fallbackErr != nil {
 		if errors.Is(fallbackErr, errFallbackDeclined) {
 			cmd.Printf("Installation aborted.\n")
@@ -368,7 +369,7 @@ func runPluginInstall(cmd *cobra.Command, specifier string, p pluginInstallParam
 		result, err := installer.Install(ctx2, specifier, opts, progress)
 		if err != nil {
 			return handleInstallError(
-				cmd, installer, spec, opts, progress,
+				ctx2, cmd, installer, spec, opts, progress,
 				specifier, err, p.noFallback, p.fallbackToLatest, p.clean, p.pluginDir,
 			)
 		}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -232,11 +232,11 @@ func newCostCmd() *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// Call root command's PersistentPreRunE to ensure logging/tracing is set up.
 			// Cobra child commands override parent's PersistentPreRunE, so we must call explicitly.
-			// Navigate to the root command to avoid recursion. We pass root itself as the command
-			// to prevent Cobra from traversing back through the parent chain.
+			// Invoke the root hook directly with the executing command so global flags
+			// and context values (including dry-run) reach the subcommand.
 			root := cmd.Root()
 			if root != nil && root.PersistentPreRunE != nil && root != cmd {
-				if err := root.PersistentPreRunE(root, args); err != nil {
+				if err := root.PersistentPreRunE(cmd, args); err != nil {
 					return err
 				}
 			}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -522,7 +522,12 @@ func StepInitConfig(baseDir string) StepResult {
 	}
 
 	cfg := config.New()
-	if err := cfg.Save(); err != nil {
+	cfg.SetConfigPath(configPath)
+	err := cfg.Load()
+	if err == nil || os.IsNotExist(err) {
+		err = cfg.Save()
+	}
+	if err != nil {
 		return StepResult{
 			Name:     "Config initialization",
 			Status:   StepError,

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -295,6 +295,11 @@ func TestStepInitConfig(t *testing.T) {
 	// Verify the config file was created
 	configPath := filepath.Join(tmpDir, "config.hujson")
 	assert.FileExists(t, configPath)
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	var saved config.Config
+	require.NoError(t, json.Unmarshal(data, &saved))
+	assert.Equal(t, "table", saved.Output.DefaultFormat)
 }
 
 // TestStepInitConfig_AlreadyExists verifies config is not overwritten.
@@ -304,7 +309,8 @@ func TestStepInitConfig_AlreadyExists(t *testing.T) {
 
 	// Create a custom config
 	configPath := filepath.Join(tmpDir, "config.hujson")
-	customContent := []byte("custom: true\n")
+	customContent, readErr := os.ReadFile("../../testdata/config/preserved.hujson")
+	require.NoError(t, readErr)
 	require.NoError(t, os.WriteFile(configPath, customContent, 0o600))
 
 	step := cli.StepInitConfig(config.ResolveConfigDir())
@@ -720,4 +726,33 @@ func TestSetupFullRun(t *testing.T) {
 
 	// Should end with summary
 	assert.Contains(t, output, "Setup complete!")
+}
+
+func TestStepInitConfigPreservesLegacyKeys(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("FINFOCUS_HOME", dir)
+	legacy := []byte(`output:
+  default_format: json
+custom:
+  enabled: true
+installed_plugins:
+  - name: test-plugin
+    version: v1.0.0
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), legacy, 0600))
+
+	step := cli.StepInitConfig(dir)
+	require.NoError(t, step.Err)
+	assert.Equal(t, cli.StepSuccess, step.Status)
+	data, err := os.ReadFile(filepath.Join(dir, "config.hujson"))
+	require.NoError(t, err)
+	var saved map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &saved))
+	assert.JSONEq(t, `{"enabled":true}`, string(saved["custom"]))
+	var plugins []config.InstalledPlugin
+	require.NoError(t, json.Unmarshal(saved["installed_plugins"], &plugins))
+	assert.Equal(t, []config.InstalledPlugin{{Name: "test-plugin", Version: "v1.0.0"}}, plugins)
+	cfg, err := config.NewStrict()
+	require.NoError(t, err)
+	assert.Equal(t, "json", cfg.Output.DefaultFormat)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -100,8 +101,11 @@ type Config struct {
 	// If nil, automatic provider-based routing is used (FR-023 backward compatibility).
 	Routing *RoutingConfig `yaml:"routing,omitempty" json:"routing,omitempty"`
 
+	InstalledPlugins []InstalledPlugin `yaml:"installed_plugins,omitempty" json:"installed_plugins,omitempty"`
+
 	// Internal fields
 	configPath string
+	extraKeys  map[string]json.RawMessage
 }
 
 // PluginHostConfig defines plugin host behavior settings.
@@ -128,7 +132,10 @@ type PluginConfig struct {
 func (pc *PluginConfig) UnmarshalJSON(data []byte) error {
 	var m map[string]interface{}
 	if err := json.Unmarshal(data, &m); err != nil {
-		return err
+		return fmt.Errorf("parsing plugins configuration section: %w", err)
+	}
+	if m == nil {
+		m = make(map[string]interface{})
 	}
 	pc.Config = m
 	return nil
@@ -137,6 +144,9 @@ func (pc *PluginConfig) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements json.Marshaler for PluginConfig.
 // It marshals the Config map directly (simulating the YAML inline behavior).
 func (pc PluginConfig) MarshalJSON() ([]byte, error) {
+	if pc.Config == nil {
+		return json.Marshal(map[string]interface{}{})
+	}
 	return json.Marshal(pc.Config)
 }
 
@@ -281,9 +291,9 @@ func New() *Config {
 	// Load from file if exists
 	if err := cfg.Load(); err != nil {
 		switch {
-		case os.IsNotExist(err):
+		case errors.Is(err, fs.ErrNotExist):
 			// Config file doesn't exist - this is fine, use defaults
-		case os.IsPermission(err):
+		case errors.Is(err, fs.ErrPermission):
 			// Permission error - warn but continue (or fail in strict mode)
 			if strictMode {
 				panic(fmt.Sprintf("STRICT MODE: Permission denied reading config file: %v", err))
@@ -371,9 +381,9 @@ func NewStrict() (*Config, error) {
 	// Load from file with strict error handling
 	if loadErr := cfg.Load(); loadErr != nil {
 		switch {
-		case os.IsNotExist(loadErr):
+		case errors.Is(loadErr, fs.ErrNotExist):
 			// Config file doesn't exist - this is fine, use defaults
-		case os.IsPermission(loadErr):
+		case errors.Is(loadErr, fs.ErrPermission):
 			// Permission error - fail immediately
 			return nil, fmt.Errorf("permission denied reading config file: %w", loadErr)
 		default:
@@ -396,6 +406,41 @@ func NewStrict() (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// UnmarshalJSON preserves unrecognized top-level keys for subsequent saves.
+func (c *Config) UnmarshalJSON(data []byte) error {
+	type plainConfig Config
+	if err := json.Unmarshal(data, (*plainConfig)(c)); err != nil {
+		return err
+	}
+	var keys map[string]json.RawMessage
+	if err := json.Unmarshal(data, &keys); err != nil {
+		return err
+	}
+	for _, key := range []string{"output", "plugins", "logging", "analyzer", "plugin_host",
+		"cost", "routing", "plugin_dir", "installed_plugins"} {
+		delete(keys, key)
+	}
+	c.extraKeys = keys
+	return nil
+}
+
+// MarshalJSON includes unrecognized top-level keys retained while loading.
+func (c *Config) MarshalJSON() ([]byte, error) {
+	type plainConfig Config
+	data, err := json.Marshal(plainConfig(*c))
+	if err != nil {
+		return nil, err
+	}
+	var keys map[string]json.RawMessage
+	if err := json.Unmarshal(data, &keys); err != nil {
+		return nil, err
+	}
+	for key, value := range c.extraKeys {
+		keys[key] = value
+	}
+	return json.Marshal(keys)
 }
 
 // SetConfigPath overrides the config file path used by Load and Save.
@@ -423,8 +468,10 @@ func migrateFromLegacyYAML(configPath string) error {
 	legacyPath := filepath.Join(dir, "config.yaml")
 
 	if _, err := os.Stat(legacyPath); err != nil {
-		// Legacy file doesn't exist either, that's fine
-		return nil //nolint:nilerr // Returning nil is intentional when legacy file doesn't exist
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("checking legacy YAML config: %w", err)
 	}
 
 	data, err := os.ReadFile(legacyPath)
@@ -461,37 +508,54 @@ func migrateFromLegacyYAML(configPath string) error {
 // Returns an error if the config file cannot be parsed or if a legacy
 // file exists but is corrupted.
 func (c *Config) Load() error {
-	if err := migrateFromLegacyYAML(c.configPath); err != nil {
+	return loadConfig(c.configPath, c)
+}
+
+// loadConfig reads either format through the shared migration path.
+func loadConfig(configPath string, dst interface{}) error {
+	if err := migrateFromLegacyYAML(configPath); err != nil {
 		return err
 	}
 
-	file, err := os.Open(c.configPath)
+	file, err := os.Open(configPath)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
 
-	return ax.ParseConfig(context.Background(), file, c)
+	var data json.RawMessage
+	if err := ax.ParseConfig(context.Background(), file, &data); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, dst); err != nil {
+		return fmt.Errorf("parsing configuration: %w", err)
+	}
+	return nil
 }
 
 // Save saves the current configuration to the config file using JSON format.
 // It creates the directory if needed and performs an atomic write using a temp file.
 func (c *Config) Save() error {
+	return saveConfig(c.configPath, c)
+}
+
+// saveConfig atomically writes a configuration document as JSON.
+func saveConfig(configPath string, cfg interface{}) error {
 	// Ensure directory exists
-	if err := os.MkdirAll(filepath.Dir(c.configPath), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(configPath), 0700); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
-	data, err := json.MarshalIndent(c, "", "  ")
+	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	tmpPath := c.configPath + ".tmp"
+	tmpPath := configPath + ".tmp"
 	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
 	}
-	if err := os.Rename(tmpPath, c.configPath); err != nil {
+	if err := os.Rename(tmpPath, configPath); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("failed to save config: %w", err)
 	}
@@ -997,7 +1061,7 @@ func (c *Config) applyLegacyEnvOverrides() {
 		if c.Plugins == nil {
 			c.Plugins = make(map[string]PluginConfig)
 		}
-		if _, exists := c.Plugins[pluginName]; !exists {
+		if c.Plugins[pluginName].Config == nil {
 			c.Plugins[pluginName] = PluginConfig{Config: make(map[string]interface{})}
 		}
 		c.Plugins[pluginName].Config[configKey] = value
@@ -1034,7 +1098,7 @@ func (c *Config) scanPluginEnvironmentVars() {
 			c.Plugins = make(map[string]PluginConfig)
 		}
 
-		if _, exists := c.Plugins[pluginName]; !exists {
+		if c.Plugins[pluginName].Config == nil {
 			c.Plugins[pluginName] = PluginConfig{Config: make(map[string]interface{})}
 		}
 
@@ -1076,7 +1140,7 @@ func (c *Config) setPluginValue(parts []string, value string) error {
 		c.Plugins = make(map[string]PluginConfig)
 	}
 
-	if _, exists := c.Plugins[pluginName]; !exists {
+	if c.Plugins[pluginName].Config == nil {
 		c.Plugins[pluginName] = PluginConfig{Config: make(map[string]interface{})}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,8 +2,11 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1237,6 +1240,30 @@ func TestMigrateFromLegacyYAML(t *testing.T) {
 		assert.NoError(t, legacyStatErr, "legacy YAML file must be left in place, not deleted")
 	})
 
+	t.Run("unreadable legacy YAML returns permission error", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Windows does not enforce Unix permission bits")
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("root can read files regardless of permission bits")
+		}
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "config.hujson")
+		legacyPath := filepath.Join(dir, "config.yaml")
+		require.NoError(t, os.WriteFile(legacyPath, []byte("output: {}\n"), 0600))
+		t.Cleanup(func() { require.NoError(t, os.Chmod(legacyPath, 0600)) })
+		require.NoError(t, os.Chmod(legacyPath, 0000))
+
+		err := migrateFromLegacyYAML(configPath)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, fs.ErrPermission))
+		assert.NoFileExists(t, configPath)
+		t.Setenv("FINFOCUS_HOME", dir)
+		_, err = NewStrict()
+		assert.ErrorIs(t, err, fs.ErrPermission)
+		assert.NotErrorIs(t, err, ErrConfigCorrupted)
+	})
+
 	t.Run("corrupted legacy YAML returns an error", func(t *testing.T) {
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, "config.hujson")
@@ -1250,4 +1277,32 @@ func TestMigrateFromLegacyYAML(t *testing.T) {
 		_, statErr := os.Stat(configPath)
 		assert.True(t, os.IsNotExist(statErr), "no new config file should be written when migration fails")
 	})
+}
+
+func TestPluginConfigJSON(t *testing.T) {
+	for _, input := range []string{`{}`, `null`, `{"region":"us-east-1"}`} {
+		t.Run(input, func(t *testing.T) {
+			var plugin PluginConfig
+			require.NoError(t, json.Unmarshal([]byte(input), &plugin))
+			require.NotNil(t, plugin.Config)
+			cfg := &Config{Plugins: map[string]PluginConfig{"aws": plugin}}
+			require.NoError(t, cfg.Set("plugins.aws.region", "us-west-2"))
+			assert.Equal(t, "us-west-2", cfg.Plugins["aws"].Config["region"])
+		})
+	}
+	data, err := json.Marshal(PluginConfig{})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{}`, string(data))
+	cfg := &Config{Plugins: map[string]PluginConfig{"aws": {}}}
+	require.NoError(t, cfg.Set("plugins.aws.region", "us-west-2"))
+	assert.Equal(t, "us-west-2", cfg.Plugins["aws"].Config["region"])
+
+	t.Setenv("FINFOCUS_HOME", t.TempDir())
+	require.NoError(t, os.WriteFile(filepath.Join(ResolveConfigDir(), "config.hujson"),
+		[]byte(`{"plugins":{"aws":42}}`), 0600))
+	_, err = NewStrict()
+	require.ErrorIs(t, err, ErrConfigCorrupted)
+	assert.ErrorContains(t, err, "plugins configuration section")
+	var typeErr *json.UnmarshalTypeError
+	assert.ErrorAs(t, err, &typeErr)
 }

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -65,9 +65,14 @@ func ShallowMergeYAML(target *Config, overlayPath string) error {
 		// Convert YAML map to JSON RawMessage map
 		overlay = make(map[string]json.RawMessage)
 		for key, value := range yamlOverlay {
-			if jsonBytes, marshalErr := json.Marshal(value); marshalErr == nil {
-				overlay[key] = jsonBytes
+			if !knownTopLevelKeys[key] {
+				continue
 			}
+			jsonBytes, marshalErr := json.Marshal(value)
+			if marshalErr != nil {
+				return fmt.Errorf("converting overlay section %q to JSON: %w", key, marshalErr)
+			}
+			overlay[key] = jsonBytes
 		}
 	}
 

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -457,48 +457,65 @@ analyzer:
 	assert.Equal(t, "secret", p.Env["API_KEY"])
 }
 
-// TestShallowMergeYAML_HujsonCommentOnlySkeleton verifies that the literal
-// project skeleton content SaveProjectSkeleton writes (real Hujson: a JSON
-// object containing only "//" comments) merges successfully rather than
-// erroring out. Plain encoding/json.Unmarshal rejects "//" comments outright,
-// and YAML doesn't recognize them as comments either (YAML uses "#") - both
-// naive parse attempts fail on this exact content, so this guards against a
-// regression where every project using the stock skeleton silently falls
-// back to global-only config with just a warning logged.
-func TestShallowMergeYAML_HujsonCommentOnlySkeleton(t *testing.T) {
-	dir := t.TempDir()
-	skeletonPath := filepath.Join(dir, "config.hujson")
-	require.NoError(t, config.SaveProjectSkeleton(skeletonPath))
-
-	target := newDefaultTarget()
-	err := config.ShallowMergeYAML(target, skeletonPath)
-	require.NoError(t, err, "the stock project skeleton (comments only) must merge cleanly")
-
-	// A comment-only skeleton has no real keys, so the target must be
-	// untouched relative to its defaults.
-	assert.Equal(t, "table", target.Output.DefaultFormat)
-}
-
-// TestShallowMergeYAML_HujsonWithRealOverride verifies a Hujson overlay that
-// mixes a real override with "//" comments - not just the all-comments
-// skeleton case above - parses via the Hujson path (not the YAML fallback).
-func TestShallowMergeYAML_HujsonWithRealOverride(t *testing.T) {
-	dir := t.TempDir()
-	overlayPath := filepath.Join(dir, "config.hujson")
-	content := `{
+func TestShallowMergeYAML_Hujson(t *testing.T) {
+	tests := []struct {
+		name          string
+		content       string
+		skeleton      bool
+		wantFormat    string
+		wantPrecision int
+		wantErr       bool
+		errContains   string
+	}{
+		{name: "comment-only skeleton", skeleton: true, wantFormat: "table", wantPrecision: 2},
+		{
+			name: "real override with comments and trailing commas",
+			content: `{
   // Override the output format for this project.
   "output": {
     "default_format": "json",
     "precision": 4,
   },
 }
-`
-	require.NoError(t, os.WriteFile(overlayPath, []byte(content), 0600))
-
-	target := newDefaultTarget()
-	err := config.ShallowMergeYAML(target, overlayPath)
-	require.NoError(t, err)
-
-	assert.Equal(t, "json", target.Output.DefaultFormat)
-	assert.Equal(t, 4, target.Output.Precision)
+`,
+			wantFormat: "json", wantPrecision: 4,
+		},
+		{
+			name:        "invalid section",
+			content:     `{"output": "invalid"}`,
+			wantErr:     true,
+			errContains: `applying overlay section "output"`,
+		},
+		{
+			name:        "known YAML section cannot convert",
+			content:     "plugins:\n  aws:\n    value: .nan\n",
+			wantErr:     true,
+			errContains: `converting overlay section "plugins" to JSON`,
+		},
+		{
+			name:          "unknown YAML section ignored before conversion",
+			content:       "unknown:\n  value: .nan\n",
+			wantFormat:    "table",
+			wantPrecision: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			overlayPath := filepath.Join(t.TempDir(), "config.hujson")
+			if tt.skeleton {
+				require.NoError(t, config.SaveProjectSkeleton(overlayPath))
+			} else {
+				require.NoError(t, os.WriteFile(overlayPath, []byte(tt.content), 0600))
+			}
+			target := newDefaultTarget()
+			err := config.ShallowMergeYAML(target, overlayPath)
+			if tt.wantErr {
+				require.ErrorContains(t, err, tt.errContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFormat, target.Output.DefaultFormat)
+			assert.Equal(t, tt.wantPrecision, target.Output.Precision)
+		})
+	}
 }

--- a/internal/config/plugins.go
+++ b/internal/config/plugins.go
@@ -1,11 +1,16 @@
 package config
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
+	"github.com/rshade/ax-go"
 	"gopkg.in/yaml.v3"
 )
 
@@ -75,7 +80,7 @@ func LoadInstalledPlugins() ([]InstalledPlugin, error) {
 	}
 
 	var cfg InstalledPluginsConfig
-	if unmarshalErr := json.Unmarshal(data, &cfg); unmarshalErr != nil {
+	if unmarshalErr := ax.ParseConfig(context.Background(), bytes.NewReader(data), &cfg); unmarshalErr != nil {
 		return nil, fmt.Errorf("failed to parse config: %w", unmarshalErr)
 	}
 
@@ -89,44 +94,15 @@ func LoadInstalledPlugins() ([]InstalledPlugin, error) {
 // It returns an error if marshaling or file operations fail.
 func SaveInstalledPlugins(plugins []InstalledPlugin) error {
 	configPath := pluginsConfigPath()
-
-	// Ensure directory exists
-	if err := os.MkdirAll(filepath.Dir(configPath), 0700); err != nil {
-		return fmt.Errorf("failed to create config directory: %w", err)
+	var cfg map[string]interface{}
+	if err := loadConfig(configPath, &cfg); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("failed to load config: %w", err)
 	}
-
-	// Load existing config to preserve other settings
-	var fullConfig map[string]interface{}
-	if existingData, readErr := os.ReadFile(configPath); readErr == nil {
-		if unmarshalErr := json.Unmarshal(existingData, &fullConfig); unmarshalErr != nil {
-			fullConfig = make(map[string]interface{})
-		}
+	if cfg == nil {
+		cfg = make(map[string]interface{})
 	}
-	if fullConfig == nil {
-		fullConfig = make(map[string]interface{})
-	}
-
-	// Update installed_plugins
-	fullConfig["installed_plugins"] = plugins
-
-	// Marshal to JSON
-	data, err := json.MarshalIndent(fullConfig, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal config: %w", err)
-	}
-
-	// Write to temp file first, then rename (atomic write)
-	tmpPath := configPath + ".tmp"
-	if writeErr := os.WriteFile(tmpPath, data, 0600); writeErr != nil {
-		return fmt.Errorf("failed to write config: %w", writeErr)
-	}
-
-	if renameErr := os.Rename(tmpPath, configPath); renameErr != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("failed to save config: %w", renameErr)
-	}
-
-	return nil
+	cfg["installed_plugins"] = plugins
+	return saveConfig(configPath, cfg)
 }
 
 // AddInstalledPlugin adds or updates the given plugin in the installed plugins configuration.
@@ -222,9 +198,8 @@ func GetMissingPlugins() ([]InstalledPlugin, error) {
 		return nil, err
 	}
 
-	// Use ResolveConfigDir to determine the finfocus directory
-	configDir := ResolveConfigDir()
-	pluginsDir := filepath.Join(configDir, "plugins")
+	// Use the resolved plugin directory, including config and environment overrides.
+	pluginsDir := New().PluginDir
 
 	var missing []InstalledPlugin
 	for _, p := range plugins {

--- a/internal/config/plugins_test.go
+++ b/internal/config/plugins_test.go
@@ -1,11 +1,13 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -116,9 +118,8 @@ func TestSaveInstalledPlugins(t *testing.T) {
 
 	// Verify file was created
 	configPath := filepath.Join(tmpDir, ".finfocus", "config.hujson")
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		t.Error("config.hujson was not created")
-	}
+	_, err = os.Stat(configPath)
+	require.NoError(t, err)
 
 	// Load and verify
 	loaded, err := LoadInstalledPlugins()
@@ -315,7 +316,81 @@ func TestLoadInstalledPluginsInvalidYAML(t *testing.T) {
 	}
 
 	_, err := LoadInstalledPlugins()
-	if err == nil {
-		t.Error("expected error for invalid YAML")
+	require.Error(t, err, "expected error for invalid YAML")
+}
+
+func TestSaveInstalledPluginsPreservesConfig(t *testing.T) {
+	fixture, err := os.ReadFile("../../testdata/config/preserved.hujson")
+	require.NoError(t, err)
+	tests := []struct {
+		name        string
+		fileName    string
+		data        []byte
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "legacy", fileName: "config.yaml",
+			data: []byte("output:\n  default_format: json\n  precision: 4\ncustom:\n  enabled: true\n"),
+		},
+		{name: "hujson", fileName: "config.hujson", data: fixture},
+		{
+			name: "corrupted", fileName: "config.hujson", data: []byte("{invalid"),
+			wantErr: true, errContains: "failed to load config",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("FINFOCUS_HOME", dir)
+			path := filepath.Join(dir, tt.fileName)
+			data := tt.data
+			require.NoError(t, os.WriteFile(path, data, 0600))
+			plugins := []InstalledPlugin{{Name: "updated", Version: "v2.0.0"}}
+			err = SaveInstalledPlugins(plugins)
+			if tt.wantErr {
+				require.ErrorContains(t, err, tt.errContains)
+				got, readErr := os.ReadFile(path)
+				require.NoError(t, readErr)
+				assert.Equal(t, data, got)
+				return
+			}
+			require.NoError(t, err)
+			loaded, err := LoadInstalledPlugins()
+			require.NoError(t, err)
+			assert.Equal(t, plugins, loaded)
+			saved, err := os.ReadFile(filepath.Join(dir, "config.hujson"))
+			require.NoError(t, err)
+			var values map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(saved, &values))
+			assert.JSONEq(t, `{"enabled":true}`, string(values["custom"]))
+			assert.JSONEq(t, `{"default_format":"json","precision":4}`, string(values["output"]))
+		})
+	}
+}
+
+func TestGetMissingPluginsDirectoryOverrides(t *testing.T) {
+	for _, source := range []string{"default", "config", "environment"} {
+		t.Run(source, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("FINFOCUS_HOME", dir)
+			t.Setenv("FINFOCUS_PLUGIN_DIR", "")
+			cfg := New()
+			pluginsDir := cfg.PluginDir
+			if source != "default" {
+				pluginsDir = t.TempDir()
+				cfg.PluginDirOverride = pluginsDir
+			}
+			if source == "environment" {
+				cfg.PluginDirOverride = t.TempDir()
+				t.Setenv("FINFOCUS_PLUGIN_DIR", pluginsDir)
+			}
+			cfg.InstalledPlugins = []InstalledPlugin{{Name: "present", Version: "v1"}, {Name: "missing", Version: "v1"}}
+			require.NoError(t, cfg.Save())
+			require.NoError(t, os.MkdirAll(filepath.Join(pluginsDir, "present", "v1"), 0700))
+			missing, err := GetMissingPlugins()
+			require.NoError(t, err)
+			assert.Equal(t, cfg.InstalledPlugins[1:], missing)
+		})
 	}
 }

--- a/internal/engine/estimate.go
+++ b/internal/engine/estimate.go
@@ -302,7 +302,7 @@ func estimateResponseToCostResult(resp *pbc.EstimateCostResponse, resource *Reso
 		Notes:        strings.Join(notes, "; "),
 	}
 
-	if ts := resp.GetExpiresAt(); ts != nil {
+	if ts := resp.GetExpiresAt(); ts.IsValid() {
 		expiresAt := ts.AsTime()
 		result.ExpiresAt = &expiresAt
 	}

--- a/internal/engine/estimate_test.go
+++ b/internal/engine/estimate_test.go
@@ -713,43 +713,61 @@ func TestTryEstimateCostRPC_NilExpiresAt(t *testing.T) {
 	assert.Nil(t, result.Modified.ExpiresAt, "ExpiresAt should be nil: response did not set expires_at")
 }
 
-// TestTryEstimateCostRPC_PopulatedExpiresAt verifies that ExpiresAt is
-// extracted from the EstimateCostResponse's expires_at cache hint (added in
-// finfocus-spec v0.6.1) onto both the baseline and modified CostResult.
-func TestTryEstimateCostRPC_PopulatedExpiresAt(t *testing.T) {
+// TestTryEstimateCostRPC_ExpiresAt verifies that only valid cache hints propagate.
+func TestTryEstimateCostRPC_ExpiresAt(t *testing.T) {
 	expiry := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
-	mock := &estimateMockPlugin{
-		estimateCostFunc: func(_ context.Context, _ *pbc.EstimateCostRequest, _ ...grpc.CallOption) (*pbc.EstimateCostResponse, error) {
-			return &pbc.EstimateCostResponse{
-				Currency:    "USD",
-				CostMonthly: 10.0,
-				ExpiresAt:   timestamppb.New(expiry),
-			}, nil
-		},
+	tests := []struct {
+		name       string
+		expiresAt  *timestamppb.Timestamp
+		wantExpiry bool
+	}{
+		{name: "valid", expiresAt: timestamppb.New(expiry), wantExpiry: true},
+		{name: "absent"},
+		{name: "seconds out of range", expiresAt: &timestamppb.Timestamp{Seconds: 253402300800}},
+		{name: "negative nanos", expiresAt: &timestamppb.Timestamp{Nanos: -1}},
+		{name: "nanos out of range", expiresAt: &timestamppb.Timestamp{Nanos: 1000000000}},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &estimateMockPlugin{
+				estimateCostFunc: func(_ context.Context, _ *pbc.EstimateCostRequest, _ ...grpc.CallOption) (*pbc.EstimateCostResponse, error) {
+					return &pbc.EstimateCostResponse{
+						Currency:    "USD",
+						CostMonthly: 10.0,
+						ExpiresAt:   tt.expiresAt,
+					}, nil
+				},
+			}
 
-	clients := []*pluginhost.Client{{Name: "test-plugin", API: mock}}
-	eng := New(clients, &mockSpecLoader{})
+			clients := []*pluginhost.Client{{Name: "test-plugin", API: mock}}
+			eng := New(clients, &mockSpecLoader{})
 
-	request := &EstimateRequest{
-		Resource: &ResourceDescriptor{
-			Provider:   "aws",
-			Type:       "aws:ec2/instance:Instance",
-			ID:         "i-exp-set",
-			Properties: map[string]interface{}{"instanceType": "t3.micro"},
-		},
-		PropertyOverrides: map[string]string{"instanceType": "m5.large"},
+			request := &EstimateRequest{
+				Resource: &ResourceDescriptor{
+					Provider:   "aws",
+					Type:       "aws:ec2/instance:Instance",
+					ID:         "i-exp-set",
+					Properties: map[string]interface{}{"instanceType": "t3.micro"},
+				},
+				PropertyOverrides: map[string]string{"instanceType": "m5.large"},
+			}
+
+			result, err := eng.EstimateCost(context.Background(), request)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			assert.False(t, result.UsedFallback)
+			if tt.wantExpiry {
+				require.NotNil(t, result.Baseline.ExpiresAt)
+				require.NotNil(t, result.Modified.ExpiresAt)
+				assert.True(t, expiry.Equal(*result.Baseline.ExpiresAt))
+				assert.True(t, expiry.Equal(*result.Modified.ExpiresAt))
+			} else {
+				assert.Nil(t, result.Baseline.ExpiresAt)
+				assert.Nil(t, result.Modified.ExpiresAt)
+			}
+		})
 	}
-
-	result, err := eng.EstimateCost(context.Background(), request)
-	require.NoError(t, err)
-	require.NotNil(t, result)
-
-	assert.False(t, result.UsedFallback)
-	require.NotNil(t, result.Baseline.ExpiresAt)
-	require.NotNil(t, result.Modified.ExpiresAt)
-	assert.True(t, expiry.Equal(*result.Baseline.ExpiresAt))
-	assert.True(t, expiry.Equal(*result.Modified.ExpiresAt))
 }
 
 // TestEstimateCost_FallbackOnUnimplemented verifies that when a plugin returns

--- a/internal/pluginhost/process_test.go
+++ b/internal/pluginhost/process_test.go
@@ -203,29 +203,39 @@ func TestProcessLauncher_CreateCloseFn(t *testing.T) {
 
 func TestProcessLauncher_TryConnect(t *testing.T) {
 	launcher := NewProcessLauncher()
-
-	// Create a test server
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to create test listener: %v", err)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, listener.Close()) })
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		address string
+		wantErr error
+	}{
+		{name: "available port", ctx: context.Background(), address: listener.Addr().String()},
+		// gRPC creates clients lazily; an unavailable port does not fail creation.
+		{name: "unavailable port", ctx: context.Background(), address: "127.0.0.1:65534"},
+		{name: "canceled context", ctx: canceledCtx, address: listener.Addr().String(), wantErr: context.Canceled},
 	}
-	defer listener.Close()
-
-	address := listener.Addr().String()
-
-	// Test successful connection
-	conn, err := launcher.tryConnect(context.Background(), address)
-	if err != nil {
-		t.Errorf("tryConnect failed: %v", err)
-	} else {
-		conn.Close()
-	}
-
-	// Test connection to non-existent port (use a high port that's likely unavailable)
-	_, err = launcher.tryConnect(context.Background(), "127.0.0.1:65534")
-	if err == nil {
-		t.Log("Note: Port 65534 might be available on this system - connection succeeded")
-		// Don't fail as port availability varies by system
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start := time.Now()
+			conn, err := launcher.tryConnect(tt.ctx, tt.address)
+			if conn != nil {
+				t.Cleanup(func() { require.NoError(t, conn.Close()) })
+			}
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, conn)
+				assert.Less(t, time.Since(start), time.Second)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, conn)
+		})
 	}
 }
 

--- a/test/integration/cli/config_commands_test.go
+++ b/test/integration/cli/config_commands_test.go
@@ -24,7 +24,7 @@ func TestConfigInit_CreateNewConfig(t *testing.T) {
 		assert.Contains(t, output, "Configuration initialized")
 
 		// Verify config file was created
-		configPath := filepath.Join(tempHome, ".finfocus", "config.yaml")
+		configPath := filepath.Join(tempHome, ".finfocus", "config.hujson")
 		assert.FileExists(t, configPath)
 	})
 }

--- a/test/integration/helpers/cli_helper.go
+++ b/test/integration/helpers/cli_helper.go
@@ -2,7 +2,10 @@ package helpers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -11,6 +14,8 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+
+	"github.com/rshade/ax-go"
 
 	"github.com/rshade/finfocus/internal/cli"
 )
@@ -68,6 +73,14 @@ func filterLogLines(output string) string {
 
 // Execute runs a CLI command with the given arguments.
 // Returns the stdout output and any error.
+//
+// Commands run through ax.Execute, the same entry point cmd/finfocus uses, so
+// the persistent agentic flags ax mounts on the root command (--format,
+// --dry-run, --yes, --idempotency-key) are available here exactly as they are
+// in production. ax.Execute reports failure as a non-zero exit code and writes
+// an ax.Error envelope to stderr rather than returning an error, so the exit
+// code is converted back into an error for callers.
+//
 // Note: Output is filtered to remove log lines from plugin processes that may
 // write to stderr (which gets captured by the test runner).
 func (h *CLIHelper) Execute(args ...string) (string, error) {
@@ -79,18 +92,35 @@ func (h *CLIHelper) Execute(args ...string) (string, error) {
 
 	// Create root command
 	h.cmd = cli.NewRootCmd("test-version")
-	h.cmd.SetOut(h.stdout)
-	h.cmd.SetErr(h.stderr)
 	h.cmd.SetArgs(args)
 
-	// Execute command
-	err := h.cmd.Execute()
+	exitCode := ax.Execute(
+		context.Background(),
+		h.cmd,
+		ax.WithVersion("test-version"),
+		ax.WithStdout(h.stdout),
+		ax.WithStderr(h.stderr),
+	)
 
 	// Filter log lines from output - plugin processes may write logs to stderr
 	// which can appear in stdout when captured by the test framework
 	output := filterLogLines(h.stdout.String())
 
-	return output, err
+	if exitCode != ax.ExitSuccess {
+		return output, commandError(exitCode, h.stderr.String())
+	}
+
+	return output, nil
+}
+
+// commandError rebuilds an error from the ax.Error envelope ax.Execute wrote to
+// stderr, so callers asserting on error text see the command's own diagnostics.
+func commandError(exitCode int, stderr string) error {
+	message := strings.TrimSpace(filterLogLines(stderr))
+	if message == "" {
+		return fmt.Errorf("command failed with exit code %d", exitCode)
+	}
+	return errors.New(message)
 }
 
 // ExecuteOrFail runs a CLI command and fails the test if it returns an error.

--- a/testdata/config/preserved.hujson
+++ b/testdata/config/preserved.hujson
@@ -1,0 +1,8 @@
+{
+  // Preserve application extensions and installed plugin records when saving.
+  "custom": {"enabled": true},
+  "output": {"default_format": "json", "precision": 4},
+  "installed_plugins": [
+    {"name": "test-plugin", "url": "https://example.com/plugin", "version": "v1.0.0"},
+  ],
+}


### PR DESCRIPTION
## Summary

- Completes the CodeRabbit review of #1468. Nineteen of its 24 comments were already handled on this branch; this finishes the critical and partial ones that were missed.
- `ax.Confirm` always pairs `ConfirmationBlocked` with a non-nil error, so the `Blocked` switch arm sat behind an early return and propagated a provably-nil `confirmErr`. Were that contract to change, a blocked confirmation would skip its mutation and exit 0. All three sites now fail closed.
- Integration tests drove the CLI through `cli.NewRootCmd().Execute()` rather than `ax.Execute`, so the persistent agentic flags (`--format`, `--dry-run`, `--yes`, `--idempotency-key`) were never mounted. `config list --format json` consequently worked in production and in unit tests but failed only under integration.
- `config init` writes `config.hujson`, while one integration assertion still expected the legacy `config.yaml` name. Fixtures that write `config.yaml` as legacy input are deliberately left alone, since auto-migration is a supported path.

## Test plan

- [x] `make lint` passes with zero issues, identical to baseline
- [x] `make test` passes
- [x] The three integration tests failing on main now pass
- [x] Integration failure set diffed against a pre-change baseline: 53 to 50 failures, zero newly broken
- [ ] The remaining 50 integration failures are pre-existing and environmental. Those tests read the developer's real `~/.finfocus/config.hujson` and pass in CI only because the runner HOME is empty. Not addressed here; needs its own issue.

## Changes

### New files

- `testdata/config/preserved.hujson` - HuJSON fixture with comments and trailing commas, shared by the config and CLI test packages

### Modified files

- `internal/cli/cost_recommendations_dismiss.go`, `internal/cli/cost_recommendations_undismiss.go` - fail closed on `ConfirmationBlocked`; give undismiss a real `--dry-run` rehearsal in place of a nil closure
- `internal/cli/config_init.go`, `internal/cli/config_list.go`, `internal/cli/setup.go` - preserve an existing legacy project config; select output style via `--as` so the global `--format` is not shadowed
- `internal/cli/plugin_install.go`, `internal/cli/root.go` - forward the derived context to the fallback path; run the root persistent hook against the invoked command so `--dry-run` reaches `cost` subcommands
- `internal/config/config.go`, `internal/config/merge.go`, `internal/config/plugins.go` - wrap unmarshal and migration errors, preserve unrecognized top-level keys across a save, and honour plugin directory overrides
- `internal/engine/estimate.go` - propagate plugin expiry hints
- `test/integration/helpers/cli_helper.go` - run commands through `ax.Execute`, matching `cmd/finfocus` and `axtest.Run`, and convert the returned exit code back into an error for callers
- `test/integration/cli/config_commands_test.go` - assert that `config init` creates `config.hujson`
- `CLAUDE.md` - document the integration-test gotchas this change uncovered: the helper's `ax.Execute` requirement, the tests that read the developer's real `~/.finfocus` config, and which `config.yaml` references are deliberate legacy fixtures
- Test files across `internal/cli`, `internal/config`, `internal/engine`, `internal/pluginhost` - testify conversions, table-driven restructuring, and added error-path cases

Follow-up to #1468.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration initialization now recognizes existing legacy YAML files and preserves their settings during migration to HuJSON.
  * Configuration data retains custom settings and installed plugin information when saved.
  * Recommendation dismiss, snooze, and undismiss actions now show intended changes during dry runs.
  * Added a shorthand option for selecting configuration output format.

* **Bug Fixes**
  * Invalid expiration timestamps no longer produce incorrect cache expiration values.
  * Blocked confirmation attempts now return an explicit error instead of silently succeeding.

* **Documentation**
  * Added guidance for integration-test configuration and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->